### PR TITLE
examples: add reference configuration

### DIFF
--- a/examples/aws-production/cluster.lokocfg
+++ b/examples/aws-production/cluster.lokocfg
@@ -1,0 +1,64 @@
+variable "dns_zone" {}
+variable "route53_zone_id" {}
+variable "ssh_public_keys" {}
+variable "grafana_admin_password" {}
+variable "state_s3_bucket" {}
+variable "lock_dynamodb_table" {}
+
+variable "asset_dir" {
+  default = "./lokomotive-assets"
+}
+
+variable "cluster_name" {
+  default = "lokomotive-cluster"
+}
+
+variable "controllers_count" {
+  default = 3
+}
+
+variable "workers_count" {
+  default = 3
+}
+
+variable "state_s3_key" {
+  default = "lokomotive/terraform.tfstate"
+}
+
+variable "state_s3_region" {
+  default = "eu-central-1"
+}
+
+variable "workers_type" {
+  default = "i3.large"
+}
+
+backend "s3" {
+  bucket         = var.state_s3_bucket
+  key            = var.state_s3_key
+  region         = var.state_s3_region
+  dynamodb_table = var.lock_dynamodb_table
+}
+
+cluster "aws" {
+  asset_dir        = pathexpand(var.asset_dir)
+  cluster_name     = var.cluster_name
+  controller_count = var.controllers_count
+  dns_zone         = var.dns_zone
+  dns_zone_id      = var.route53_zone_id
+  ssh_pubkeys      = var.ssh_public_keys
+  worker_count     = var.workers_count
+  worker_type      = var.workers_type
+}
+
+component "metrics-server" {}
+
+component "flatcar-linux-update-operator" {}
+
+component "openebs-operator" {}
+
+component "openebs-storage-class" {}
+
+component "prometheus-operator" {
+  grafana_admin_password = var.grafana_admin_password
+}

--- a/examples/aws-testing/cluster.lokocfg
+++ b/examples/aws-testing/cluster.lokocfg
@@ -1,0 +1,52 @@
+variable "dns_zone" {}
+variable "route53_zone_id" {}
+variable "ssh_public_keys" {}
+variable "grafana_admin_password" {}
+
+variable "asset_dir" {
+  default = "./lokomotive-assets"
+}
+
+variable "cluster_name" {
+  default = "lokomotive-cluster"
+}
+
+variable "controllers_count" {
+  default = 1
+}
+
+variable "workers_count" {
+  default = 1
+}
+
+variable "workers_type" {
+  default = "i3.large"
+}
+
+cluster "aws" {
+  asset_dir        = pathexpand(var.asset_dir)
+  cluster_name     = var.cluster_name
+  controller_count = var.controllers_count
+  dns_zone         = var.dns_zone
+  dns_zone_id      = var.route53_zone_id
+  ssh_pubkeys      = var.ssh_public_keys
+  worker_count     = var.workers_count
+  worker_type      = var.workers_type
+}
+
+component "metrics-server" {}
+
+component "flatcar-linux-update-operator" {}
+
+component "openebs-operator" {}
+
+component "openebs-storage-class" {
+  storage-class "openebs-test-sc" {
+    replica_count = 1
+    default       = true
+  }
+}
+
+component "prometheus-operator" {
+  grafana_admin_password = var.grafana_admin_password
+}

--- a/examples/packet-production/cluster.lokocfg
+++ b/examples/packet-production/cluster.lokocfg
@@ -1,0 +1,98 @@
+variable "dns_zone" {}
+variable "route53_zone_id" {}
+variable "packet_project_id" {}
+variable "ssh_public_keys" {}
+variable "management_cidrs" {}
+variable "node_private_cidr" {}
+variable "cert_manager_email" {}
+variable "grafana_admin_password" {}
+variable "state_s3_bucket" {}
+variable "lock_dynamodb_table" {}
+
+variable "asset_dir" {
+  default = "./lokomotive-assets"
+}
+
+variable "facility" {
+  default = "ams1"
+}
+
+variable "cluster_name" {
+  default = "lokomotive-cluster"
+}
+
+variable "controllers_count" {
+  default = 3
+}
+
+variable "workers_count" {
+  default = 3
+}
+
+variable "workers_type" {
+  default = "c2.medium.x86"
+}
+
+variable "state_s3_key" {
+  default = "lokomotive/terraform.tfstate"
+}
+
+variable "state_s3_region" {
+  default = "eu-central-1"
+}
+
+backend "s3" {
+  bucket         = var.state_s3_bucket
+  key            = var.state_s3_key
+  region         = var.state_s3_region
+  dynamodb_table = var.lock_dynamodb_table
+}
+
+cluster "packet" {
+  asset_dir        = pathexpand(var.asset_dir)
+  cluster_name     = var.cluster_name
+  controller_count = var.controllers_count
+
+  dns {
+    zone = var.dns_zone
+
+    provider {
+      route53 {
+        zone_id = var.route53_zone_id
+      }
+    }
+  }
+
+  facility    = var.facility
+
+  project_id = var.packet_project_id
+
+  ssh_pubkeys       = var.ssh_public_keys
+  management_cidrs  = var.management_cidrs
+  node_private_cidr = var.node_private_cidr
+
+  worker_pool "pool-1" {
+    count     = var.workers_count
+    node_type = var.workers_type
+  }
+}
+
+component "metrics-server" {}
+
+component "openebs-operator" {}
+
+component "contour" {}
+
+component "metallb" {}
+
+component "cert-manager" {
+  email = var.cert_manager_email
+}
+
+component "flatcar-linux-update-operator" {}
+
+component "openebs-storage-class" {}
+
+component "prometheus-operator" {
+  grafana_admin_password = var.grafana_admin_password
+}

--- a/examples/packet-testing/cluster.lokocfg
+++ b/examples/packet-testing/cluster.lokocfg
@@ -1,0 +1,92 @@
+variable "dns_zone" {}
+variable "route53_zone_id" {}
+variable "packet_project_id" {}
+variable "ssh_public_keys" {}
+variable "cert_manager_email" {}
+variable "grafana_admin_password" {}
+
+variable "asset_dir" {
+  default = "./lokomotive-assets"
+}
+
+variable "facility" {
+  default = "ams1"
+}
+
+variable "cluster_name" {
+  default = "lokomotive-cluster"
+}
+
+variable "controllers_count" {
+  default = 1
+}
+
+variable "workers_count" {
+  default = 1
+}
+
+variable "workers_type" {
+  default = "c2.medium.x86"
+}
+
+variable "management_cidrs" {
+  default = "0.0.0.0/0"
+}
+
+variable "node_private_cidr" {
+  default = "10.0.0.0/8"
+}
+
+cluster "packet" {
+  asset_dir        = pathexpand(var.asset_dir)
+  cluster_name     = var.cluster_name
+  controller_count = var.controllers_count
+
+  dns {
+    zone = var.dns_zone
+
+    provider {
+      route53 {
+        zone_id = var.route53_zone_id
+      }
+    }
+  }
+
+  facility    = var.facility
+
+  project_id = var.packet_project_id
+
+  ssh_pubkeys       = var.ssh_public_keys
+  management_cidrs  = var.management_cidrs
+  node_private_cidr = var.node_private_cidr
+
+  worker_pool "pool-1" {
+    count     = var.workers_count
+    node_type = var.workers_type
+  }
+}
+
+component "metrics-server" {}
+
+component "openebs-operator" {}
+
+component "contour" {}
+
+component "metallb" {}
+
+component "cert-manager" {
+  email = var.cert_manager_email
+}
+
+component "flatcar-linux-update-operator" {}
+
+component "openebs-storage-class" {
+  storage-class "openebs-test-sc" {
+    replica_count = 1
+    default       = true
+  }
+}
+
+component "prometheus-operator" {
+  grafana_admin_password = var.grafana_admin_password
+}


### PR DESCRIPTION
This PR adds example configuration files, which can be copied by the
user and used by adding the lokocfg.vars file to the working directory.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>