### PR TITLE
ci/packet: disable installing and testing FLUO

### DIFF
--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -110,8 +110,6 @@ component "gangway" {
 
 component "rook" {}
 
-component "flatcar-linux-update-operator" {}
-
 # openebs-storage-class component should always be the last to be installed
 # pending when https://github.com/kinvolk/lokoctl/issues/374 is fixed
 # because when the discovery failure for creating StoragePoolClaim happens,

--- a/test/components/flatcar-linux-update-operator/fluo_test.go
+++ b/test/components/flatcar-linux-update-operator/fluo_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build aws packet
+// +build aws
 // +build e2e
 
 package fluo


### PR DESCRIPTION
Currently Packet ships old versions of Flatcar so when installing FLUO,
if a new version is already downloaded in controller nodes, it will
reboot it which makes tests fail pretty often.

Let's disable installing (and testing) FLUO on Packet until we have a
proper solution for this.