### PR TITLE
Revert "ci/packet: disable installing and testing FLUO"

### DIFF
--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -110,6 +110,8 @@ component "gangway" {
 
 component "rook" {}
 
+component "flatcar-linux-update-operator" {}
+
 # openebs-storage-class component should always be the last to be installed
 # pending when https://github.com/kinvolk/lokoctl/issues/374 is fixed
 # because when the discovery failure for creating StoragePoolClaim happens,

--- a/test/components/flatcar-linux-update-operator/fluo_test.go
+++ b/test/components/flatcar-linux-update-operator/fluo_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build aws
+// +build aws packet
 // +build e2e
 
 package fluo


### PR DESCRIPTION
This reverts commit cc303e7aa822a9320566fa530726101fd0394cea.

The CI disables reboots on controller nodes now, so we should be able to
test FLUO again on Packet.