### PR TITLE
metallb: make sure controllers run on controllers and speakers run on workers

### DIFF
--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -67,11 +67,6 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	}
 	c.ControllerNodeSelectors["beta.kubernetes.io/os"] = "linux"
 
-	c.SpeakerTolerations = append(c.SpeakerTolerations, util.Toleration{
-		Effect: "NoSchedule",
-		Key:    "node-role.kubernetes.io/master",
-	})
-
 	t, err := util.RenderTolerations(c.SpeakerTolerations)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal speaker tolerations")

--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -66,6 +66,12 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		c.ControllerNodeSelectors = map[string]string{}
 	}
 	c.ControllerNodeSelectors["beta.kubernetes.io/os"] = "linux"
+	c.ControllerNodeSelectors["node.kubernetes.io/master"] = ""
+
+	c.ControllerTolerations = append(c.SpeakerTolerations, util.Toleration{
+		Effect: "NoSchedule",
+		Key:    "node-role.kubernetes.io/master",
+	})
 
 	t, err := util.RenderTolerations(c.SpeakerTolerations)
 	if err != nil {


### PR DESCRIPTION
We took this from upstream but running speaker Pods on the master node
it doesn't make much sense since they're not likely to host services
accessible by the outside.

Fixes #46 