### PR TITLE
Reordering the `pkg/components/util` package.

### DIFF
--- a/cli/cmd/component-install.go
+++ b/cli/cmd/component-install.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/lokomotive/pkg/components"
-	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	"github.com/kinvolk/lokomotive/pkg/config"
 )
 
@@ -80,7 +80,7 @@ func installComponents(lokoConfig *config.Config, kubeconfig string, componentNa
 			return diags
 		}
 
-		if err := util.InstallComponent(componentName, component, kubeconfig); err != nil {
+		if err := helmutil.InstallComponent(componentName, component, kubeconfig); err != nil {
 			return err
 		}
 

--- a/cli/cmd/component-install.go
+++ b/cli/cmd/component-install.go
@@ -21,8 +21,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/lokomotive/pkg/components"
-	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	"github.com/kinvolk/lokomotive/pkg/config"
+	"github.com/kinvolk/lokomotive/pkg/helm"
 )
 
 var componentInstallCmd = &cobra.Command{
@@ -80,7 +80,7 @@ func installComponents(lokoConfig *config.Config, kubeconfig string, componentNa
 			return diags
 		}
 
-		if err := helmutil.InstallComponent(componentName, component, kubeconfig); err != nil {
+		if err := helm.InstallComponent(componentName, component, kubeconfig); err != nil {
 			return err
 		}
 

--- a/pkg/components/cert-manager/component.go
+++ b/pkg/components/cert-manager/component.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 )
 
 const name = "cert-manager"
@@ -60,7 +61,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -70,7 +71,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/cert-manager/component.go
+++ b/pkg/components/cert-manager/component.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
-	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
+	"github.com/kinvolk/lokomotive/pkg/helm"
 )
 
 const name = "cert-manager"
@@ -61,7 +61,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helm.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -71,7 +71,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helm.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/cluster-autoscaler/component.go
+++ b/pkg/components/cluster-autoscaler/component.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
-	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
+	"github.com/kinvolk/lokomotive/pkg/helm"
 )
 
 const name = "cluster-autoscaler"
@@ -287,7 +287,7 @@ func (c *component) validatePacket(diagnostics hcl.Diagnostics) hcl.Diagnostics 
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
+	helmChart, err := helm.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -317,7 +317,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	return helmutil.RenderChart(helmChart, name, c.Namespace, values)
+	return helm.RenderChart(helmChart, name, c.Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/cluster-autoscaler/component.go
+++ b/pkg/components/cluster-autoscaler/component.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 )
 
 const name = "cluster-autoscaler"
@@ -286,7 +287,7 @@ func (c *component) validatePacket(diagnostics hcl.Diagnostics) hcl.Diagnostics 
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -316,7 +317,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	return util.RenderChart(helmChart, name, c.Namespace, values)
+	return helmutil.RenderChart(helmChart, name, c.Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/external-dns/component.go
+++ b/pkg/components/external-dns/component.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
-	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
+	"github.com/kinvolk/lokomotive/pkg/helm"
 	"github.com/pkg/errors"
 )
 
@@ -94,7 +94,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 
 // RenderManifests renders the helm chart templates with values provided.
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helm.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -121,7 +121,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helm.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/external-dns/component.go
+++ b/pkg/components/external-dns/component.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	"github.com/pkg/errors"
 )
 
@@ -93,7 +94,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 
 // RenderManifests renders the helm chart templates with values provided.
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -120,7 +121,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/metrics-server/component.go
+++ b/pkg/components/metrics-server/component.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
-	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
+	"github.com/kinvolk/lokomotive/pkg/helm"
 )
 
 const name = "metrics-server"
@@ -71,7 +71,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
+	helmChart, err := helm.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -81,7 +81,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helm.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/metrics-server/component.go
+++ b/pkg/components/metrics-server/component.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 )
 
 const name = "metrics-server"
@@ -70,7 +71,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -80,7 +81,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/prometheus-operator/component.go
+++ b/pkg/components/prometheus-operator/component.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
-	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
+	"github.com/kinvolk/lokomotive/pkg/helm"
 )
 
 const name = "prometheus-operator"
@@ -87,7 +87,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helm.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -97,7 +97,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helm.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/prometheus-operator/component.go
+++ b/pkg/components/prometheus-operator/component.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 )
 
 const name = "prometheus-operator"
@@ -86,7 +87,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -96,7 +97,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/velero/velero.go
+++ b/pkg/components/velero/velero.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	"github.com/kinvolk/lokomotive/pkg/components/velero/azure"
 )
 
@@ -145,7 +146,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 
 // RenderManifest read helm chart from assets and renders it into list of files
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -155,7 +156,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/velero/velero.go
+++ b/pkg/components/velero/velero.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
-	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	"github.com/kinvolk/lokomotive/pkg/components/velero/azure"
+	"github.com/kinvolk/lokomotive/pkg/helm"
 )
 
 const name = "velero"
@@ -146,7 +146,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 
 // RenderManifest read helm chart from assets and renders it into list of files
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helm.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -156,7 +156,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helm.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package helmutil
+// Package helm implements methods required for installing components as
+// Helm charts.
+package helm
 
 import (
 	"fmt"

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package helmutil
 
 import (
 	"fmt"

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package helmutil
+package helm
 
 import (
 	"fmt"

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package helmutil
 
 import (
 	"fmt"

--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package helmutil
+package helm
 
 import (
 	"fmt"

--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package helmutil
 
 import (
 	"fmt"

--- a/test/components/install_test.go
+++ b/test/components/install_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/components"
 	_ "github.com/kinvolk/lokomotive/pkg/components/flatcar-linux-update-operator"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	testutil "github.com/kinvolk/lokomotive/test/components/util"
 )
 
@@ -51,11 +52,11 @@ component "flatcar-linux-update-operator" {}
 	}
 
 	k := testutil.KubeconfigPath(t)
-	if err := util.InstallAsRelease(n, c, k); err != nil {
+	if err := helmutil.InstallAsRelease(n, c, k); err != nil {
 		t.Fatalf("Installing component as release should succeed, got: %v", err)
 	}
 
-	if err := util.InstallAsRelease(n, c, k); err != nil {
+	if err := helmutil.InstallAsRelease(n, c, k); err != nil {
 		t.Fatalf("Installing component twice as release should succeed, got: %v", err)
 	}
 }

--- a/test/components/install_test.go
+++ b/test/components/install_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/components"
 	_ "github.com/kinvolk/lokomotive/pkg/components/flatcar-linux-update-operator"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
-	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
+	"github.com/kinvolk/lokomotive/pkg/helm"
 	testutil "github.com/kinvolk/lokomotive/test/components/util"
 )
 
@@ -52,11 +52,11 @@ component "flatcar-linux-update-operator" {}
 	}
 
 	k := testutil.KubeconfigPath(t)
-	if err := helmutil.InstallAsRelease(n, c, k); err != nil {
+	if err := helm.InstallAsRelease(n, c, k); err != nil {
 		t.Fatalf("Installing component as release should succeed, got: %v", err)
 	}
 
-	if err := helmutil.InstallAsRelease(n, c, k); err != nil {
+	if err := helm.InstallAsRelease(n, c, k); err != nil {
 		t.Fatalf("Installing component twice as release should succeed, got: %v", err)
 	}
 }


### PR DESCRIPTION
- helm.go and its test file mostly contained the code for charts. Hence
  renamed to charts.go and charts_test.go

- install.go contains mostly code for installing the chart as a release,
  hence renamed to release.go, so that in near future for uninstalling
  a release, we use the same file and not create another like
  `uninstall.go`

- release.go, charts.go and its test file is related to helm, hence its
  better to put them in a separate package under
  `pkg/components/utl/helmutil`

- lastly, made the changes required in the components which used the
  functions in the above files.

Signed-off-by: Imran Pochi <imran@kinvolk.io>