### PR TITLE
[WIP] Add cli subcommand for component uninstall

### DIFF
--- a/cli/cmd/component-install.go
+++ b/cli/cmd/component-install.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/lokomotive/pkg/components"
-	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	"github.com/kinvolk/lokomotive/pkg/config"
 )
 
@@ -80,7 +80,7 @@ func installComponents(lokoConfig *config.Config, kubeconfig string, componentNa
 			return diags
 		}
 
-		if err := util.InstallComponent(componentName, component, kubeconfig); err != nil {
+		if err := helmutil.InstallComponent(componentName, component, kubeconfig); err != nil {
 			return err
 		}
 

--- a/cli/cmd/component-uninstall.go
+++ b/cli/cmd/component-uninstall.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/kinvolk/lokomotive/pkg/components"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
+	"github.com/kinvolk/lokomotive/pkg/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var confirmUninstall bool
+
+var componentUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall a component",
+	Run:   runUninstall,
+}
+
+func init() {
+	componentCmd.AddCommand(componentUninstallCmd)
+	pf := componentUninstallCmd.PersistentFlags()
+	pf.BoolVarP(&confirmUninstall, "confirm", "", false, "Conform component uninstall")
+}
+
+func runUninstall(cmd *cobra.Command, args []string) {
+	contextLogger := log.WithFields(log.Fields{
+		"command": "lokoctl component uninstall",
+		"args":    args,
+	})
+
+	lokoConfig, diags := getLokoConfig()
+	if diags.HasErrors() {
+		contextLogger.Fatal(diags)
+	}
+
+	var componentsToUninstall []string
+	if len(args) > 0 {
+		componentsToUninstall = append(componentsToUninstall, args...)
+	}
+
+	kubeconfig, err := getKubeconfig()
+	if err != nil {
+		contextLogger.Fatal("Error in finding kubeconfig file: %s", err)
+	}
+
+	if err := uninstallComponents(lokoConfig, kubeconfig, componentsToUninstall...); err != nil {
+		contextLogger.Fatal(err)
+	}
+}
+
+func uninstallComponents(lokoConfig *config.Config, kubeconfig string, componentsToUninstall ...string) error {
+	for _, componentName := range componentsToUninstall {
+		fmt.Printf("Uninstalling component '%s'...\n", componentName)
+
+		component, err := components.Get(componentName)
+		if err != nil {
+			return err
+		}
+
+		if err := helmutil.UninstallRelease(componentName, component, kubeconfig); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/components/cert-manager/component.go
+++ b/pkg/components/cert-manager/component.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 )
 
 const name = "cert-manager"
@@ -60,7 +61,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -70,7 +71,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/cluster-autoscaler/component.go
+++ b/pkg/components/cluster-autoscaler/component.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 )
 
 const name = "cluster-autoscaler"
@@ -286,7 +287,7 @@ func (c *component) validatePacket(diagnostics hcl.Diagnostics) hcl.Diagnostics 
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -316,7 +317,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	return util.RenderChart(helmChart, name, c.Namespace, values)
+	return helmutil.RenderChart(helmChart, name, c.Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/external-dns/component.go
+++ b/pkg/components/external-dns/component.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	"github.com/pkg/errors"
 )
 
@@ -93,7 +94,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 
 // RenderManifests renders the helm chart templates with values provided.
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -120,7 +121,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/metrics-server/component.go
+++ b/pkg/components/metrics-server/component.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 )
 
 const name = "metrics-server"
@@ -70,7 +71,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -80,7 +81,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/prometheus-operator/component.go
+++ b/pkg/components/prometheus-operator/component.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 )
 
 const name = "prometheus-operator"
@@ -86,7 +87,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -96,7 +97,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/pkg/components/util/helmutil/charts.go
+++ b/pkg/components/util/helmutil/charts.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package helmutil
 
 import (
 	"fmt"

--- a/pkg/components/util/helmutil/charts_test.go
+++ b/pkg/components/util/helmutil/charts_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package helmutil
 
 import (
 	"fmt"

--- a/pkg/components/util/helmutil/release.go
+++ b/pkg/components/util/helmutil/release.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package helmutil
 
 import (
 	"fmt"

--- a/pkg/components/velero/velero.go
+++ b/pkg/components/velero/velero.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/util/helmutil"
 	"github.com/kinvolk/lokomotive/pkg/components/velero/azure"
 )
 
@@ -145,7 +146,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 
 // RenderManifest read helm chart from assets and renders it into list of files
 func (c *component) RenderManifests() (map[string]string, error) {
-	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
+	helmChart, err := helmutil.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
 	}
@@ -155,7 +156,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
+	renderedFiles, err := helmutil.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
 		return nil, errors.Wrap(err, "render chart")
 	}

--- a/test/components/install_test.go
+++ b/test/components/install_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	_ "github.com/kinvolk/lokomotive/pkg/components/flatcar-linux-update-operator"
-	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/components/helmutil"
 	testutil "github.com/kinvolk/lokomotive/test/components/util"
 )
 
@@ -51,11 +51,11 @@ component "flatcar-linux-update-operator" {}
 	}
 
 	k := testutil.KubeconfigPath(t)
-	if err := util.InstallAsRelease(n, c, k); err != nil {
+	if err := helmutil.InstallAsRelease(n, c, k); err != nil {
 		t.Fatalf("Installing component as release should succeed, got: %v", err)
 	}
 
-	if err := util.InstallAsRelease(n, c, k); err != nil {
+	if err := helmutil.InstallAsRelease(n, c, k); err != nil {
 		t.Fatalf("Installing component twice as release should succeed, got: %v", err)
 	}
 }


### PR DESCRIPTION
This PR builds on #73 

Currently we redirect the user to use helm for uninstalling the component or piping the output of `lokoctl component render-manifest` to `kubectl delete -f` which isn't ideal.

This PR addresses the need to have a simple uninstallation command
`lokoctl component uninstall <component-name>`