### PR TITLE
Makefile: use concourse base_sha if available when linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test: check-go-format run-unit-tests
 
 .PHONY: lint
 lint:
-	golangci-lint run --enable-all --disable=godox --max-same-issues=0 --max-issues-per-linter=0 --build-tags aws,packet,e2e,disruptive-e2e --new-from-rev=$$(git merge-base master HEAD) --modules-download-mode=$(MOD) --timeout=5m ./...
+	golangci-lint run --enable-all --disable=godox --max-same-issues=0 --max-issues-per-linter=0 --build-tags aws,packet,e2e,disruptive-e2e --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "master") HEAD) --modules-download-mode=$(MOD) --timeout=5m ./...
 
 GOFORMAT_FILES := $(shell find . -name '*.go' | grep -v '^./vendor')
 


### PR DESCRIPTION
As CI will merge the PR code into master branch when running tests, so
then local (CI) master branch diff will always be empty, so we should
compare against actual reference of the remote master branch, which can
be taken from metadata files provided by concourse.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

From https://github.com/telia-oss/github-pr-resource:
>Clones the base (e.g. master branch) at the latest commit, and merges the pull request at the specified commit into master. This ensures that we are both testing and setting status on the exact commit that was requested in input. Because the base of the PR is not locked to a specific commit in versions emitted from check, a fresh get will always use the latest commit in master and report the SHA of said commit in the metadata. Both the requested version and the metadata emitted by get are available to your tasks as JSON:
> - .git/resource/version.json
> - .git/resource/metadata.json
> - .git/resource/changed_files (if enabled by list_changed_files)
>
>The information in metadata.json is also available as individual files in the .git/resource directory, e.g. the base_sha is available as .git/resource/base_sha. For a complete list of available (individual) metadata files, please check the code here.