### PR TITLE
pkg/install/aws: use defaults from Terraform

### DIFF
--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -30,6 +30,10 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/terraform"
 )
 
+const (
+	defaultWorkerCount = 2
+)
+
 type config struct {
 	AssetDir                 string            `hcl:"asset_dir"`
 	ClusterName              string            `hcl:"cluster_name"`
@@ -78,7 +82,7 @@ func (c *config) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContext) 
 
 func NewConfig() *config {
 	return &config{
-		WorkerCount:       2,
+		WorkerCount:       defaultWorkerCount,
 		Region:            "eu-central-1",
 		EnableAggregation: true,
 	}

--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -78,21 +78,9 @@ func (c *config) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContext) 
 
 func NewConfig() *config {
 	return &config{
-		OSName:          "flatcar",
-		OSChannel:       "stable",
-		OSVersion:       "current",
-		ControllerCount: 1,
-		ControllerType:  "t3.small",
-		WorkerCount:     2,
-		WorkerType:      "t3.small",
-		Region:          "eu-central-1",
-		// Initialize the string slices to make sure they are
-		// rendered as `[]` when no snippets are given and not
-		// `null`, as the latter would lead to a terraform error
-		ControllerCLCSnippets: make([]string, 0),
-		WorkerCLCSnippets:     make([]string, 0),
-		WorkerTargetGroups:    make([]string, 0),
-		EnableAggregation:     true,
+		WorkerCount:       2,
+		Region:            "eu-central-1",
+		EnableAggregation: true,
 	}
 }
 

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -37,8 +37,13 @@ module "aws-{{.Config.ClusterName}}" {
   ssh_keys  = {{$.SSHPublicKeys}}
   asset_dir = "../cluster-assets"
 
+	{{- if .Config.ControllerCount}}
   controller_count = {{.Config.ControllerCount}}
+	{{- end }}
+
+	{{- if .Config.ControllerType}}
   controller_type  = "{{.Config.ControllerType}}"
+	{{- end }}
 
   worker_count = {{.Config.WorkerCount}}
   {{- if .Config.WorkerType }}
@@ -70,12 +75,22 @@ module "aws-{{.Config.ClusterName}}" {
   host_cidr = "{{.Config.HostCIDR}}"
   {{- end }}
 
+	{{- if .Config.OSName }}
   os_name = "{{.Config.OSName}}"
+	{{- end }}
+	{{- if .Config.OSChannel }}
   os_channel = "{{.Config.OSChannel}}"
+	{{- end }}
+	{{- if .Config.OSVersion }}
   os_version = "{{.Config.OSVersion}}"
+	{{- end }}
 
+	{{- if ne .ControllerCLCSnippets "null" }}
   controller_clc_snippets = {{.ControllerCLCSnippets}}
+	{{- end }}
+	{{- if ne .WorkerCLCSnippets "null" }}
   worker_clc_snippets     = {{.WorkerCLCSnippets}}
+	{{- end }}
 
   enable_aggregation = {{.Config.EnableAggregation}}
 


### PR DESCRIPTION
And only render values, which are actually defined. With this patch,
more defaults from Terraform are used, so it is easier to change those
defaults in the future.

This commit also reduces amount of Terraform configuration which is
generated, which should make debugging easier.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>