### PR TITLE
Fix error wrapping across packages

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,14 +64,14 @@ type Config struct {
 func loadLokocfgPaths(configPath string) ([]string, error) {
 	isDir, err := util.PathIsDir(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat config path %q: %v", configPath, err)
+		return nil, fmt.Errorf("failed to stat config path %q: %w", configPath, err)
 	}
 	var lokocfgPaths []string
 	if isDir {
 		globPattern := filepath.Join(configPath, "*.lokocfg")
 		configFiles, err := filepath.Glob(globPattern)
 		if err != nil {
-			return nil, fmt.Errorf("bad filepath glob pattern %q: %v", globPattern, err)
+			return nil, fmt.Errorf("bad filepath glob pattern %q: %w", globPattern, err)
 		}
 		lokocfgPaths = append(lokocfgPaths, configFiles...)
 	} else {

--- a/pkg/k8sutil/create.go
+++ b/pkg/k8sutil/create.go
@@ -353,11 +353,11 @@ func parseManifests(r io.Reader) ([]manifest, error) {
 
 		jsonManifest, err := yaml.ToJSON(yamlManifest)
 		if err != nil {
-			return nil, fmt.Errorf("invalid manifest: %v", err)
+			return nil, fmt.Errorf("invalid manifest: %w", err)
 		}
 		m, err := parseJSONManifest(jsonManifest)
 		if err != nil {
-			return nil, fmt.Errorf("parse manifest: %v", err)
+			return nil, fmt.Errorf("parse manifest: %w", err)
 		}
 		manifests = append(manifests, m...)
 	}

--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -293,7 +293,7 @@ func (ex *Executor) Plan() error {
 func (ex *Executor) Output(key string, s interface{}) error {
 	o, err := ex.ExecuteSync("output", "-json", key)
 	if err != nil {
-		return fmt.Errorf("failed getting Terraform output: %v", err)
+		return fmt.Errorf("failed getting Terraform output: %w", err)
 	}
 
 	return json.Unmarshal(o, s)


### PR DESCRIPTION
Even though we don't use it right now, since Go 1.13 it's recommended to use `%w` with combination of `fmt.Errorf`, so then receiver can unwrap underlying error.