### PR TITLE
Makefile: add 'all' and 'build-test' targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ LDFLAGS := "-X github.com/kinvolk/lokomotive/pkg/version.Version=$(VERSION) -ext
 .PHONY: build
 build: update-assets build-slim
 
+.PHONY: build-test
+build-test:
+	go test -run=nonexistent -mod=$(MOD) -tags="aws,packet,e2e,disruptive-e2e" -covermode=atomic -buildmode=exe -v ./...
+
+.PHONY: all
+all: build build-test test lint
+
 .PHONY: update-assets
 update-assets:
 	GO111MODULE=on go generate -mod=$(MOD) ./...


### PR DESCRIPTION
This commit adds 'build-test' target to Makefile, which will compile all
tests code, without running them, to make sure that syntax for all
tests, including e2e tests is correct. This is useful while refactoring.

It also adds 'all' target, which combines all possible checks for the
code into a single target to run, which should be run to run all
possible checks for the code.

Closes #93 #44

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>