### PR TITLE
pkg/terraform/executor.go: include key in Output error message

### DIFF
--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -293,7 +293,7 @@ func (ex *Executor) Plan() error {
 func (ex *Executor) Output(key string, s interface{}) error {
 	o, err := ex.ExecuteSync("output", "-json", key)
 	if err != nil {
-		return fmt.Errorf("failed getting Terraform output: %w", err)
+		return fmt.Errorf("failed getting Terraform output for key %q: %w", key, err)
 	}
 
 	return json.Unmarshal(o, s)

--- a/pkg/terraform/executor_test.go
+++ b/pkg/terraform/executor_test.go
@@ -5,10 +5,11 @@ package terraform
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 )
 
-func TestExecuteCheckErrors(t *testing.T) {
+func executor(t *testing.T) *Executor {
 	tmpDir, err := ioutil.TempDir("", "lokoctl-tests-")
 	if err != nil {
 		t.Fatalf("Creating tmp dir should succeed, got: %v", err)
@@ -26,7 +27,29 @@ func TestExecuteCheckErrors(t *testing.T) {
 		t.Fatalf("Creating new executor should succeed, got: %v", err)
 	}
 
+	return ex
+}
+
+func TestExecuteCheckErrors(t *testing.T) {
+	ex := executor(t)
+
 	if err := ex.Execute("apply"); err == nil {
 		t.Fatalf("Applying on empty directory should fail")
+	}
+}
+
+func TestOutputIncludeKeyInError(t *testing.T) {
+	ex := executor(t)
+
+	k := "foo"
+	o := ""
+
+	err := ex.Output(k, &o)
+	if err == nil {
+		t.Fatalf("Output should fail on non existing installation")
+	}
+
+	if !strings.Contains(err.Error(), k) {
+		t.Fatalf("Error message should contain key, got: %v", err)
 	}
 }


### PR DESCRIPTION
So it's easier to debug which key is wrong.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>