### PR TITLE
metallb-dashboard: Add error and updates monitoring

### DIFF
--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -120,6 +120,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	if c.ServiceMonitor {
 		rendered["service.yaml"] = service
 		rendered["service-monitor.yaml"] = serviceMonitor
+		rendered["grafana-dashboard.yaml"] = grafanaDashboard
 	}
 
 	return rendered, nil

--- a/pkg/components/metallb/manifests.go
+++ b/pkg/components/metallb/manifests.go
@@ -440,9 +440,184 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 26,
       "links": [],
       "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Rate of Kubernetes object updates that failed for some reason.",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 0,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(metallb_k8s_client_update_errors_total[1m])",
+              "legendFormat": "pod={{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Client Update Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Rate of Kubernetes object updates that have been processed.",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 10,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(metallb_k8s_client_updates_total[1m])",
+              "legendFormat": "pod={{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kubernetes Client Updates",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
         {
           "cacheTimeout": null,
           "colorBackground": false,
@@ -465,7 +640,7 @@ data:
             "h": 5,
             "w": 5,
             "x": 0,
-            "y": 0
+            "y": 8
           },
           "id": 4,
           "interval": null,
@@ -548,7 +723,7 @@ data:
             "h": 5,
             "w": 5,
             "x": 5,
-            "y": 0
+            "y": 8
           },
           "id": 2,
           "interval": null,
@@ -638,6 +813,6 @@ data:
       "timezone": "",
       "title": "MetalLB Dashboard",
       "uid": "0qwBMU_Wk",
-      "version": 2
+      "version": 1
     }
 `


### PR DESCRIPTION
* Also I forgot to install the dashboard in previous PR. Now that is taken care of in 1st commit.
* Dashboard looks like this: https://snapshot.raintank.io/dashboard/snapshot/VSd2fULu673q1fuNr4TF5t9MtgD7C90v

