### PR TITLE
Makefile: Disable lint until disparity is removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ test: run-unit-tests
 
 .PHONY: lint
 lint:
-	golangci-lint run --enable-all --disable=godox --max-same-issues=0 --max-issues-per-linter=0 --build-tags aws,packet,e2e,disruptive-e2e --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
+	# TODO: Uncomment this when https://github.com/kinvolk/lokomotive/issues/81 is fixed
+	# golangci-lint run --enable-all --disable=godox --max-same-issues=0 --max-issues-per-linter=0 --build-tags aws,packet,e2e,disruptive-e2e --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
 
 GOFORMAT_FILES := $(shell find . -name '*.go' | grep -v '^./vendor')
 


### PR DESCRIPTION
Disable linting until the disparity between CI and local development
enviroment setup is hit. The linting tool is highly unreliable and
reports no errors locally and only fails in CI thus increasing the RTT
of the development.

---

We should revert this commit whenever https://github.com/kinvolk/lokomotive/issues/81 is fixed.