### PR TITLE
 *: change quiet flag to verbose and disable it by default 

### DIFF
--- a/cli/cmd/cluster-destroy.go
+++ b/cli/cmd/cluster-destroy.go
@@ -31,7 +31,7 @@ func init() {
 	clusterCmd.AddCommand(clusterDestroyCmd)
 	pf := clusterDestroyCmd.PersistentFlags()
 	pf.BoolVarP(&confirm, "confirm", "", false, "Destroy cluster without asking for confirmation")
-	pf.BoolVarP(&quiet, "quiet", "q", false, "Suppress the output from Terraform")
+	pf.BoolVarP(&verbose, "verbose", "v", false, "Show output from Terraform")
 }
 
 func runClusterDestroy(cmd *cobra.Command, args []string) {

--- a/cli/cmd/cluster-install.go
+++ b/cli/cmd/cluster-install.go
@@ -86,6 +86,8 @@ func runClusterInstall(cmd *cobra.Command, args []string) {
 		componentsToInstall = append(componentsToInstall, component.Name)
 	}
 
+	ctxLogger.Println("Installing components")
+
 	if len(componentsToInstall) > 0 {
 		if err := installComponents(lokoConfig, kubeconfigPath, componentsToInstall...); err != nil {
 			ctxLogger.Fatalf("Installing components failed: %v", err)

--- a/cli/cmd/cluster-install.go
+++ b/cli/cmd/cluster-install.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	quiet          bool
+	verbose        bool //nolint:gochecknoglobals
 	skipComponents bool
 )
 
@@ -41,7 +41,7 @@ func init() {
 	clusterCmd.AddCommand(clusterInstallCmd)
 	pf := clusterInstallCmd.PersistentFlags()
 	pf.BoolVarP(&confirm, "confirm", "", false, "Upgrade cluster without asking for confirmation")
-	pf.BoolVarP(&quiet, "quiet", "q", false, "Suppress the output from Terraform")
+	pf.BoolVarP(&verbose, "verbose", "v", false, "Show output from Terraform")
 	pf.BoolVarP(&skipComponents, "skip-components", "", false, "Skip component installation")
 }
 

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -107,7 +107,7 @@ func initializeTerraform(ctxLogger *logrus.Entry, p platform.Platform, b backend
 
 	conf := terraform.Config{
 		WorkingDir: terraform.GetTerraformRootDir(assetDir),
-		Quiet:      quiet,
+		Verbose:    verbose,
 	}
 
 	ex, err := terraform.NewExecutor(conf)

--- a/docs/cli/lokoctl_cluster_destroy.md
+++ b/docs/cli/lokoctl_cluster_destroy.md
@@ -15,7 +15,7 @@ lokoctl cluster destroy [flags]
 ```
       --confirm   Destroy cluster without asking for confirmation
   -h, --help      help for destroy
-  -q, --quiet     Suppress the output from Terraform
+  -v, --verbose   Show output from Terraform
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/lokoctl_cluster_install.md
+++ b/docs/cli/lokoctl_cluster_install.md
@@ -15,8 +15,8 @@ lokoctl cluster install [flags]
 ```
       --confirm           Upgrade cluster without asking for confirmation
   -h, --help              help for install
-  -q, --quiet             Suppress the output from Terraform
       --skip-components   Skip component installation
+  -v, --verbose           Show output from Terraform
 ```
 
 ### Options inherited from parent commands

--- a/docs/installer/general.md
+++ b/docs/installer/general.md
@@ -4,10 +4,10 @@ This document includes information that is relevant for the Lokomotive installer
 regardless of the target platform. For platform-specific information, refer to the docs of the
 relevant [platform](../../README.md#supported-platforms).
 
-## Suppressing Terraform Output
+## Showing Terraform Output
 
-When running `lokoctl cluster install`, by default the installer prints all of Terraform's output.
-If you wish to hide it, you can append the `--quiet` flag, or `-q` for short.
+When running `lokoctl cluster install`, by default the installer doesn't print Terraform output.
+If you wish to show it, you can append the `--verbose` flag, or `-v` for short.
 
 ## Asset Directory
 

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -19,5 +19,5 @@ package terraform
 // command-line arguments.
 type Config struct {
 	WorkingDir string
-	Quiet      bool
+	Verbose    bool
 }

--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -91,14 +91,14 @@ type Executor struct {
 	executionPath string
 	binaryPath    string
 	envVariables  map[string]string
-	quiet         bool
+	verbose       bool
 }
 
 // NewExecutor initializes a new Executor.
 func NewExecutor(conf Config) (*Executor, error) {
 	ex := new(Executor)
 	ex.executionPath = conf.WorkingDir
-	ex.quiet = conf.Quiet
+	ex.verbose = conf.Verbose
 
 	// Create the folder in which the executor, and its logs will be stored,
 	// if not existing.
@@ -191,7 +191,7 @@ func (ex *Executor) Execute(args ...string) error {
 	p := filepath.Join(ex.WorkingDirectory(), "logs", fmt.Sprintf("%d%s", pid, ".log"))
 
 	// If we print output, schedule it as well.
-	if !ex.quiet {
+	if ex.verbose {
 		wg.Add(1)
 
 		go tailFile(p, done, &wg)

--- a/pkg/terraform/executor_test.go
+++ b/pkg/terraform/executor_test.go
@@ -18,7 +18,7 @@ func executor(t *testing.T) *Executor {
 	defer os.RemoveAll(tmpDir)
 
 	conf := Config{
-		Quiet:      true,
+		Verbose:    false,
 		WorkingDir: tmpDir,
 	}
 


### PR DESCRIPTION
So we don't show Terraform output by default.

Also, add more logging to show the execution phases and fix a bug where "terraform plan" was not showing the diff if `--verbose` is false, check commit messages for details.

Closes #129 