### PR TITLE
lint: disable gochecknoglobals linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test: run-unit-tests
 
 .PHONY: lint
 lint:
-	golangci-lint run --enable-all --disable=godox --max-same-issues=0 --max-issues-per-linter=0 --build-tags aws,packet,e2e,disruptive-e2e --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
+	golangci-lint run --enable-all --disable=godox,gochecknoglobals --max-same-issues=0 --max-issues-per-linter=0 --build-tags aws,packet,e2e,disruptive-e2e --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
 
 GOFORMAT_FILES := $(shell find . -name '*.go' | grep -v '^./vendor')
 

--- a/cli/cmd/cluster-install.go
+++ b/cli/cmd/cluster-install.go
@@ -27,9 +27,9 @@ import (
 )
 
 var (
-	verbose         bool //nolint:gochecknoglobals
-	skipComponents  bool //nolintgo:checknoglobals
-	upgradeKubelets bool //nolintgo:checknoglobals
+	verbose         bool
+	skipComponents  bool
+	upgradeKubelets bool
 )
 
 var clusterInstallCmd = &cobra.Command{


### PR DESCRIPTION
We're using global variables heavily for CLI handling so it doesn't make
sense to have this linter.