### PR TITLE
packet: Use user-specified pool name for TF pool

### DIFF
--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -131,11 +131,16 @@ func (c *config) Apply(ex *terraform.Executor) error {
 
 	c.AssetDir = assetDir
 
+	dnsProvider, err := dns.ParseDNS(&c.DNS)
+	if err != nil {
+		return errors.Wrap(err, "parsing DNS configuration failed")
+	}
+
 	if err := c.Initialize(ex); err != nil {
 		return err
 	}
 
-	return c.terraformSmartApply(ex)
+	return c.terraformSmartApply(ex, dnsProvider)
 }
 
 func (c *config) Destroy(ex *terraform.Executor) error {
@@ -203,12 +208,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 }
 
 // terraformSmartApply applies cluster configuration.
-func (c *config) terraformSmartApply(ex *terraform.Executor) error {
-	dnsProvider, err := dns.ParseDNS(&c.DNS)
-	if err != nil {
-		return errors.Wrap(err, "parsing DNS configuration failed")
-	}
-
+func (c *config) terraformSmartApply(ex *terraform.Executor, dnsProvider dns.DNSProvider) error {
 	// If the provider isn't manual, apply everything in a single step.
 	if dnsProvider != dns.DNSManual {
 		return ex.Apply()

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -202,6 +202,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 	return nil
 }
 
+// terraformSmartApply applies cluster configuration.
 func (c *config) terraformSmartApply(ex *terraform.Executor) error {
 	dnsProvider, err := dns.ParseDNS(&c.DNS)
 	if err != nil {
@@ -246,7 +247,7 @@ func (c *config) GetExpectedNodes() int {
 	return c.ControllerCount + workers
 }
 
-// Check cluster config is valid
+// checkValidConfig validates cluster configuration.
 func (c *config) checkValidConfig() hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
@@ -256,6 +257,7 @@ func (c *config) checkValidConfig() hcl.Diagnostics {
 	return diagnostics
 }
 
+// checkNotEmptyWorkers checks if the cluster has at least 1 node pool defined.
 func (c *config) checkNotEmptyWorkers() hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
@@ -270,6 +272,7 @@ func (c *config) checkNotEmptyWorkers() hcl.Diagnostics {
 	return diagnostics
 }
 
+// checkWorkerPoolNamesUnique verifies that all worker pool names are unique.
 func (c *config) checkWorkerPoolNamesUnique() hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
@@ -281,7 +284,7 @@ func (c *config) checkWorkerPoolNamesUnique() hcl.Diagnostics {
 			continue
 		}
 
-		// It is duplicated
+		// It is duplicated.
 		diagnostics = append(diagnostics, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Worker pools name should be unique",

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -92,15 +92,7 @@ func (c *config) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContext) 
 	if diags := gohcl.DecodeBody(*configBody, evalContext, c); len(diags) != 0 {
 		return diags
 	}
-	if len(c.WorkerPools) == 0 {
-		err := &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "At least one worker pool must be defined",
-			Detail:   "Make sure to define at least one worker pool block in your cluster block",
-		}
-		return hcl.Diagnostics{err}
-	}
-	return nil
+	return c.checkValidConfig()
 }
 
 func NewConfig() *config {
@@ -251,4 +243,17 @@ func (c *config) GetExpectedNodes() int {
 	}
 
 	return c.ControllerCount + workers
+}
+
+// Check cluster config is valid
+func (c *config) checkValidConfig() hcl.Diagnostics {
+	if len(c.WorkerPools) == 0 {
+		err := &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "At least one worker pool must be defined",
+			Detail:   "Make sure to define at least one worker pool block in your cluster block",
+		}
+		return hcl.Diagnostics{err}
+	}
+	return nil
 }

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -250,6 +250,15 @@ func (c *config) GetExpectedNodes() int {
 func (c *config) checkValidConfig() hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
+	diagnostics = append(diagnostics, c.checkNotEmptyWorkers()...)
+	diagnostics = append(diagnostics, c.checkWorkerPoolNamesUnique()...)
+
+	return diagnostics
+}
+
+func (c *config) checkNotEmptyWorkers() hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
 	if len(c.WorkerPools) == 0 {
 		diagnostics = append(diagnostics, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
@@ -258,8 +267,14 @@ func (c *config) checkValidConfig() hcl.Diagnostics {
 		})
 	}
 
-	// Check that worker pools names are unique
+	return diagnostics
+}
+
+func (c *config) checkWorkerPoolNamesUnique() hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
 	dup := make(map[string]bool)
+
 	for _, w := range c.WorkerPools {
 		if !dup[w.Name] {
 			dup[w.Name] = true

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -93,7 +93,7 @@ module "packet-{{.Config.ClusterName}}" {
 }
 
 {{ range $index, $pool := .Config.WorkerPools }}
-module "worker-pool-{{ $index }}" {
+module "worker-{{ $pool.Name }}" {
   source = "../lokomotive-kubernetes/packet/flatcar-linux/kubernetes/workers"
 
   providers = {


### PR DESCRIPTION
This patches are extracted from https://github.com/kinvolk/lokomotive/pull/119. I found a bug in the code that I needed to change for that PR, so I fixed it.

That PR is not yet ready to be merged, so I'm including the fixes I found while writing it in this PR. Most of the commits are cosmetic (create a function for this and that) and make way more sense when PR #119 is merged, as those functions will not be so simple. To keep the backport simple, I decided to include them here, though

The fix is in patch: `packet: Use user-specified pool name for TF pool`, all the rest are cleanups or cosmetic changes. I c&p here the commit message from that patch, as it explains quite well what is doing and why it is important (let me know if I'm missing something!):

Before this commit, the pool name specified in lokoctl was being
completely ignored. The terraform code just iterated over the worker
pools, and the first one was named "pool-0", second "pool-1", etc.

This can create confusion for the user (an error on "pool-1" when the
name was "foo" is not meaningful, is difficult to know to which pools
servers belong). But, WAY more importantly, if the user reorders the
pools in the lokocfg file (or if for some reason that order is not
guaranteed by golang), it will create a mess in terraform.

This patch just makes that part sane: the terraform worker pools are
created with the user specified name. Therefore, errors in terraform are
meaningful to the user, the user can match servers hostnames in Packet
and can re-order pools without making terraform go nuts.

Also, this patch adds adds a check that all pool names are different