### PR TITLE
Makefile: Only run linter if code compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ build-slim:
 test: run-unit-tests
 
 .PHONY: lint
-lint:
+lint: build-slim
 	golangci-lint run --enable-all --disable=godox,gochecknoglobals --max-same-issues=0 --max-issues-per-linter=0 --build-tags aws,packet,e2e,disruptive-e2e --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
 
 GOFORMAT_FILES := $(shell find . -name '*.go' | grep -v '^./vendor')

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ build-slim:
 test: run-unit-tests
 
 .PHONY: lint
-lint: build-slim
+lint: build-slim build-test
 	golangci-lint run --enable-all --disable=godox,gochecknoglobals --max-same-issues=0 --max-issues-per-linter=0 --build-tags aws,packet,e2e,disruptive-e2e --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
 
 GOFORMAT_FILES := $(shell find . -name '*.go' | grep -v '^./vendor')


### PR DESCRIPTION
There are ton of cases where the linter can't run, with errors like:

	WARN [runner] Can't run linter goanalysis_metalinter: assign: failed prerequisites: inspect@github.com/kinvolk/lokomotive/pkg/platform/packet
	WARN [runner] Can't run linter unused: buildssa: analysis skipped: errors in package: [lokomotive/pkg/platform/packet/packet.go:271:20: cannot use arguments (variable of type []string) as string value in argument to ex.Execute]
	ERRO Running error: buildssa: analysis skipped: errors in package: [lokomotive/pkg/platform/packet/packet.go:271:20: cannot use arguments (variable of type []string) as string value in argument to ex.Execute]

The error is not crystal clear, but if you look closely it says there
were some errors in the package. While not very clear, that seems to
mean **compilation** errors.

I've faced this linter error several times in the last days and kept the
branches to later analyze (didn't find the reason immediately). I can
confirm that all the branches I kept where the linter failed to run with
similar errors, there were compilation errors and running "make lint"
(with this patch) makes it obvious.

Adding this dependency, the error is way clear, as it shows the
compilation error, like:

	pkg/platform/packet/packet.go:270:17: too many arguments in call to ex.Apply

This would have saved me quite some time, as this is way more clear.
And I sometimes trying to fix a linter error end up creating a syntax
error.