### PR TITLE
Add ability to create AWS worker pools

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -14,6 +14,15 @@ cluster "aws" {
   dns_zone_id  = "$AWS_DNS_ZONE_ID"
   os_channel   = var.os_channel
   ssh_pubkeys  = ["$PUB_KEY"]
+
+  worker_pool "pool-ci" {
+    count       = 2
+    ssh_pubkeys = ["$PUB_KEY"]
+    disk_size   = 30
+    tags = {
+      "deployment" = "ci"
+    }
+  }
 }
 
 component "openebs-operator" {}

--- a/docs/configuration-reference/platforms/aws.md
+++ b/docs/configuration-reference/platforms/aws.md
@@ -45,8 +45,11 @@ variable "region" {}
 variable "disk_size" {}
 variable "disk_type" {}
 variable "disk_iops" {}
-variable "worker_price" {}
-variable "worker_target_groups" {}
+variable "worker_disk_size" {}
+variable "worker_disk_type" {}
+variable "worker_disk_iops" {}
+variable "worker_spot_price" {}
+variable "target_groups" {}
 
 backend "s3" {
   bucket         = var.state_s3_bucket
@@ -86,13 +89,7 @@ cluster "aws" {
 
   certs_validity_period_hours = 8760
 
-  worker_count = var.workers_count
-
-  worker_type = var.workers_type
-
   controller_clc_snippets = var.controller_clc_snippets
-
-  worker_clc_snippets = var.worker_clc_snippets
 
   region = var.region
 
@@ -103,10 +100,6 @@ cluster "aws" {
   disk_type = var.disk_type
 
   disk_iops = var.disk_iops
-
-  worker_price = var.worker_price
-
-  worker_target_groups = var.worker_target_groups
 
   network_mtu = 1480
 
@@ -119,6 +112,34 @@ cluster "aws" {
   cluster_domain_suffix = "cluster.local"
 
   enable_reporting = false
+
+  worker_pool "my-worker-pool {
+    count = 2
+
+    instance_type = var.workers_type
+
+    ssh_pubkeys = var.ssh_public_keys
+
+    os_channel = "stable"
+
+    os_version = "current"
+
+    disk_size = var.worker_disk_size
+
+    disk_type = var.worker_disk_type
+
+    disk_iops = var.worker_disk_iops
+
+    spot_price = var.worker_spot_price
+
+    target_groups = var.target_groups
+
+    clc_snippets = var.worker_clc_snippets
+
+    tags = {
+      "key" = "value"
+    }
+  }
 }
 ```
 
@@ -127,20 +148,21 @@ block in the cluster configuration.
 
 Example:
 
-The default for worker_type is `t3.small`. If you wish to change the default, then you
+The default for instance_type in worker pool block is `t3.small`. If you wish to change the default, then you
 define the variable and use it to refer in the cluster configuration.
 
 ```tf
-variable "custom_default_worker_type" {
+variable "custom_worker_type" {
   default = "i3.large"
 }
 
 .
 .
-.
-worker_type = var.custom_default_worker_type
-.
-.
+worker_pool "my-worker-pool" {
+  worker_type = var.custom_worker_type
+  .
+  .
+}
 .
 
 ```
@@ -159,17 +181,12 @@ worker_type = var.custom_default_worker_type
 | `ssh_pubkeys`                 | SSH public keys for user `core`.                                                                                                                                                           | -               | true     |
 | `controller_count`            | Number of controller nodes.                                                                                                                                                                | 1               | false    |
 | `controller_type`             | AWS instance type for controllers.                                                                                                                                                         | "t3.small"      | false    |
-| `worker_count`                | Number of worker nodes.                                                                                                                                                                    | 2               | false    |
-| `worker_type`                 | AWS instance type for worker nodes.                                                                                                                                                        | "t3.small"      | false    |
 | `controller_clc_snippets`     | Controller Flatcar Container Linux Config snippets.                                                                                                                                        | []              | false    |
-| `worker_clc_snippets`         | Worker Flatcar Container Linux Config snippets".                                                                                                                                           | []              | false    |
 | `region`                      | AWS region to use for deploying the cluster.                                                                                                                                               | "eu-central-1"  | false    |
 | `enable_aggregation`          | Enable the Kubernetes Aggregation Layer.                                                                                                                                                   | true            | false    |
 | `disk_size`                   | Size of the EBS volume in GB.                                                                                                                                                              | 40              | false    |
 | `disk_type`                   | Type of the EBS volume (e.g. standard, gp2, io1).                                                                                                                                          | "gp2"           | false    |
 | `disk_iops`                   | IOPS of the EBS volume (e.g 100).                                                                                                                                                          | 0               | false    |
-| `worker_price`                | Spot price in USD for autoscaling group spot instances. Leave as empty string for autoscaling group to use on-demand instances. Switching in-place from spot to on-demand is not possible. | ""              | false    |
-| `worker_target_groups`        | Additional target group ARNs to which worker instances should be added.                                                                                                                    | []              | false    |
 | `network_mtu`                 | CNI interface MTU. Use 8981 if using instances types with Jumbo frames.                                                                                                                    | 1480            | false    |
 | `host_cidr`                   | CIDR IPv4 range to assign to EC2 nodes.                                                                                                                                                    | "10.0.0.0/16"   | false    |
 | `pod_cidr`                    | CIDR IPv4 range to assign Kubernetes pods.                                                                                                                                                 | "10.2.0.0/16"   | false    |
@@ -177,6 +194,19 @@ worker_type = var.custom_default_worker_type
 | `cluster_domain_suffix`       | Cluster's DNS domain.                                                                                                                                                                      | "cluster.local" | false    |
 | `enable_reporting`            | Enables usage or analytics reporting to upstream.                                                                                                                                          | false           | false    |
 | `certs_validity_period_hours` | Validity of all the certificates in hours.                                                                                                                                                 | 8760            | false    |
+| `worker_pool`                 | Configuration block for worker pools. There can be more than one.                                                                                                                          | -               | true     |
+| `worker_pool.count`           | Number of workers in the worker pool. Can be changed afterwards to add or delete workers.                                                                                                  | -               | true     |
+| `worker_pool.instance_type`   | AWS instance type for worker nodes.                                                                                                                                                        | "t3.small"      | false    |
+| `worker_pool.ssh_pubkeys`     | SSH public keys for user `core`.                                                                                                                                                           | -               | true     |
+| `worker_pool.os_channel`      | Flatcar Container Linux channel to install from (stable, beta, alpha, edge).                                                                                                               | "stable"        | false    |
+| `worker_pool.os_version`      | Flatcar Container Linux version to install. Version such as "2303.3.1" or "current".                                                                                                       | "current"       | false    |
+| `worker_pool.disk_size`       | Size of the EBS volume in GB.                                                                                                                                                              | 40              | false    |
+| `worker_pool.disk_type`       | Type of the EBS volume (e.g. standard, gp2, io1).                                                                                                                                          | "gp2"           | false    |
+| `worker_pool.disk_iops`       | IOPS of the EBS volume (e.g 100).                                                                                                                                                          | 0               | false    |
+| `worker_pool.spot_price`      | Spot price in USD for autoscaling group spot instances. Leave as empty string for autoscaling group to use on-demand instances. Switching in-place from spot to on-demand is not possible. | ""              | false    |
+| `worker_pool.target_groups`   | Additional target group ARNs to which worker instances should be added.                                                                                                                    | []              | false    |
+| `worker_pool.clc_snippets`    | CWorker Flatcar Container Linux Config snippets.                                                                                                                                           | []              | false    |
+| `worker_pool.tags`            | Optional details to tag on AWS resources.                                                                                                                                                  | -               | false    |
 
 ## Installing
 

--- a/examples/aws-production/cluster.lokocfg
+++ b/examples/aws-production/cluster.lokocfg
@@ -47,8 +47,12 @@ cluster "aws" {
   dns_zone         = var.dns_zone
   dns_zone_id      = var.route53_zone_id
   ssh_pubkeys      = var.ssh_public_keys
-  worker_count     = var.workers_count
-  worker_type      = var.workers_type
+
+  worker_pool "my-worker-pool-name" {
+    count         = var.workers_count
+    instance_type = var.workers_type
+    ssh_pubkeys   = var.ssh_public_keys
+  }
 }
 
 component "metrics-server" {}

--- a/examples/aws-testing/cluster.lokocfg
+++ b/examples/aws-testing/cluster.lokocfg
@@ -30,8 +30,12 @@ cluster "aws" {
   dns_zone         = var.dns_zone
   dns_zone_id      = var.route53_zone_id
   ssh_pubkeys      = var.ssh_public_keys
-  worker_count     = var.workers_count
-  worker_type      = var.workers_type
+
+  worker_pool "my-worker-pool-name" {
+    instance_type = var.workers_type
+    count         = var.workers_count
+    ssh_pubkeys   = var.ssh_public_keys
+  }
 }
 
 component "metrics-server" {}

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -45,16 +45,8 @@ module "aws-{{.Config.ClusterName}}" {
   controller_type  = "{{.Config.ControllerType}}"
  {{- end }}
 
-  worker_count = {{.Config.WorkerCount}}
-  {{- if .Config.WorkerType }}
-  worker_type  = "{{.Config.WorkerType}}"
-  {{- end }}
-  {{- if .Config.WorkerPrice }}
-  worker_price = "{{.Config.WorkerPrice}}"
-  {{- end }}
-  {{- if .Config.WorkerTargetGroups }}
-  worker_target_groups = {{.WorkerTargetGroups}}
-  {{- end }}
+	# Do not allow creation of workers apart from using worker pools.
+  worker_count = 0
 
   {{- if .Config.NetworkMTU }}
   network_mtu = {{.Config.NetworkMTU}}
@@ -82,9 +74,6 @@ module "aws-{{.Config.ClusterName}}" {
 
  {{- if ne .ControllerCLCSnippets "null" }}
   controller_clc_snippets = {{.ControllerCLCSnippets}}
- {{- end }}
-  {{- if ne .WorkerCLCSnippets "null" }}
-  worker_clc_snippets     = {{.WorkerCLCSnippets}}
  {{- end }}
 
   enable_aggregation = {{.Config.EnableAggregation}}

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -37,13 +37,13 @@ module "aws-{{.Config.ClusterName}}" {
   ssh_keys  = {{$.SSHPublicKeys}}
   asset_dir = "../cluster-assets"
 
-	{{- if .Config.ControllerCount}}
+ {{- if .Config.ControllerCount}}
   controller_count = {{.Config.ControllerCount}}
-	{{- end }}
+ {{- end }}
 
-	{{- if .Config.ControllerType}}
+ {{- if .Config.ControllerType}}
   controller_type  = "{{.Config.ControllerType}}"
-	{{- end }}
+ {{- end }}
 
   worker_count = {{.Config.WorkerCount}}
   {{- if .Config.WorkerType }}
@@ -70,22 +70,22 @@ module "aws-{{.Config.ClusterName}}" {
   host_cidr = "{{.Config.HostCIDR}}"
   {{- end }}
 
-	{{- if .Config.OSName }}
+ {{- if .Config.OSName }}
   os_name = "{{.Config.OSName}}"
-	{{- end }}
-	{{- if .Config.OSChannel }}
+ {{- end }}
+ {{- if .Config.OSChannel }}
   os_channel = "{{.Config.OSChannel}}"
-	{{- end }}
-	{{- if .Config.OSVersion }}
+ {{- end }}
+ {{- if .Config.OSVersion }}
   os_version = "{{.Config.OSVersion}}"
-	{{- end }}
+ {{- end }}
 
-	{{- if ne .ControllerCLCSnippets "null" }}
+ {{- if ne .ControllerCLCSnippets "null" }}
   controller_clc_snippets = {{.ControllerCLCSnippets}}
-	{{- end }}
-	{{- if ne .WorkerCLCSnippets "null" }}
+ {{- end }}
+  {{- if ne .WorkerCLCSnippets "null" }}
   worker_clc_snippets     = {{.WorkerCLCSnippets}}
-	{{- end }}
+ {{- end }}
 
   enable_aggregation = {{.Config.EnableAggregation}}
 
@@ -103,6 +103,72 @@ module "aws-{{.Config.ClusterName}}" {
   certs_validity_period_hours = {{.Config.CertsValidityPeriodHours}}
   {{- end }}
 }
+
+{{ range $index, $pool := .Config.WorkerPools }}
+module "worker-pool-{{ $index }}" {
+  source = "../lokomotive-kubernetes/aws/flatcar-linux/kubernetes/workers"
+
+  providers = {
+    aws      = aws.default
+  }
+
+  vpc_id                = module.aws-{{ $.Config.ClusterName }}.vpc_id
+  subnet_ids            = flatten([module.aws-{{ $.Config.ClusterName }}.subnet_ids])
+  security_groups       = module.aws-{{ $.Config.ClusterName }}.worker_security_groups
+  kubeconfig            = module.aws-{{ $.Config.ClusterName }}.kubeconfig
+
+  {{- if $.Config.ServiceCIDR }}
+  service_cidr          = "{{ $.Config.ServiceCIDR }}"
+  {{- end }}
+
+  {{- if $.Config.ClusterDomainSuffix }}
+  cluster_domain_suffix = "{{ $.Config.ClusterDomainSuffix }}"
+  {{- end }}
+
+  ssh_keys              = {{ index (index $.WorkerpoolCfg $index) "ssh_pub_keys" }}
+  name                  = "{{ $pool.Name }}"
+  worker_count          = "{{ $pool.Count}}"
+  os_name               = "flatcar"
+  {{- if $pool.InstanceType }}
+  instance_type         = "{{ $pool.InstanceType }}"
+  {{- end }}
+
+  {{- if $pool.OSChannel }}
+  os_channel            = "{{ $pool.OSChannel }}"
+  {{- end }}
+
+  {{- if $pool.OSVersion }}
+  os_version            = "{{ $pool.OSVersion }}"
+  {{- end }}
+
+  {{- if $pool.DiskSize }}
+  disk_size             = "{{ $pool.DiskSize }}"
+  {{- end }}
+
+  {{- if $pool.DiskType }}
+  disk_type             = "{{ $pool.DiskType }}"
+  {{- end }}
+
+  {{- if $pool.DiskIOPS }}
+  disk_iops             = "{{ $pool.DiskIOPS }}"
+  {{- end }}
+
+  {{- if $pool.SpotPrice }}
+  spot_price            = "{{ $pool.SpotPrice }}"
+  {{- end }}
+  {{- if $pool.TargetGroups }}
+  target_groups         = "{{ index (index $.WorkerpoolCfg $index) "target_groups" }}"
+  {{- end }}
+
+  {{- if ne (index (index $.WorkerpoolCfg $index) "clc_snippets") "null" }}
+  clc_snippets          = {{ index (index $.WorkerpoolCfg $index) "clc snippets" }}
+  {{- end }}
+
+  {{- if $pool.Tags }}
+  tags                  = {{ index (index $.WorkerpoolCfg $index) "tags" }}
+  {{- end }}
+}
+{{- end }}
 
 provider "aws" {
   version = "2.48.0"


### PR DESCRIPTION
This facility is available in lokomotive-kubernetes
With this PR , a user can create worker pools in AWS as well (#155 )

This also removes the worker related configuration fields such as `worker_count` , `worker_type` etc. from the config struct and moves them into workerpool struct. Fixes #156 

This makes creating the worker pool mandatory to add workers for creating a Lokomotive cluster.
