### PR TITLE
packet: use worker pool variable for the IPXE script URL

### DIFF
--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -120,7 +120,7 @@ module "worker-{{ $pool.Name }}" {
   {{- end }}
 
   {{- if $.Config.IPXEScriptURL }}
-  ipxe_script_url = "{{ $.Config.IPXEScriptURL }}"
+  ipxe_script_url = "{{ $pool.IPXEScriptURL }}"
   {{- end }}
 
   {{- if $pool.OSArch }}


### PR DESCRIPTION
Otherwise we'll be using the same as the controller module.