### PR TITLE
cli/cmd/cluster-apply.go: initialize components to apply as empty slice

### DIFF
--- a/cli/cmd/cluster-apply.go
+++ b/cli/cmd/cluster-apply.go
@@ -107,7 +107,7 @@ func runClusterApply(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	componentsToApply := make([]string, len(lokoConfig.RootConfig.Components))
+	componentsToApply := []string{}
 	for _, component := range lokoConfig.RootConfig.Components {
 		componentsToApply = append(componentsToApply, component.Name)
 	}


### PR DESCRIPTION
This commit fixes a regression introduced in
485994b8baef25a8b2abeb2731fd659e6c35a34c, which causes, that 'cluster
apply' command can no longer install components.

This is happening, because it changed the way we initialize the
componentsToApply variable. Before it was a nil slice and mentioned
commit changed it to initialize it as an slice with number of empty
elements equal to number of configured components. As we use 'append'
later, we end up with N empty elements and N valid elements, hence the
components installation fails.

This commit changes an initialation to simply assignment, which is a
most common approach for working with slices in Go, together with
'append'. We don't need to use 'make' for optimization here.

Closes #160

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>