### PR TITLE
ci: use spot instances for AWS testing

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -19,6 +19,7 @@ cluster "aws" {
     count       = 2
     ssh_pubkeys = ["$PUB_KEY"]
     disk_size   = 30
+    spot_price = "0.02"
     tags = {
       "deployment" = "ci"
     }


### PR DESCRIPTION
We're currently using t3.medium instances which cost $0.048 per hour.
Let's try to use spot instances with $0.02 as target price.

According to https://aws.amazon.com/ec2/spot/pricing/ the spot price for
a t3.medium is $0.0144 but even if we get a worse instance tests will
probably be ok.

We should revisit this when we enable single-node Lokomotive update
testing since that requires more memory.

Closes #149 