### PR TITLE
fix: Prefix cluster name to aws worker pool

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -15,7 +15,7 @@ cluster "aws" {
   os_channel   = var.os_channel
   ssh_pubkeys  = ["$PUB_KEY"]
 
-  worker_pool "pool-ci" {
+  worker_pool "$CLUSTER_ID-wp" {
     count       = 2
     ssh_pubkeys = ["$PUB_KEY"]
     disk_size   = 30


### PR DESCRIPTION
- This commit fixes the condition where all AWS CI jobs have the same
  worker pool name, causing errors such as:

  ```
  error: Error creating LB Target Group: DuplicateTargetGroupName: A
  target group with the same name 'pool-ci-workers-http' exists, but
  with different settings
  ```

Signed-off-by: Imran Pochi <imran@kinvolk.io>