### PR TITLE
pkg/aws: check cluster name and worker pool name length

### DIFF
--- a/examples/aws-production/cluster.lokocfg
+++ b/examples/aws-production/cluster.lokocfg
@@ -48,7 +48,7 @@ cluster "aws" {
   dns_zone_id      = var.route53_zone_id
   ssh_pubkeys      = var.ssh_public_keys
 
-  worker_pool "my-worker-pool-name" {
+  worker_pool "my-wp-name" {
     count         = var.workers_count
     instance_type = var.workers_type
     ssh_pubkeys   = var.ssh_public_keys

--- a/examples/aws-testing/cluster.lokocfg
+++ b/examples/aws-testing/cluster.lokocfg
@@ -31,7 +31,7 @@ cluster "aws" {
   dns_zone_id      = var.route53_zone_id
   ssh_pubkeys      = var.ssh_public_keys
 
-  worker_pool "my-worker-pool-name" {
+  worker_pool "my-wp-name" {
     instance_type = var.workers_type
     count         = var.workers_count
     ssh_pubkeys   = var.ssh_public_keys


### PR DESCRIPTION
There are tight restrictions on resource name length on AWS. Check
cluster name and worker pool name against those.

Fixes #179 