### PR TITLE
docs/prometheus-operator: clarify alertmanager config indentation

### DIFF
--- a/docs/configuration-reference/components/prometheus-operator.md
+++ b/docs/configuration-reference/components/prometheus-operator.md
@@ -55,7 +55,7 @@ Create `alertmanager-config.yaml` file if necessary. Visit the [alertmanager
 configuration](https://prometheus.io/docs/alerting/configuration/#configuration-file) for more
 information.
 
-**Note**: Make sure it is indented to two spaces.
+**Note**: Make sure the whole file is indented two spaces. That is, there are two spaces before the top level block.
 
 ```yaml
   config:


### PR DESCRIPTION
The current sentence is ambiguous: it might be interpreted as the file
needing to use 2 spaces as indentation.

Change it to clarify the whole file needs to be indented two spaces.
