### PR TITLE
docs/backend/s3: add primary key requirement to dynamodb table

### DIFF
--- a/docs/configuration-reference/backend/s3.md
+++ b/docs/configuration-reference/backend/s3.md
@@ -20,7 +20,7 @@ used.
 ## Prerequisites
 
 * AWS S3 bucket to be used should already be created.
-* DynamoDB table to be used for state locking should already be created.
+* DynamoDB table to be used for state locking should already be created. The table must have a primary key named LockID.
 * Correct IAM permissions for the S3 bucket and DynamoDB Table. At minimum the following are the
   permissions required:
   * [S3 bucket permissions](https://www.terraform.io/docs/backends/types/s3.html#s3-bucket-permissions).
@@ -44,14 +44,14 @@ backend "s3" {
 
 ## Attribute reference
 
-| Argument                    | Description                                                  | Default | Required |
-|-----------------------------|--------------------------------------------------------------|:-------:|:--------:|
-| `backend.s3`                | AWS S3 backend configuration block.                          | -       | false    |
-| `backend.s3.bucket`         | Name of the S3 bucket where Lokomotive stores cluster state. | -       | true     |
-| `backend.s3.key`            | Path in the S3 bucket to store the cluster state.            | -       | true     |
-| `backend.s3.region`         | AWS Region of the S3 bucket.                                 | -       | false    |
-| `backend.s3.aws_creds_path` | Path to the AWS credentials file.                            | -       | false    |
-| `backend.s3.dynamodb_table` | Name of the DynamoDB table for locking the cluster state.    | -       | false    |
+| Argument                    | Description                                                                                                  | Default | Required |
+|-----------------------------|--------------------------------------------------------------------------------------------------------------|:-------:|:--------:|
+| `backend.s3`                | AWS S3 backend configuration block.                                                                          | -       | false    |
+| `backend.s3.bucket`         | Name of the S3 bucket where Lokomotive stores cluster state.                                                 | -       | true     |
+| `backend.s3.key`            | Path in the S3 bucket to store the cluster state.                                                            | -       | true     |
+| `backend.s3.region`         | AWS Region of the S3 bucket.                                                                                 | -       | false    |
+| `backend.s3.aws_creds_path` | Path to the AWS credentials file.                                                                            | -       | false    |
+| `backend.s3.dynamodb_table` | Name of the DynamoDB table for locking the cluster state. The table must have a primary key named LockID.    | -       | false    |
 
 >NOTE: In order for the installer to configure the credentials for S3 backend either pass them as
 environment variables or in the config above.


### PR DESCRIPTION
This is not trivial and only documented in the terraform s3 backend type
documentation AFAIK:
https://www.terraform.io/docs/backends/types/s3.html#dynamodb_table