### PR TITLE
components/external-dns: expose owner_id

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -40,7 +40,8 @@ component "cert-manager" {
 }
 
 component "external-dns" {
-  policy = "sync"
+  policy   = "sync"
+  owner_id = "$CLUSTER_ID"
   aws {
     zone_id               = "$AWS_DNS_ZONE_ID"
     aws_access_key_id     = "$AWS_ACCESS_KEY_ID"

--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -47,7 +47,8 @@ component "cert-manager" {
 }
 
 component "external-dns"{
-  policy = "sync"
+  policy   = "sync"
+  owner_id = "$CLUSTER_ID"
   aws {
     zone_id = "$AWS_DNS_ZONE_ID"
     aws_access_key_id = "$AWS_ACCESS_KEY_ID"

--- a/docs/configuration-reference/components/external-dns.md
+++ b/docs/configuration-reference/components/external-dns.md
@@ -59,17 +59,18 @@ Table of all the arguments accepted by the component.
 
 Example:
 
-| Argument                    | Description                                                                                                       | Default        | Required |
-|-----------------------------|-------------------------------------------------------------------------------------------------------------------|:--------------:|:--------:|
-| `sources`                   | Kubernetes resources type to be observed for new DNS entries by ExternalDNS.                                      | ["service"]    | false    |
-| `namespace`                 | Namespace to install ExternalDNS.                                                                                 | "external-dns" | false    |
-| `policy`                    | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only).                | "upsert-only"  | false    |
-| `metrics`                   | Enable metrics collection by Prometheus. Needs [Prometheus Operator component](prometheus-operator.md) installed. | false          | false    |
-| `aws`                       | Configuration block for AWS Route53 DNS provider.                                                                 | -              | true     |
-| `aws.zone_type`             | Filter for zones of this type (options: public, private).                                                         | "public"       | false    |
-| `aws.zone_id`               | ID of the DNS zone.                                                                                               | -              | true     |
-| `aws.aws_access_key_id`     | AWS access key ID for AWS credentials. Use environment variable AWS_ACCESS_KEY_ID instead.                        | -              | false    |
-| `aws.aws_secret_access_key` | AWS secret access key for AWS credentials. Use environment variable AWS_SECRET_ACCESS_KEY instead.                | -              | false    |
+| Argument                    | Description                                                                                                                                           | Default        | Required |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------:|:--------:|
+| `sources`                   | Kubernetes resources type to be observed for new DNS entries by ExternalDNS.                                                                          | ["service"]    | false    |
+| `namespace`                 | Namespace to install ExternalDNS.                                                                                                                     | "external-dns" | false    |
+| `policy`                    | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only).                                                    | "upsert-only"  | false    |
+| `metrics`                   | Enable metrics collection by Prometheus. Needs [Prometheus Operator component](prometheus-operator.md) installed.                                     | false          | false    |
+| `owner_id`                  | A name that identifies this instace of ExternalDNS. Set it to a unique value across the DNS zone that doesn't change for the lifetime of the cluster. | -              | true     |
+| `aws`                       | Configuration block for AWS Route53 DNS provider.                                                                                                     | -              | true     |
+| `aws.zone_type`             | Filter for zones of this type (options: public, private).                                                                                             | "public"       | false    |
+| `aws.zone_id`               | ID of the DNS zone.                                                                                                                                   | -              | true     |
+| `aws.aws_access_key_id`     | AWS access key ID for AWS credentials. Use environment variable AWS_ACCESS_KEY_ID instead.                                                            | -              | false    |
+| `aws.aws_secret_access_key` | AWS secret access key for AWS credentials. Use environment variable AWS_SECRET_ACCESS_KEY instead.                                                    | -              | false    |
 
 ## Applying
 

--- a/pkg/components/external-dns/component.go
+++ b/pkg/components/external-dns/component.go
@@ -43,7 +43,7 @@ aws:
     secretKey: "{{ .AwsConfig.SecretAccessKey }}"
     accessKey: "{{ .AwsConfig.AccessKeyID }}"
   zoneType: {{ .AwsConfig.ZoneType }}
-txtOwnerId: {{ .AwsConfig.ZoneID }}
+txtOwnerId: {{ .OwnerID }}
 {{- end }}
 policy: {{ .Policy }}
 replicas: 3
@@ -68,6 +68,7 @@ type component struct {
 	Metrics   bool      `hcl:"metrics,optional"`
 	Policy    string    `hcl:"policy,optional"`
 	AwsConfig AwsConfig `hcl:"aws,block"`
+	OwnerID   string    `hcl:"owner_id"`
 }
 
 func newComponent() *component {

--- a/pkg/components/external-dns/component_test.go
+++ b/pkg/components/external-dns/component_test.go
@@ -68,6 +68,7 @@ func TestAwsConfigWithoutProvidingCredentials(t *testing.T) {
    sources = ["service"]
    metrics =  false
    policy = "upsert-only"
+   owner_id = "test-owner"
    aws {
      zone_id = "TESTZONEID"
      zone_type = "public"
@@ -97,6 +98,7 @@ func TestAwsConfigBySettingEnvVariables(t *testing.T) {
     sources = ["service"]
     metrics =  false
     policy = "upsert-only"
+    owner_id = "test-owner"
     aws {
       zone_id = "TESTZONEID"
       zone_type = "public"
@@ -133,6 +135,7 @@ func TestAwsConfigBySettingEmptyEnvVariables(t *testing.T) {
     sources = ["service"]
     metrics =  false
     policy = "upsert-only"
+    owner_id = "test-owner"
     aws {
       zone_id = "TESTZONEID"
       zone_type = "public"
@@ -168,6 +171,7 @@ func TestAwsConfigBySettingConfigFields(t *testing.T) {
     sources = ["service"]
     metrics =  false
     policy = "upsert-only"
+    owner_id = "test-owner"
     aws {
       zone_id = "TESTZONEID"
       zone_type = "public"


### PR DESCRIPTION
We were setting it to the AWS DNS Zone ID and that means that several
clusters using the same DNS Zone will interact badly with each other.

This exposes it to the user so they can choose a reasonable ID.