### PR TITLE
test/components/util: don't return errors when taking testing.T as arg

### DIFF
--- a/test/components/cert-manager/cert-manager_test.go
+++ b/test/components/cert-manager/cert-manager_test.go
@@ -28,11 +28,7 @@ import (
 const namespace = "cert-manager"
 
 func TestCertManagerDeployments(t *testing.T) {
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	testCases := []struct {
 		deployment string

--- a/test/components/cluster-autoscaler/cluster-autoscaler_test.go
+++ b/test/components/cluster-autoscaler/cluster-autoscaler_test.go
@@ -31,12 +31,7 @@ const (
 )
 
 func TestClusterAutoscalerDeployments(t *testing.T) {
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	t.Run(fmt.Sprintf("deployment"), func(t *testing.T) {
 		t.Parallel()

--- a/test/components/contour/contour_test.go
+++ b/test/components/contour/contour_test.go
@@ -29,11 +29,7 @@ func TestEnvoyDaemonset(t *testing.T) {
 	namespace := "projectcontour"
 	daemonset := "envoy"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	testutil.WaitForDaemonSet(t, client, namespace, daemonset, time.Second*5, time.Minute*5)
 }
@@ -43,11 +39,7 @@ func TestContourDeployment(t *testing.T) {
 	namespace := "projectcontour"
 	deployment := "contour"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	testutil.WaitForDeployment(t, client, namespace, deployment, time.Second*5, time.Minute*5)
 }

--- a/test/components/coredns/coredns_test.go
+++ b/test/components/coredns/coredns_test.go
@@ -29,11 +29,7 @@ func TestCoreDNSDeployment(t *testing.T) {
 	namespace := "kube-system"
 	deployment := "coredns"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	testutil.WaitForDeployment(t, client, namespace, deployment, time.Second*5, time.Minute*5)
 }

--- a/test/components/dex/dex_test.go
+++ b/test/components/dex/dex_test.go
@@ -27,11 +27,7 @@ import (
 func TestDexDeployment(t *testing.T) {
 	namespace := "dex"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	t.Run("deployment", func(t *testing.T) {
 		t.Parallel()

--- a/test/components/external-dns/external-dns_test.go
+++ b/test/components/external-dns/external-dns_test.go
@@ -27,11 +27,7 @@ import (
 const namespace = "external-dns"
 
 func TestExternalDNSDeployments(t *testing.T) {
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	t.Run(fmt.Sprintf("deployment"), func(t *testing.T) {
 		t.Parallel()

--- a/test/components/flatcar-linux-update-operator/fluo_test.go
+++ b/test/components/flatcar-linux-update-operator/fluo_test.go
@@ -29,11 +29,7 @@ func TestUpdateAgentDaemonset(t *testing.T) {
 	namespace := "reboot-coordinator"
 	daemonset := "flatcar-linux-update-agent"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	testutil.WaitForDaemonSet(t, client, namespace, daemonset, time.Second*5, time.Minute*5)
 }
@@ -43,11 +39,7 @@ func TestUpdateOperatorDeployment(t *testing.T) {
 	namespace := "reboot-coordinator"
 	deployment := "flatcar-linux-update-operator"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	testutil.WaitForDeployment(t, client, namespace, deployment, time.Second*5, time.Minute*5)
 }

--- a/test/components/gangway/gangway_test.go
+++ b/test/components/gangway/gangway_test.go
@@ -27,11 +27,7 @@ import (
 func TestGangwayDeployment(t *testing.T) {
 	namespace := "gangway"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	t.Run("deployment", func(t *testing.T) {
 		t.Parallel()

--- a/test/components/httpbin/httpbin_test.go
+++ b/test/components/httpbin/httpbin_test.go
@@ -31,12 +31,7 @@ const (
 )
 
 func TestHttpbinDeployments(t *testing.T) {
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	t.Run(fmt.Sprintf("deployment"), func(t *testing.T) {
 		t.Parallel()

--- a/test/components/kubernetes/controller-manager_test.go
+++ b/test/components/kubernetes/controller-manager_test.go
@@ -29,12 +29,7 @@ func TestControllerManagerDeployment(t *testing.T) {
 	namespace := "kube-system"
 	deployment := "kube-controller-manager"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	testutil.WaitForDeployment(t, client, namespace, deployment, retryInterval, timeout)
 }

--- a/test/components/kubernetes/kubelet_disruptive_test.go
+++ b/test/components/kubernetes/kubelet_disruptive_test.go
@@ -29,11 +29,7 @@ import (
 )
 
 func TestSelfHostedKubeletLabels(t *testing.T) {
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	// List all the nodes and then delete a node that is not controller.
 	nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{

--- a/test/components/kubernetes/kubelet_test.go
+++ b/test/components/kubernetes/kubelet_test.go
@@ -31,12 +31,7 @@ const timeout = time.Minute * 5
 func TestSelfHostedKubeletPods(t *testing.T) {
 	t.Parallel()
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	namespace := "kube-system"
 	daemonset := "kubelet"

--- a/test/components/metallb/metallb_test.go
+++ b/test/components/metallb/metallb_test.go
@@ -27,11 +27,7 @@ import (
 func TestMetalLBDeployment(t *testing.T) {
 	namespace := "metallb-system"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	t.Run("speaker daemonset", func(t *testing.T) {
 		t.Parallel()

--- a/test/components/metrics-server/metrics_server_test.go
+++ b/test/components/metrics-server/metrics_server_test.go
@@ -27,11 +27,7 @@ import (
 func TestMetricsServerDeployment(t *testing.T) {
 	namespace := "kube-system"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	t.Run("deployment", func(t *testing.T) {
 		t.Parallel()

--- a/test/components/openebs-operator/openebs_operator_test.go
+++ b/test/components/openebs-operator/openebs_operator_test.go
@@ -27,11 +27,7 @@ import (
 func TestOpenEBSOperatorDeployment(t *testing.T) {
 	namespace := "openebs"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	deployments := []string{
 		"openebs-provisioner",

--- a/test/components/prometheus-operator/prometheus_operator_test.go
+++ b/test/components/prometheus-operator/prometheus_operator_test.go
@@ -33,11 +33,7 @@ const (
 func TestPrometheusOperatorDeployment(t *testing.T) {
 	namespace := "monitoring"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	deployments := []string{
 		"prometheus-operator-operator",

--- a/test/components/rook/rook_test.go
+++ b/test/components/rook/rook_test.go
@@ -27,11 +27,7 @@ import (
 func TestRookDeployment(t *testing.T) {
 	namespace := "rook"
 
-	client, err := testutil.CreateKubeClient(t)
-	if err != nil {
-		t.Errorf("could not create Kubernetes client: %v", err)
-	}
-	t.Log("got kubernetes client")
+	client := testutil.CreateKubeClient(t)
 
 	t.Run("deployment", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
As this is an anti-pattern when writing tests in Go. When helper
function takes testing.T as an argument and errors occurs, t.Fatalf or
t.Errorf should be used instead of returning error.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>