### PR TITLE
quickstarts,examples: expose cluster_region and clarify

### DIFF
--- a/docs/quickstarts/aws.md
+++ b/docs/quickstarts/aws.md
@@ -70,7 +70,7 @@ or
 ```console
 export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-export AWS_DEFAULT_REGION=us-east-1
+export AWS_DEFAULT_REGION=us-east-1    # This region will be used by the lokoctl S3 backend only
 ```
 
 ### Step 4: Define cluster configuration
@@ -96,6 +96,8 @@ defined in the configuration file.
 ```console
 #lokocfg.vars
 ssh_public_keys = ["public-ssh-key-1", "public-ssh-key-2", ...]
+
+cluster_region = "region-name"
 
 state_s3_bucket = "name-of-the-s3-bucket-to-store-the-cluster-state"
 lock_dynamodb_table = "name-of-the-dynamodb-table-for-state-locking"

--- a/examples/aws-production/cluster.lokocfg
+++ b/examples/aws-production/cluster.lokocfg
@@ -13,6 +13,10 @@ variable "cluster_name" {
   default = "lokomotive-cluster"
 }
 
+variable "cluster_region" {
+  default = "eu-central-1"
+}
+
 variable "controllers_count" {
   default = 3
 }
@@ -43,6 +47,7 @@ backend "s3" {
 cluster "aws" {
   asset_dir        = pathexpand(var.asset_dir)
   cluster_name     = var.cluster_name
+  region           = var.cluster_region
   controller_count = var.controllers_count
   dns_zone         = var.dns_zone
   dns_zone_id      = var.route53_zone_id

--- a/examples/aws-testing/cluster.lokocfg
+++ b/examples/aws-testing/cluster.lokocfg
@@ -11,6 +11,10 @@ variable "cluster_name" {
   default = "lokomotive-cluster"
 }
 
+variable "cluster_region" {
+  default = "eu-central-1"
+}
+
 variable "controllers_count" {
   default = 1
 }


### PR DESCRIPTION
The AWS quickstart shows how to configure the `AWS_DEFAULT_REGION`
environment variable without explaining that this only applies to the
lokoctl S3 backend.

Also, the current examples don't expose the cluster region so a user
might expect `AWS_DEFAULT_REGION` to change the region where the cluster
is deployed.

This clarifies what `AWS_DEFAULT_REGION` configures in the quickstart
and exposes a new `cluster_region` parameter in the example AWS
configurations.