### PR TITLE
docs/quickstarts: add reference to usage docs and PSP note

### DIFF
--- a/docs/concepts/securing-lokomotive-cluster.md
+++ b/docs/concepts/securing-lokomotive-cluster.md
@@ -33,6 +33,9 @@ default PSPs for general purpose application usage:
     Allowed to workloads in `kube-system` namespace only. This PSP does not restrict any workloads
     from any required permissions.
 
+Many projects provide their own Pod Security Policies tailored to their needs which can be used
+when deploying if the policies provided by Lokomotive are too strict.
+
 ## Global network policy (for Packet platform only)
 
 Lokomotive installs Calico’s

--- a/docs/quickstarts/aws.md
+++ b/docs/quickstarts/aws.md
@@ -163,6 +163,19 @@ export KUBECONFIG=./lokomotive-assets/cluster-assets/auth/kubeconfig
 kubectl get nodes
 ```
 
+## Using the cluster
+
+At this point you have access to the Kubernetes cluster and can use it!
+If you don't have Kubernetes experience you can check out the [Kubernetes
+Basics official
+documentation](https://kubernetes.io/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/)
+to learn about its usage.
+
+**Note**: Lokomotive sets up a pretty restrictive Pod Security Policy that
+disallows running containers as root by default, check the [Pod Security Policy
+documentation](../concepts/securing-lokomotive-cluster.md#cluster-wide-pod-security-policy)
+for more details.
+
 ## Cleanup
 
 To destroy the Lokomotive cluster, execute the following command:

--- a/docs/quickstarts/baremetal.md
+++ b/docs/quickstarts/baremetal.md
@@ -235,6 +235,19 @@ export KUBECONFIG=./lokomotive-assets/cluster-assets/auth/kubeconfig
 kubectl get nodes
 ```
 
+## Using the cluster
+
+At this point you have access to the Kubernetes cluster and can use it!
+If you don't have Kubernetes experience you can check out the [Kubernetes
+Basics official
+documentation](https://kubernetes.io/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/)
+to learn about its usage.
+
+**Note**: Lokomotive sets up a pretty restrictive Pod Security Policy that
+disallows running containers as root by default, check the [Pod Security Policy
+documentation](../concepts/securing-lokomotive-cluster.md#cluster-wide-pod-security-policy)
+for more details.
+
 ## Cleanup
 
 To destroy the Lokomotive cluster, execute the following command:

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -177,6 +177,19 @@ export KUBECONFIG=./lokomotive-assets/cluster-assets/auth/kubeconfig
 kubectl get nodes
 ```
 
+## Using the cluster
+
+At this point you have access to the Kubernetes cluster and can use it!
+If you don't have Kubernetes experience you can check out the [Kubernetes
+Basics official
+documentation](https://kubernetes.io/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/)
+to learn about its usage.
+
+**Note**: Lokomotive sets up a pretty restrictive Pod Security Policy that
+disallows running containers as root by default, check the [Pod Security Policy
+documentation](../concepts/securing-lokomotive-cluster.md#cluster-wide-pod-security-policy)
+for more details.
+
 ## Cleanup
 
 To destroy the Lokomotive cluster, execute the following command:


### PR DESCRIPTION
By default the cluster will refuse to run most images because they run
as root and that's disallowed by the PodSecurityPolicy. Mention this in
the quickstart pointing to the relevant documentation.

Also, link to the Kubernetes Basics documentation so inexperienced users
can learn about Kubernetes usage.

Reported-by: @jpetazzo