### PR TITLE
monitoring scrape test: Don't flush if nil object

### DIFF
--- a/test/monitoring/scrape_targets_test.go
+++ b/test/monitoring/scrape_targets_test.go
@@ -37,6 +37,10 @@ func testScrapeTargetRechability(t *testing.T, v1api v1.API) {
 	); err != nil {
 		t.Errorf("%v", err)
 
+		if w == nil {
+			return
+		}
+
 		// Finally print the table of all the targets that are down.
 		if err := w.Flush(); err != nil {
 			t.Errorf("error printing the unreachable targets: %v", err)


### PR DESCRIPTION
Add check to the tabwriter object before flushing. It is possible that
test fails and the object was never initialised, hence this can cause
unnecessary panic in the test run.