### PR TITLE
Show logs when terraform fails in `lokoctl cluster apply/destroy` 

### DIFF
--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -211,6 +211,8 @@ func (ex *Executor) execute(verbose bool, args ...string) error {
 		wg.Add(1)
 
 		go tailFile(p, done, &wg)
+	} else {
+		fmt.Printf("\nYou can find the logs in %q\n", p)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
When user is using lokoctl cluster apply/destroy in normal mode (not verbose) then show users what went wrong by showing last 20 lines of the logs.

And also let user know where the log file resides.

Fixes #225