### PR TITLE
Make Packet quickstart quick

### DIFF
--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -37,17 +37,34 @@ application to verify the cluster behaves as expected.
 
 ## Requirements
 
-* Basic understanding of Kubernetes concepts.
-* Packet account, Project ID and auth token (sometimes also referred to as [User Level API
-  key](https://www.packet.com/developers/docs/API/getting-started/)).
-* AWS account and IAM credentials (optional for Route53 DNS configuration).
-* AWS Route53 DNS Zone (registered Domain Name or delegated subdomain).
-* Terraform v0.12.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) v0.5.0
-  installed locally.
-* Local BGP enabled. More information on how to enable Local BGP for the Packet Project is found in
-  the [Packet support document](https://support.packet.com/kb/articles/bgp).
-* An SSH key pair for management access.
-* `kubectl` installed locally to access the Kubernetes cluster.
+* A Packet account with a project created and
+  [local BGP](https://www.packet.com/developers/docs/network/advanced/local-and-global-bgp/)
+  enabled.
+* A Packet project ID.
+* A Packet
+  [user level API key](https://www.packet.com/developers/docs/API/getting-started/)
+  with access to the relevant project.
+* An AWS account.
+* An AWS
+  [access key ID and secret](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
+  of a user with
+  [permissions](https://github.com/kinvolk/lokomotive/blob/master/docs/concepts/dns.md#aws-route-53)
+  to edit Route 53 records.
+* An AWS Route 53 zone (can be a subdomain).
+* An SSH key pair for accessing the cluster nodes.
+* Terraform `v0.12.x`
+  [installed](https://learn.hashicorp.com/terraform/getting-started/install.html#install-terraform).
+* The `ct` Terraform provider `v0.5.0`
+  [installed](https://github.com/poseidon/terraform-provider-ct/blob/v0.5.0/README.md#install).
+* `kubectl` [installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+
+>NOTE: The `kubectl` version used to interact with a Kubernetes cluster needs to be compatible with
+>the version of the Kubernetes control plane. Ideally you should install a `kubectl` binary whose
+>version is identical to the Kubernetes control plane included with a Lokomotive release. However,
+>some degree of version "skew" is tolerated - see the Kubernetes
+>[version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy/) document for
+>more information. You can determine the version of the Kubernetes control plane included with a
+>Lokomotive release by looking at the [release notes][releases].
 
 ## Steps
 
@@ -277,3 +294,4 @@ You can now start deploying your workloads on the cluster.
 
 For more information on installing supported Lokomotive components, you can visit the [component
 configuration references](../configuration-reference/components).
+[releases]: https://github.com/kinvolk/lokomotive/releases

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -309,8 +309,9 @@ the AWS API credentials has permissions to create records on Route 53.
 
 ## Next steps
 
-You can now start deploying your workloads on the cluster.
+In this guide you used port forwarding to communicate with a sample application on the cluster.
+However, in real-world cases you may want to expose your applications to the internet.
+[This](../how-to-guides/ingress-with-contour-metallb.md) guide explains how to use MetalLB and
+Contour to expose applications on Packet clusters to the internet.
 
-For more information on installing supported Lokomotive components, you can visit the [component
-configuration references](../configuration-reference/components).
 [releases]: https://github.com/kinvolk/lokomotive/releases

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -5,14 +5,11 @@
 * [Introduction](#introduction)
 * [Requirements](#requirements)
 * [Step 1: Install lokoctl](#step-1-install-lokoctl)
-* [Step 2: Set up a working directory](#step-2-set-up-a-working-directory)
-* [Step 3: Set up credentials from environment variables](#step-3-set-up-credentials-from-environment-variables)
-* [Step 4: Define cluster configuration](#step-4-define-cluster-configuration)
-* [Step 5: Create Lokomotive cluster](#step-5-create-lokomotive-cluster)
+* [Step 2: Create a cluster configuration](#step-2-create-a-cluster-configuration)
+* [Step 3: Deploy the cluster](#step-3-deploy-the-cluster)
 * [Verification](#verification)
 * [Cleanup](#cleanup)
 * [Troubleshooting](#troubleshooting)
-* [Conclusion](#conclusion)
 * [Next steps](#next-steps)
 
 ## Introduction

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -17,10 +17,23 @@
 
 ## Introduction
 
-This quickstart guide walks through the steps needed to create a Lokomotive cluster on Packet with
-Flatcar Container Linux using Route53 as the DNS provider.
+This guide shows how to create a Lokomotive cluster on [Packet](https://www.packet.com/). By the
+end of this guide, you'll have a basic Lokomotive cluster running on Packet with a demo application
+deployed.
 
-By the end of this guide, you'll have a production-ready Kubernetes cluster running on Packet.
+The guide uses `t1.small.x86` as the Packet device type for all created nodes. This is also the
+default device type.
+
+Lokomotive runs on top of [Flatcar Container Linux](https://www.flatcar-linux.org/). This guide
+uses the `stable` channel.
+
+The guide uses [Amazon Route 53](https://aws.amazon.com/route53/) as a DNS provider. For more
+information on how Lokomotive handles DNS, refer to [this](../concepts/dns.md) document.
+
+[Lokomotive components](../concepts/components.md) complement the "stock" Kubernetes functionality
+by adding features such as load balancing, persistent storage and monitoring to a cluster. To keep
+this guide short you will deploy a single component - `httpbin` - which serves as a demo
+application to verify the cluster behaves as expected.
 
 ## Requirements
 


### PR DESCRIPTION
This PR improves the quickstart guide for Packet. Main improvements:

- Include all necessary information in the text.
- Remove unnecessary information.
- Use a simple config instead of a production-ready one.
- Fix tone and phrasing.
- Remove instructions for things which should be satisfied by requirements.

Addresses part of https://github.com/kinvolk/lokomotive/issues/273.