### PR TITLE
Makefile: Supress stdout when building tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-in-docker:
 
 .PHONY: build-test
 build-test:
-	go test -run=nonexistent -mod=$(MOD) -tags=$(ALL_BUILD_TAGS) -covermode=atomic -buildmode=exe -v ./...
+	go test -run=nonexistent -mod=$(MOD) -tags=$(ALL_BUILD_TAGS) -covermode=atomic -buildmode=exe -v ./... > /dev/null
 
 .PHONY: all
 all: build build-test test lint


### PR DESCRIPTION
Currently, when running "make build-test" it shows 157 of non useful
information, like:
```
	testing: warning: no tests to run
	PASS
	coverage: [no statements]
	ok  	github.com/kinvolk/lokomotive/test/components/prometheus-operator	(cached)	coverage: [no statements] [no tests to run]
	testing: warning: no tests to run
	PASS
	coverage: [no statements]
	ok  	github.com/kinvolk/lokomotive/test/components/rook	(cached)	coverage: [no statements] [no tests to run]
	?   	github.com/kinvolk/lokomotive/test/components/util	[no test files]
	testing: warning: no tests to run
```

If there is a compilation error, it is printed to stderr. Therefore,
just supressing stdout is fine. Removing the "-v" option doesn't help
either, as still tons of lines are printed and it says that no test were
run.

Also, some other make targets depend on this, like "make lint", which
makes the output of "make lint" quite unreadable with such a huge
output.

This patch just redirects the stdout to /dev/null.