### PR TITLE
Makefile: lint: Fallback to "origin/master"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test: run-unit-tests
 lint: build-slim build-test
 	# Note: Make sure that you run `git config diff.noprefix false` in this repo
 	# See this issue for more details: https://github.com/golangci/golangci-lint/issues/948
-	golangci-lint run --enable-all --disable=godox,gochecknoglobals --max-same-issues=0 --max-issues-per-linter=0 --build-tags $(ALL_BUILD_TAGS) --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
+	golangci-lint run --enable-all --disable=godox,gochecknoglobals --max-same-issues=0 --max-issues-per-linter=0 --build-tags $(ALL_BUILD_TAGS) --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "origin/master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
 
 .PHONY: lint-docker
 lint-docker:


### PR DESCRIPTION
The ".git/resource/base_sha" file exists in the concourse CI only. When
running it locally, the code fallbacks to "master". However, there is no
guarantee that the master branch in a local coputer is up to date.

This patch just changes the fallback to be "origin/master", as that has
more chances of being up to date. For example, I usually work in
branches and rarely update my master branch.

Using "origin/master" will also continue to work on users that update
the local master branch, as when they do so, they update the
"origin/master" reference too, usually.

The downside is that it assumes that the remote is named "origin". This
is a reasonable requirement for local development, however, as many
other project have them. If you want to name it differently, you can run
the linter manually too.