### PR TITLE
packet: Remove optimization to create workers

### DIFF
--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -219,12 +219,7 @@ func (c *config) terraformSmartApply(ex *terraform.Executor, dnsProvider dns.DNS
 	// Get DNS entries (it forces the creation of the controller nodes).
 	arguments = append(arguments, fmt.Sprintf("-target=module.packet-%s.null_resource.dns_entries", c.ClusterName))
 
-	// Add worker nodes to speed things up.
-	for _, w := range c.WorkerPools {
-		arguments = append(arguments, fmt.Sprintf("-target=module.worker-%v.packet_device.nodes", w.Name))
-	}
-
-	// Create controller and workers nodes.
+	// Create controller
 	if err := ex.Execute(arguments...); err != nil {
 		return errors.Wrap(err, "failed executing Terraform")
 	}


### PR DESCRIPTION
Creating workers at the same time than the controllers only saves time
if the cluster is small. If you have more than 3 workers, this won't
save much time. Also, it will increase a lot the time the user will wait
to answer the next prompt.

This patch just creates the controllers and asks the user ASAP for the
next input. This way, the user needs to wait for manual steps as little
as possible.

This may increase the total time it takes to create the cluster, but
reduces the time the user needs to different stages and do manual
actions.