### PR TITLE
Packet: Add clc snippets,tags to worker_pool and clc snippets to controller

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -16,6 +16,21 @@ cluster "aws" {
   os_channel       = var.os_channel
   ssh_pubkeys      = ["$PUB_KEY"]
 
+  controller_clc_snippets = [
+    <<EOF
+storage:
+  files:
+    - path: /opt/clc_snippet_hello
+      filesystem: root
+      contents:
+        inline: Hello, world!
+      mode: 0644
+      user:
+        id: 500
+      group:
+        id: 500
+EOF
+  ]
   worker_pool "wp" {
     count         = 2
     ssh_pubkeys   = ["$PUB_KEY"]
@@ -25,6 +40,21 @@ cluster "aws" {
     tags = {
       "deployment" = "ci"
     }
+    clc_snippets = [
+      <<EOF
+storage:
+  files:
+    - path: /opt/clc_snippet_hello
+      filesystem: root
+      contents:
+        inline: Hello, world!
+      mode: 0644
+      user:
+        id: 500
+      group:
+        id: 500
+EOF
+    ]
   }
 
   # Adds oidc flags to API server with default values.

--- a/ci/packet-arm/packet-arm-cluster.lokocfg.envsubst
+++ b/ci/packet-arm/packet-arm-cluster.lokocfg.envsubst
@@ -3,6 +3,21 @@ cluster "packet" {
   cluster_name     = "$CLUSTER_ID"
   controller_count = 1
 
+  controller_clc_snippets = [
+    <<EOF
+storage:
+  files:
+    - path: /opt/clc_snippet_hello
+      filesystem: root
+      contents:
+        inline: Hello, world!
+      mode: 0644
+      user:
+        id: 500
+      group:
+        id: 500
+EOF
+  ]
   dns {
     provider = "route53"
     zone     = "$AWS_DNS_ZONE"
@@ -27,6 +42,21 @@ cluster "packet" {
     os_arch         = "arm64"
     os_channel      = "alpha"
     node_type       = "c2.large.arm"
+    clc_snippets = [
+      <<EOF
+storage:
+  files:
+    - path: /opt/clc_snippet_hello
+      filesystem: root
+      contents:
+        inline: Hello, world!
+      mode: 0644
+      user:
+        id: 500
+      group:
+        id: 500
+EOF
+    ]
   }
 
   # Adds oidc flags to API server with default values.

--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -3,6 +3,21 @@ cluster "packet" {
   cluster_name     = "$CLUSTER_ID"
   controller_count = 1
 
+  controller_clc_snippets = [
+    <<EOF
+storage:
+  files:
+    - path: /opt/clc_snippet_hello
+      filesystem: root
+      contents:
+        inline: Hello, world!
+      mode: 0644
+      user:
+        id: 500
+      group:
+        id: 500
+EOF
+  ]
   dns {
     provider = "route53"
     zone     = "$AWS_DNS_ZONE"
@@ -20,6 +35,21 @@ cluster "packet" {
     count     = 2
     node_type = "c2.medium.x86"
     labels    = "testing.io=yes,roleofnode=testing"
+    clc_snippets = [
+      <<EOF
+storage:
+  files:
+    - path: /opt/clc_snippet_hello
+      filesystem: root
+      contents:
+        inline: Hello, world!
+      mode: 0644
+      user:
+        id: 500
+      group:
+        id: 500
+EOF
+    ]
   }
 
   # Adds oidc flags to API server with default values.

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -49,6 +49,7 @@ variable "oidc_issuer_url" {}
 variable "oidc_client_id" {}
 variable "oidc_username_claim" {}
 variable "oidc_groups_claim" {}
+variable "worker_clc_snippets" {}
 
 backend "s3" {
   bucket         = var.state_s3_bucket
@@ -131,6 +132,12 @@ cluster "packet" {
 
   worker_pool "worker-pool-1" {
     count = var.workers_count
+
+    clc_snippets = var.worker_clc_snippets
+
+    tags = {
+      pool = "storage"
+    }
 
     ipxe_script_url = ""
 
@@ -221,6 +228,8 @@ node_type = var.custom_default_worker_type
 | `certs_validity_period_hours`         | Validity of all the certificates in hours.                                                                                                                                    | 8760            | false    |
 | `worker_pool`                         | Configuration block for worker pools. There can be more than one.                                                                                                             | -               | true     |
 | `worker_pool.count`                   | Number of workers in the worker pool. Can be changed afterwards to add or delete workers.                                                                                     | 1               | true     |
+| `worker_pool.clc_snippets`            | Flatcar Container Linux Config snippets for nodes in the worker pool.                                                                                                         | []              | false    |
+| `worker_pool.tags`                    | List of tags that will be propagated to nodes in the worker pool.                                                                                                             | -               | false    |
 | `worker_pool.disable_bgp`             | Disable BGP on nodes. Nodes won't be able to connect to Packet BGP peers.                                                                                                     | false           | false    |
 | `worker_pool.ipxe_script_url`         | Boot via iPXE. Required for arm64.                                                                                                                                            | -               | false    |
 | `worker_pool.os_arch`                 | Flatcar Container Linux architecture to install (amd64, arm64).                                                                                                               | "amd64"         | false    |

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -35,6 +35,7 @@ variable "cluster_name" {}
 variable "controllers_count" {}
 variable "workers_count" {}
 variable "controller_type" {}
+variable "controller_clc_snippets" {}
 variable "workers_type" {}
 variable "dns_zone" {}
 variable "route53_zone_id" {}
@@ -70,6 +71,8 @@ cluster "packet" {
   controller_count = var.controllers_count
 
   controller_type = "t1.small.x86"
+
+  controller_clc_snippets = var.controller_clc.snippets
 
   facility = var.facility
 
@@ -189,6 +192,7 @@ node_type = var.custom_default_worker_type
 | `tags`                                | List of tags that will be propagated to master nodes.                                                                                                                         | -               | false    |
 | `controller_count`                    | Number of controller nodes.                                                                                                                                                   | 1               | false    |
 | `controller_type`                     | Packet instance type for controllers.                                                                                                                                         | "t1.small.x86"  | false    |
+| `controller_clc_snippets`             | Controller Flatcar Container Linux Config snippets.                                                                                                                           | []              | false    |
 | `dns`                                 | DNS configuration block.                                                                                                                                                      | -               | true     |
 | `dns.zone`                            | A DNS zone to use for the cluster. The following format is used for cluster-related DNS records: `<record>.<cluster_name>.<dns_zone>`                                         | -               | true     |
 | `dns.provider`                        | DNS provider to use for the cluster. Valid values: `cloudflare`, `route53`, `manual`.                                                                                         | -               | true     |

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -70,6 +70,7 @@ type config struct {
 	Tags                     map[string]string `hcl:"tags,optional"`
 	ControllerCount          int               `hcl:"controller_count"`
 	ControllerType           string            `hcl:"controller_type,optional"`
+	ControllerCLCSnippets    []string          `hcl:"controller_clc_snippets,optional"`
 	DNS                      dns.Config        `hcl:"dns,block"`
 	Facility                 string            `hcl:"facility"`
 	ProjectID                string            `hcl:"project_id"`

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -60,6 +60,8 @@ type workerPool struct {
 	SetupRaidHDD          bool              `hcl:"setup_raid_hdd,optional"`
 	SetupRaidSSD          bool              `hcl:"setup_raid_ssd,optional"`
 	SetupRaidSSDFS        bool              `hcl:"setup_raid_ssd_fs,optional"`
+	CLCSnippets           []string          `hcl:"clc_snippets,optional"`
+	Tags                  map[string]string `hcl:"tags,optional"`
 	NodesDependOn         []string          // Not exposed to the user
 }
 
@@ -226,7 +228,13 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal tags")
 	}
-
+	// Append lokoctl-version tag to all worker pools.
+	for i := range cfg.WorkerPools {
+		// Using index as we are using []workerPool which creates a copy of the slice
+		// Hence when the template is rendered worker pool Tags is empty.
+		// TODO: Add tests for validating the worker pool configuration.
+		util.AppendTags(&cfg.WorkerPools[i].Tags)
+	}
 	// Add explicit terraform dependencies for nodes with specific hw
 	// reservation UUIDs.
 	cfg.terraformAddDeps()

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -135,8 +135,27 @@ module "worker-{{ $pool.Name }}" {
 
   ssh_keys  = {{$.SSHPublicKeys}}
 
+  {{- if $pool.CLCSnippets}}
+  clc_snippets = [
+	{{- range $clc_snippet := $pool.CLCSnippets}}
+    <<EOF
+{{ $clc_snippet }}
+EOF
+    ,
+  {{- end}}
+  ]
+  {{- end }}
+
   cluster_name = "{{$.Config.ClusterName}}"
-  tags         = {{$.Tags}}
+
+  {{- if $pool.Tags }}
+  tags = [
+      {{- range $key, $value := $pool.Tags }}
+      "{{ $key }}:{{ $value }}",
+      {{- end }}
+	]
+  {{- end }}
+
   project_id   = "{{$.Config.ProjectID}}"
   facility     = "{{$.Config.Facility}}"
   {{- if $.Config.ClusterDomainSuffix }}

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -84,6 +84,16 @@ module "packet-{{.Config.ClusterName}}" {
   }
   {{- end }}
 
+  {{- if .Config.ControllerCLCSnippets}}
+  controller_clc_snippets = [
+	{{- range $clc_snippet := .Config.ControllerCLCSnippets}}
+    <<EOF
+{{ $clc_snippet }}
+EOF
+    ,
+  {{- end }}
+  ]
+  {{- end }}
   {{- if .Config.ReservationIDsDefault }}
   reservation_ids_default = "{{.Config.ReservationIDsDefault}}"
   {{- end }}

--- a/test/system/clc_snippets_test.go
+++ b/test/system/clc_snippets_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build aws aws_edge packet
+// +build e2e
+
+package system // nolint:testpackage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	testutil "github.com/kinvolk/lokomotive/test/components/util"
+)
+
+const (
+	fileName = "clc_snippet_hello"
+)
+
+// Define manifest as YAML and then unmarshal it to a Go struct so that it is easier to
+// write and debug, as it can be copy-pasted to a file and applied manually.
+const clcSnippetsAddedToNodesDSManifest = `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generateName: test-clc-snippets-
+spec:
+  selector:
+    matchLabels:
+      name: test-clc-snippets
+  template:
+    metadata:
+      labels:
+        name: test-clc-snippets
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: test-clc-snippets
+        image: ubuntu
+        command: ["bash"]
+        volumeMounts:
+        - name: opt
+          mountPath: /opt
+          readOnly: true
+      volumes:
+      - name: opt
+        hostPath:
+          path: /opt
+`
+
+func TestFileCreatedByCLCSnippetExistsOnNodes(t *testing.T) {
+	t.Parallel()
+
+	namespace := "kube-system"
+
+	client := testutil.CreateKubeClient(t)
+
+	ds := &appsv1.DaemonSet{}
+	if err := yaml.Unmarshal([]byte(clcSnippetsAddedToNodesDSManifest), ds); err != nil {
+		t.Fatalf("failed unmarshaling manifest: %v", err)
+	}
+
+	// Set the right arguments from the manifest with the correct fileName
+	ds.Spec.Template.Spec.Containers[0].Args = []string{
+		"-c",
+		fmt.Sprintf("test -e /opt/%s && exec tail -f /dev/null", fileName),
+	}
+
+	ds, err := client.AppsV1().DaemonSets(namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create DaemonSet: %v", err)
+	}
+
+	testutil.WaitForDaemonSet(t, client, namespace, ds.ObjectMeta.Name, time.Second*5, time.Minute*5)
+
+	t.Cleanup(func() {
+		if err := client.AppsV1().DaemonSets(namespace).Delete(
+			context.TODO(), ds.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("failed to remove DaemonSet: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
- Adds Tags field for WorkerPool
- Adds ControllerCLCSnippets for Controller
- Adds CLCSnippets for WorkerPool

The above mentioned fields are part of lokomotive-kubernetes  under
assets/lokomotive-kubernetes but they are not exposed to the user on
Lokomotive.

Signed-off-by: Imran Pochi <imran@kinvolk.io>