### PR TITLE
ci/aws: test HA control plane on the CI

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -8,12 +8,13 @@ variable "os_channel" {
 }
 
 cluster "aws" {
-  asset_dir    = pathexpand(var.asset_dir)
-  cluster_name = "$CLUSTER_ID"
-  dns_zone     = "$AWS_DNS_ZONE"
-  dns_zone_id  = "$AWS_DNS_ZONE_ID"
-  os_channel   = var.os_channel
-  ssh_pubkeys  = ["$PUB_KEY"]
+  asset_dir        = pathexpand(var.asset_dir)
+  cluster_name     = "$CLUSTER_ID"
+  controller_count = 2
+  dns_zone         = "$AWS_DNS_ZONE"
+  dns_zone_id      = "$AWS_DNS_ZONE_ID"
+  os_channel       = var.os_channel
+  ssh_pubkeys      = ["$PUB_KEY"]
 
   worker_pool "$CLUSTER_ID-wp" {
     count         = 2


### PR DESCRIPTION
Since this is the production recommended setup let's test it on every
PR.

We have some coverage for the non-HA control plane because we test it in
the Flatcar Edge pipeline.