### PR TITLE
Fix rendering of `ingress_hosts` in Contour component

### DIFF
--- a/pkg/components/contour/component_test.go
+++ b/pkg/components/contour/component_test.go
@@ -52,6 +52,15 @@ component "contour" {
 	testRenderManifest(t, configHCL)
 }
 
+func TestRenderManifestWithIngressHostsWildcard(t *testing.T) {
+	configHCL := `
+component "contour" {
+  ingress_hosts = ["*.domain.com"]
+}
+`
+	testRenderManifest(t, configHCL)
+}
+
 func TestRenderManifestWithServiceMonitor(t *testing.T) {
 	configHCL := `
 component "contour" {

--- a/pkg/components/contour/manifest.go
+++ b/pkg/components/contour/manifest.go
@@ -22,7 +22,10 @@ monitoring:
 {{- end }}
 
 {{- if .IngressHosts }}
-ingressHosts: {{ .IngressHosts }}
+ingressHosts:
+  {{- range .IngressHosts}}
+  - "{{ . }}"
+  {{- end }}
 {{- end }}
 
 {{- if .NodeAffinity }}


### PR DESCRIPTION
Fixes #416 
Rendering of `ingress_hosts` field in values template results in a space delimited list of strings.
```
ingress_hosts: [ test.local cluster.local]
```
This causes error in rendering of helm chart [envoy service template], and also results in an error when wildcard pattern is used in `ingress_hosts`.