### PR TITLE
Makefile: update golangci-lint to 1.27.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ lint: build-slim build-test
 
 .PHONY: lint-docker
 lint-docker:
-	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.23.8 make lint
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.27.0 make lint
 
 GOFORMAT_FILES := $(shell find . -name '*.go' | grep -v '^./vendor')
 


### PR DESCRIPTION
It is latest version available now.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>