### PR TITLE
Makefile: Disable goerr113 linter check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test: run-unit-tests
 lint: build-slim build-test
 	# Note: Make sure that you run `git config diff.noprefix false` in this repo
 	# See this issue for more details: https://github.com/golangci/golangci-lint/issues/948
-	golangci-lint run --enable-all --disable=godox,gochecknoglobals --max-same-issues=0 --max-issues-per-linter=0 --build-tags $(ALL_BUILD_TAGS) --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "origin/master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
+	golangci-lint run --enable-all --disable=godox,gochecknoglobals,goerr113 --max-same-issues=0 --max-issues-per-linter=0 --build-tags $(ALL_BUILD_TAGS) --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "origin/master") HEAD) --modules-download-mode=$(MOD) --timeout=5m --exclude-use-default=false ./...
 
 .PHONY: lint-docker
 lint-docker:


### PR DESCRIPTION
We aren't aligned on a single approach regarding adding info to
Go errors. Since we seem to be using `fmt.Errorf` more than other
approaches (e.g. wrapping), we should disable this check for now.