### PR TITLE
prometheus operator grafana: Generate password random, always

### DIFF
--- a/pkg/components/prometheus-operator/component.go
+++ b/pkg/components/prometheus-operator/component.go
@@ -122,6 +122,14 @@ func newComponent() *component {
 				"tier":    "control-plane",
 			},
 		},
+		Grafana: &Grafana{
+			// This is done in order to make sure that Grafana admin user password is generated if
+			// user does not provide one.
+			// If this block is not provided here and user also does not specify any grafana related
+			// config then admin password is set to "prom-operator".
+			// See: https://github.com/kinvolk/lokomotive/pull/507#issuecomment-636049574
+			AdminPassword: "",
+		},
 	}
 }
 

--- a/pkg/components/prometheus-operator/template.go
+++ b/pkg/components/prometheus-operator/template.go
@@ -56,7 +56,6 @@ grafana:
       searchNamespace: ALL
   rbac:
     pspUseAppArmor: false
-  {{ if .Grafana}}
   adminPassword: {{.Grafana.AdminPassword}}
   {{ if .Grafana.Ingress }}
   ingress:
@@ -74,7 +73,6 @@ grafana:
   grafana.ini:
     server:
       root_url: https://{{ .Grafana.Ingress.Host }}
-  {{ end }}
   {{ end }}
 
 kubeEtcd:

--- a/test/monitoring/grafana_password_test.go
+++ b/test/monitoring/grafana_password_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build aws aws_edge packet aks
+// +build poste2e
+
+package monitoring // nolint:testpackage
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testutil "github.com/kinvolk/lokomotive/test/components/util"
+)
+
+// testGrafanaDefaultPassword tests if the Grafana deployment does not expose Grafana with default
+// password of `prom-operator`.
+func testGrafanaDefaultPassword(t *testing.T, v1api v1.API) {
+	client := testutil.CreateKubeClient(t)
+
+	const (
+		namespace              = "monitoring"
+		secretName             = "prometheus-operator-grafana"
+		defaultGrafanaPassword = "prom-operator"
+	)
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			t.Fatalf("secret not found")
+		}
+
+		t.Fatalf("could not get secret: %v", err)
+	}
+
+	data, ok := secret.Data["admin-password"]
+	if !ok {
+		t.Fatalf("password not found in the secret")
+	}
+
+	if string(data) == defaultGrafanaPassword {
+		t.Fatalf("default password %q provided", defaultGrafanaPassword)
+	}
+}

--- a/test/monitoring/monitoring_test.go
+++ b/test/monitoring/monitoring_test.go
@@ -66,6 +66,10 @@ func TestPrometheus(t *testing.T) {
 			Name: "ScrapeTargetReachability",
 			Func: testScrapeTargetRechability,
 		},
+		{
+			Name: "TestGrafanaDefaultPassword",
+			Func: testGrafanaDefaultPassword,
+		},
 	}
 
 	// Invoke the test functions passing them the test object and the prometheus client.


### PR DESCRIPTION
Fixes issue where grafana dashboard password is not random when user
does not provide the grafana block.

Fixes https://github.com/kinvolk/lokomotive/issues/506

---

TODOs:

- [x] Add test