### PR TITLE
dex: Update to v2.24.0

### DIFF
--- a/pkg/components/dex/component.go
+++ b/pkg/components/dex/component.go
@@ -114,7 +114,7 @@ spec:
       serviceAccountName: dex
       initContainers:
       - name: download-theme
-        image: alpine/git:v2.24.2
+        image: alpine/git:v2.24.3
         command:
         - git
         - clone
@@ -124,7 +124,7 @@ spec:
         - name: theme
           mountPath: /theme/
       containers:
-      - image: quay.io/dexidp/dex:v2.23.0
+      - image: quay.io/dexidp/dex:v2.24.0
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         ports:


### PR DESCRIPTION
- Dex release: https://github.com/dexidp/dex/releases/tag/v2.24.0.
- Update the image(alpine/git) version of initContainer that downloads
theme to v2.24.3.