### PR TITLE
grafana: Add secret_env variable

### DIFF
--- a/ci/aks/aks-cluster.lokocfg.envsubst
+++ b/ci/aks/aks-cluster.lokocfg.envsubst
@@ -82,6 +82,12 @@ component "prometheus-operator" {
       "k8s-app" = "kube-dns",
     }
   }
+
+  grafana {
+    secret_env = {
+      "LOKOMOTIVE_VERY_SECRET_PASSWORD" = "VERY_VERY_SECRET"
+    }
+  }
 }
 
 component "contour" {

--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -79,7 +79,13 @@ component "openebs-storage-class" {
   }
 }
 
-component "prometheus-operator" {}
+component "prometheus-operator" {
+  grafana {
+    secret_env = {
+      "LOKOMOTIVE_VERY_SECRET_PASSWORD" = "VERY_VERY_SECRET"
+    }
+  }
+}
 
 component "contour" {
   ingress_hosts     = ["dex.$CLUSTER_ID.$AWS_DNS_ZONE", "gangway.$CLUSTER_ID.$AWS_DNS_ZONE"]

--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -72,7 +72,13 @@ component "openebs-storage-class" {
   }
 }
 
-component "prometheus-operator" {}
+component "prometheus-operator" {
+  grafana {
+    secret_env = {
+      "LOKOMOTIVE_VERY_SECRET_PASSWORD" = "VERY_VERY_SECRET"
+    }
+  }
+}
 
 component "contour" {
   ingress_hosts     = ["dex.$CLUSTER_ID.$AWS_DNS_ZONE", "gangway.$CLUSTER_ID.$AWS_DNS_ZONE"]

--- a/docs/configuration-reference/components/prometheus-operator.md
+++ b/docs/configuration-reference/components/prometheus-operator.md
@@ -33,6 +33,9 @@ component "prometheus-operator" {
 
   grafana {
     admin_password = "foobar"
+    secret_env = { # This might contain sensitive information, declare a variable and define this in `lokocfg.vars`.
+      "KEY" = "VERY_SECRET"
+    }
     ingress {
       host                       = "grafana.mydomain.net"
       class                      = "contour"
@@ -116,6 +119,7 @@ Example:
 |--------	|--------------|:-------:|:--------:|
 | `namespace` | Namespace to deploy the Prometheus Operator. | `monitoring` | false |
 | `grafana.admin_password` | Password for `admin` user in Grafana. If not provided it is auto generated and stored in secret `prometheus-operator-grafana`.  | - | false |
+| `grafana.secret_env` | Sensitive environment variables passed to Grafana pod and stored as secret. Read more on manipulating `grafana.ini` using env var [here](https://grafana.com/docs/grafana/latest/installation/configuration/#configure-with-environment-variables). | - | false |
 | `grafana.ingress.host` | Ingress URL host to expose Grafana over the internet. **NOTE:** When running on Packet, a DNS entry pointing at the ingress controller needs to be created.  | - | true |
 | `grafana.ingress.class` | Ingress class to use for Grafana ingress. | `contour` | false |
 | `grafana.ingress.certmanager_cluster_issuer` | `ClusterIssuer` to be used by cert-manager while issuing TLS certificates. Supported values: `letsencrypt-production`, `letsencrypt-staging`.  | `letsencrypt-production` | false |

--- a/pkg/components/prometheus-operator/component.go
+++ b/pkg/components/prometheus-operator/component.go
@@ -49,8 +49,9 @@ type CoreDNS struct {
 
 // Grafana object collects sub component grafana related information.
 type Grafana struct {
-	AdminPassword string         `hcl:"admin_password,optional"`
-	Ingress       *types.Ingress `hcl:"ingress,block"`
+	AdminPassword string            `hcl:"admin_password,optional"`
+	SecretEnv     map[string]string `hcl:"secret_env,optional"`
+	Ingress       *types.Ingress    `hcl:"ingress,block"`
 }
 
 type component struct {

--- a/pkg/components/prometheus-operator/template.go
+++ b/pkg/components/prometheus-operator/template.go
@@ -57,6 +57,12 @@ grafana:
   rbac:
     pspUseAppArmor: false
   adminPassword: {{.Grafana.AdminPassword}}
+  {{- if .Grafana.SecretEnv }}
+  envRenderSecret:
+    {{ range $key, $value := .Grafana.SecretEnv }}
+    {{ $key }}: {{ $value }}
+    {{ end }}
+  {{- end }}
   {{ if .Grafana.Ingress }}
   ingress:
     enabled: true


### PR DESCRIPTION
This variable allows users to provide arbitrary key values pairs that
will be exposed as environment variables inside the Grafana pod.

Using this functionality user can manipulate `grafana.ini` file. All the
values under `grafana.ini` can be replaced with environment variables in
following format:
`GF_<SectionName>_<KeyName>`.

Where the section name is the text within the brackets(for e.g.
`[auth.google]`). Everything should be upper case, `.` should be
replaced by `_`.
    
Fixes https://github.com/kinvolk/lokomotive/issues/538