### PR TITLE
Grafana: Provide root_url in grafana.ini conf

### DIFF
--- a/pkg/components/prometheus-operator/template.go
+++ b/pkg/components/prometheus-operator/template.go
@@ -71,6 +71,9 @@ grafana:
     - hosts:
       - {{ .Grafana.Ingress.Host }}
       secretName: {{ .Grafana.Ingress.Host }}-tls
+  grafana.ini:
+    server:
+      root_url: https://{{ .Grafana.Ingress.Host }}
   {{ end }}
   {{ end }}
 


### PR DESCRIPTION
This enables the application grafana to know where it is being exposed
over the internet. This makes sure that the invite URLs are not over
default `localhost` but over the user provided external URL.

Fixes #546 