### PR TITLE
docs: document Route 53 and S3+DynamoDB permissions

### DIFF
--- a/docs/concepts/dns.md
+++ b/docs/concepts/dns.md
@@ -6,13 +6,56 @@ DNS records on your behalf.
 
 ## Supported providers
 
-- [AWS Route 53](https://aws.amazon.com/route53/) - supported with AWS and Packet clusters
-- [Cloudflare](https://www.cloudflare.com/dns/) - supported with Packet clusters
-- Manual - supported with Packet clusters
+### [AWS Route 53](https://aws.amazon.com/route53/)
 
->NOTE: The *manual* DNS provider is a special provider. When using this option, no DNS records are
->provisioned automatically. Instead, the user is prompted to configure the necessary DNS records on
->their own.
+The AWS Route 53 DNS provider is supported with AWS and Packet clusters.
+
+#### IAM permissions
+
+The AWS Route 53 DNS provider requires the following IAM permissions:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetChange",
+                "route53:GetHostedZone",
+                "route53:ChangeResourceRecordSets",
+                "route53:ListResourceRecordSets",
+                "route53:ListTagsForResource"
+            ],
+            "Resource": [
+                "arn:aws:route53:::change/*",
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": "route53:ListHostedZones",
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+### [Cloudflare](https://www.cloudflare.com/dns/)
+
+The Cloudflare DNS provider is supported with Packet clusters.
+
+### Manual
+
+The Manual DNS provider is supported with Packet clusters.
+
+This is a special provider. When used, no DNS records are provisioned
+automatically. Instead, the user is prompted to configure the necessary DNS
+records on their own.
+
+## Records
 
 The records on which Lokomotive relies are mostly DNS **A records**. They are constructed based on
 the DNS zone provided by the user and the configured cluster name in the following format:

--- a/docs/configuration-reference/backend/s3.md
+++ b/docs/configuration-reference/backend/s3.md
@@ -21,10 +21,7 @@ used.
 
 * AWS S3 bucket to be used should already be created.
 * DynamoDB table to be used for state locking should already be created. The table must have a primary key named LockID.
-* Correct IAM permissions for the S3 bucket and DynamoDB Table. At minimum the following are the
-  permissions required:
-  * [S3 bucket permissions](https://www.terraform.io/docs/backends/types/s3.html#s3-bucket-permissions).
-  * [DynamoDB table permissions](https://www.terraform.io/docs/backends/types/s3.html#dynamodb-table-permissions).
+* The necessary [IAM permissions](#iam-permissions) for S3 and DynamoDB.
 
 ## Configuration
 
@@ -58,3 +55,43 @@ environment variables or in the config above.
 
 >NOTE: If no value is passed for `dynamodb_table`, installer will not use the state locking feature.
 
+## IAM permissions
+
+The following permissions are required for using the AWS S3 backend:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::<BUCKET_NAME>"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::<BUCKET_NAME>/<KEY>"
+    }
+  ]
+}
+```
+
+When using state locking, that is, when the `backend.s3.dynamodb_table` option is specified, the following permissions are required as well:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/<TABLE_NAME>"
+    }
+  ]
+}
+```


### PR DESCRIPTION
For the Route 53 DNS provider and the S3 configuration backend.

I didn't touch the quickstarts yet since they're being reworked.

Fixes https://github.com/kinvolk/lokomotive/issues/373