### PR TITLE
test/calico/metadata_access_test.go: add support for aws_edge platform

### DIFF
--- a/test/calico/metadata_access_test.go
+++ b/test/calico/metadata_access_test.go
@@ -90,7 +90,7 @@ func TestNoMetadataAccessRandomPod(t *testing.T) { //nolint:funlen
 	switch platform {
 	case testutil.PlatformPacket, testutil.PlatformPacketARM:
 		metadataAddress = "https://metadata.packet.net/metadata"
-	case testutil.PlatformAWS:
+	case testutil.PlatformAWS, testutil.PlatformAWSEdge:
 		metadataAddress = "http://169.254.169.254/latest/meta-data"
 	}
 

--- a/test/components/util/util.go
+++ b/test/components/util/util.go
@@ -329,6 +329,9 @@ const (
 	// PlatformAWS is for AWS
 	PlatformAWS = "aws"
 
+	// PlatformAWSEdge is for AWS with FCL Edge.
+	PlatformAWSEdge = "aws_edge"
+
 	// PlatformPacket is for Packet
 	PlatformPacket = "packet"
 


### PR DESCRIPTION
Currently master pipeline fails because of this.