### PR TITLE
examples: make Flatcar channels explicit

### DIFF
--- a/docs/configuration-reference/platforms/aws.md
+++ b/docs/configuration-reference/platforms/aws.md
@@ -101,7 +101,7 @@ cluster "aws" {
 
   region = var.region
 
-  enable_aggreation = true
+  enable_aggregation = true
 
   disk_size = var.disk_size
 

--- a/examples/aws-production/cluster.lokocfg
+++ b/examples/aws-production/cluster.lokocfg
@@ -51,6 +51,9 @@ cluster "aws" {
   dns_zone_id      = var.route53_zone_id
   ssh_pubkeys      = var.ssh_public_keys
 
+  //os_channel       = "stable"
+  //os_version       = "current"
+
   oidc {
     issuer_url     = var.oidc_issuer_url
     client_id      = var.oidc_client_id
@@ -62,6 +65,9 @@ cluster "aws" {
     count         = var.workers_count
     instance_type = var.workers_type
     ssh_pubkeys   = var.ssh_public_keys
+
+    //os_channel    = "stable"
+    //os_version    = "current"
   }
 }
 

--- a/examples/aws-testing/cluster.lokocfg
+++ b/examples/aws-testing/cluster.lokocfg
@@ -30,10 +30,16 @@ cluster "aws" {
   dns_zone_id      = var.route53_zone_id
   ssh_pubkeys      = var.ssh_public_keys
 
+  //os_channel       = "stable"
+  //os_version       = "current"
+
   worker_pool "my-wp-name" {
     count         = var.workers_count
     instance_type = var.workers_type
     ssh_pubkeys   = var.ssh_public_keys
+
+    //os_channel    = "stable"
+    //os_version    = "current"
   }
 }
 

--- a/examples/packet-production/cluster.lokocfg
+++ b/examples/packet-production/cluster.lokocfg
@@ -57,6 +57,9 @@ cluster "packet" {
   cluster_name     = var.cluster_name
   controller_count = var.controllers_count
 
+  //os_channel       = "stable"
+
+
   dns {
     provider = "route53"
     zone     = var.dns_zone
@@ -80,6 +83,8 @@ cluster "packet" {
   worker_pool "pool-1" {
     count     = var.workers_count
     node_type = var.workers_type
+
+    //os_channel = "stable"
   }
 }
 

--- a/examples/packet-testing/cluster.lokocfg
+++ b/examples/packet-testing/cluster.lokocfg
@@ -42,6 +42,9 @@ cluster "packet" {
   cluster_name     = var.cluster_name
   controller_count = var.controllers_count
 
+  //os_channel       = "stable"
+
+
   dns {
     provider = "route53"
     zone     = var.dns_zone
@@ -58,6 +61,8 @@ cluster "packet" {
   worker_pool "pool-1" {
     count     = var.workers_count
     node_type = var.workers_type
+
+    //os_channel = "stable"
   }
 }
 


### PR DESCRIPTION
If Flatcar channels are not explicit, it is difficult for the user to find out how to change them. It also makes it less likely to forget to change it in the worker pool section.

Also fix a typo in the configuration.