### PR TITLE
docs: provide alternate way of declaring alertmanager config

### DIFF
--- a/docs/configuration-reference/components/prometheus-operator.md
+++ b/docs/configuration-reference/components/prometheus-operator.md
@@ -81,6 +81,31 @@ information.
     - name: 'null'
 ```
 
+**NOTE**: Ensure the file `alertmanager_config.yaml` is added to `.gitignore` to avoid any accidental exposure
+of sensitive data. Alternatively you can store the alertmanager configuration in `lokocfg.vars` as below:
+
+```hcl
+#lokocfg.vars
+alertmanager_config = <<EOF
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by:
+      - job
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: 'null'
+      routes:
+      - match:
+          alertname: Watchdog
+        receiver: 'null'
+    receivers:
+    - name: 'null'
+EOF
+```
+
 ## Attribute reference
 
 Table of all the arguments accepted by the component.


### PR DESCRIPTION
Addresses: #434

This commit adds a note to the user for adding the file to `.gitignore`
to avoid leaking of sensitive data.

We also provide an alternate way of providing alertmanager
configuration to the component, instead of `file()` function we use the
variable and store the content in `lokocfg.vars`

Signed-off-by: Imran Pochi <imran@kinvolk.io>