### PR TITLE
docs/concepts/aws.md: document TLS handshake errors in kube-apiserver

### DIFF
--- a/docs/concepts/aws.md
+++ b/docs/concepts/aws.md
@@ -28,3 +28,17 @@ spec:
     - ipBlock:
         cidr: 0.0.0.0/0
 ```
+
+## TLS handshake errors in kube-apiserver logs
+
+On the AWS platform, you may see the following logs coming from `kube-apiserver` pods:
+
+```
+I0408 05:35:02.865305       1 log.go:172] http: TLS handshake error from 127.0.0.1:45332: read tcp 127.53.210.227:7443->127.0.0.1:45332: read: connection reset by peer
+I0408 05:35:12.865457       1 log.go:172] http: TLS handshake error from 127.0.0.1:45424: read tcp 127.53.210.227:7443->127.0.0.1:45424: read: connection reset by peer
+I0408 05:35:22.865279       1 log.go:172] http: TLS handshake error from 127.0.0.1:45516: read tcp 127.53.210.227:7443->127.0.0.1:45516: read: connection reset by peer
+```
+
+Those logs are harmless and are caused by AWS ELBs opening TCP connections to `kube-apiserver` to probe for availability, without performing a full TLS handshake. Unfortunately, AWS ELBs do not support TLS for probe requests at the time of writing.
+
+There is ongoing [upstream](https://github.com/kubernetes/kubernetes/pull/91277) work to resolve this issue.


### PR DESCRIPTION
Closes #438.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>