### PR TITLE
Add packet_arm as alias to packet-arm

### DIFF
--- a/ci/packet-arm/packet_arm-cluster.lokocfg.envsubst
+++ b/ci/packet-arm/packet_arm-cluster.lokocfg.envsubst
@@ -1,0 +1,1 @@
+packet-arm-cluster.lokocfg.envsubst

--- a/ci/packet_arm
+++ b/ci/packet_arm
@@ -1,0 +1,1 @@
+packet-arm/

--- a/test/calico/metadata_access_test.go
+++ b/test/calico/metadata_access_test.go
@@ -89,7 +89,7 @@ func TestNoMetadataAccessRandomPod(t *testing.T) { //nolint:funlen
 	platform := os.Getenv("PLATFORM")
 
 	switch platform {
-	case testutil.PlatformPacket, testutil.PlatformPacketARM:
+	case testutil.PlatformPacket, testutil.PlatformPacketARM, "packet-arm":
 		metadataAddress = "https://metadata.packet.net/metadata"
 	case testutil.PlatformAWS, testutil.PlatformAWSEdge:
 		metadataAddress = "http://169.254.169.254/latest/meta-data"

--- a/test/components/util/util.go
+++ b/test/components/util/util.go
@@ -337,7 +337,7 @@ const (
 	PlatformPacket = "packet"
 
 	// PlatformPacketARM is for Packet on ARM
-	PlatformPacketARM = "packet-arm"
+	PlatformPacketARM = "packet_arm"
 
 	// PlatformBaremetal is for Baremetal
 	PlatformBaremetal = "baremetal"


### PR DESCRIPTION
So CI can be configured to use packet_arm instead of packet-arm
gracefully.

This is to make packet-arm consistent with aws_edge. As - cannot be used
as in Go build tags, we changed aws-edge to aws_edge.

Part of #563.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>