### PR TITLE
Don't show release values when running Terraform

### DIFF
--- a/pkg/platform/aks/template.go
+++ b/pkg/platform/aks/template.go
@@ -220,6 +220,7 @@ resource "local_file" "kubeconfig" {
 # Used when checking, if we should ask user for confirmation when
 # applying changes to the cluster.
 output "initialized" {
-  value = true
+  value     = true
+  sensitive = true
 }
 `

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -219,12 +219,14 @@ provider "tls" {
 # Used when checking, if we should ask user for confirmation, when
 # applying changes to the cluster.
 output "initialized" {
-  value = true
+  value     = true
+  sensitive = true
 }
 
 # values.yaml content for all deployed charts.
 output "pod-checkpointer_values" {
-  value = module.aws-{{.Config.ClusterName}}.pod-checkpointer_values
+  value     = module.aws-{{.Config.ClusterName}}.pod-checkpointer_values
+  sensitive = true
 }
 
 output "kube-apiserver_values" {
@@ -243,6 +245,7 @@ output "kubelet_values" {
 }
 
 output "calico_values" {
-  value = module.aws-{{.Config.ClusterName}}.calico_values
+  value     = module.aws-{{.Config.ClusterName}}.calico_values
+  sensitive = true
 }
 `

--- a/pkg/platform/baremetal/template.go
+++ b/pkg/platform/baremetal/template.go
@@ -101,12 +101,14 @@ provider "tls" {
 # Used when checking, if we should ask user for confirmation, when
 # applying changes to the cluster.
 output "initialized" {
-  value = true
+  value     = true
+  sensitive = true
 }
 
 # values.yaml content for all deployed charts.
 output "pod-checkpointer_values" {
-  value = module.bare-metal-{{.ClusterName}}.pod-checkpointer_values
+  value     = module.bare-metal-{{.ClusterName}}.pod-checkpointer_values
+  sensitive = true
 }
 
 output "kube-apiserver_values" {
@@ -125,6 +127,7 @@ output "kubelet_values" {
 }
 
 output "calico_values" {
-  value = module.bare-metal-{{.ClusterName}}.calico_values
+  value     = module.bare-metal-{{.ClusterName}}.calico_values
+  sensitive = true
 }
 `

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -303,12 +303,14 @@ provider "packet" {
 # Used when checking, if we should ask user for confirmation, when
 # applying changes to the cluster.
 output "initialized" {
-  value = true
+  value     = true
+  sensitive = true
 }
 
 # values.yaml content for all deployed charts.
 output "pod-checkpointer_values" {
-  value = module.packet-{{.Config.ClusterName}}.pod-checkpointer_values
+  value     = module.packet-{{.Config.ClusterName}}.pod-checkpointer_values
+  sensitive = true
 }
 
 output "kube-apiserver_values" {
@@ -327,6 +329,7 @@ output "kubelet_values" {
 }
 
 output "calico_values" {
-  value = module.packet-{{.Config.ClusterName}}.calico_values
+  value     = module.packet-{{.Config.ClusterName}}.calico_values
+  sensitive = true
 }
 `


### PR DESCRIPTION
This commit adds 'sensitive = true' to all Terraform outputs, so they
don't show up, when we run 'terraform apply' from the code. This is
to avoid cluttering the user output, as those values are information,
which user don't need to see.

As far as I know, adding 'sensitive = true' is the only way in Terraform
to hide this output, even though the values itself are not really
sensitive.

Closes #625

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>