### PR TITLE
pkg/components/aws-ebs-csi-driver: fix building

### DIFF
--- a/pkg/components/aws-ebs-csi-driver/component.go
+++ b/pkg/components/aws-ebs-csi-driver/component.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+
+	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
 )
@@ -60,7 +62,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, fmt.Errorf("loading chart from assets failed: %w", err)
 	}
 
-	values, err := util.RenderTemplate(chartValuesTmpl, c)
+	values, err := template.Render(chartValuesTmpl, c)
 	if err != nil {
 		return nil, fmt.Errorf("rendering chart values template failed: %w", err)
 	}


### PR DESCRIPTION
In f0f21f383e8e6ddfe43ef5ecd065da7ea66ea0e0 we removed
util.RenderTemplate function and replaced it with template.Render.
However, due to base branch being outdated, this broke buliding master
branch, so this commit fixes it.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>