### PR TITLE
Pass kubeconfig content around rather than file path

### DIFF
--- a/cli/cmd/cluster-apply.go
+++ b/cli/cmd/cluster-apply.go
@@ -81,13 +81,14 @@ func runClusterApply(cmd *cobra.Command, args []string) {
 	fmt.Printf("\nYour configurations are stored in %s\n", assetDir)
 
 	kubeconfigPath := assetsKubeconfig(assetDir)
-	if err := verifyCluster(kubeconfigPath, p.Meta().ExpectedNodes); err != nil {
-		ctxLogger.Fatalf("Verify cluster: %v", err)
-	}
 
 	kubeconfigContent, err := ioutil.ReadFile(kubeconfigPath) // #nosec G304
 	if err != nil {
 		ctxLogger.Fatalf("Failed to read kubeconfig file: %q: %v", kubeconfigPath, err)
+	}
+
+	if err := verifyCluster(kubeconfigContent, p.Meta().ExpectedNodes); err != nil {
+		ctxLogger.Fatalf("Verify cluster: %v", err)
 	}
 
 	// Do controlplane upgrades only if cluster already exists and it is not a managed platform.
@@ -130,12 +131,7 @@ func runClusterApply(cmd *cobra.Command, args []string) {
 	}
 }
 
-func verifyCluster(kubeconfigPath string, expectedNodes int) error {
-	kubeconfig, err := ioutil.ReadFile(kubeconfigPath) // #nosec G304
-	if err != nil {
-		return errors.Wrapf(err, "failed to read kubeconfig file")
-	}
-
+func verifyCluster(kubeconfig []byte, expectedNodes int) error {
 	cs, err := k8sutil.NewClientset(kubeconfig)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set up clientset")

--- a/cli/cmd/cluster-apply.go
+++ b/cli/cmd/cluster-apply.go
@@ -125,7 +125,7 @@ func runClusterApply(cmd *cobra.Command, args []string) {
 	ctxLogger.Println("Applying component configuration")
 
 	if len(componentsToApply) > 0 {
-		if err := applyComponents(lokoConfig, kubeconfigPath, componentsToApply...); err != nil {
+		if err := applyComponents(lokoConfig, kubeconfigContent, componentsToApply...); err != nil {
 			ctxLogger.Fatalf("Applying component configuration failed: %v", err)
 		}
 	}

--- a/cli/cmd/cluster-apply.go
+++ b/cli/cmd/cluster-apply.go
@@ -85,15 +85,20 @@ func runClusterApply(cmd *cobra.Command, args []string) {
 		ctxLogger.Fatalf("Verify cluster: %v", err)
 	}
 
+	kubeconfigContent, err := ioutil.ReadFile(kubeconfigPath) // #nosec G304
+	if err != nil {
+		ctxLogger.Fatalf("Failed to read kubeconfig file: %q: %v", kubeconfigPath, err)
+	}
+
 	// Do controlplane upgrades only if cluster already exists and it is not a managed platform.
 	if exists && !p.Meta().Managed {
 		fmt.Printf("\nEnsuring that cluster controlplane is up to date.\n")
 
 		cu := controlplaneUpdater{
-			kubeconfigPath: kubeconfigPath,
-			assetDir:       assetDir,
-			ctxLogger:      *ctxLogger,
-			ex:             *ex,
+			kubeconfig: kubeconfigContent,
+			assetDir:   assetDir,
+			ctxLogger:  *ctxLogger,
+			ex:         *ex,
 		}
 
 		releases := []string{"pod-checkpointer", "kube-apiserver", "kubernetes", "calico"}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -148,10 +148,10 @@ func clusterExists(ctxLogger *logrus.Entry, ex *terraform.Executor) bool {
 }
 
 type controlplaneUpdater struct {
-	kubeconfigPath string
-	assetDir       string
-	ctxLogger      logrus.Entry
-	ex             terraform.Executor
+	kubeconfig []byte
+	assetDir   string
+	ctxLogger  logrus.Entry
+	ex         terraform.Executor
 }
 
 func (c controlplaneUpdater) getControlplaneChart(name string) (*chart.Chart, error) {
@@ -187,7 +187,7 @@ func (c controlplaneUpdater) upgradeComponent(component string) {
 		"component": component,
 	})
 
-	actionConfig, err := util.HelmActionConfig("kube-system", c.kubeconfigPath)
+	actionConfig, err := util.HelmActionConfig("kube-system", c.kubeconfig)
 	if err != nil {
 		ctxLogger.Fatalf("Failed initializing helm: %v", err)
 	}

--- a/cli/cmd/component-apply.go
+++ b/cli/cmd/component-apply.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -64,12 +63,7 @@ func runApply(cmd *cobra.Command, args []string) {
 		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
 	}
 
-	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
-	if err != nil {
-		contextLogger.Fatalf("Failed to read kubeconfig file: %q: %v", kubeconfig, err)
-	}
-
-	if err := applyComponents(lokoConfig, kubeconfigContent, componentsToApply...); err != nil {
+	if err := applyComponents(lokoConfig, kubeconfig, componentsToApply...); err != nil {
 		contextLogger.Fatal(err)
 	}
 }

--- a/cli/cmd/component-apply.go
+++ b/cli/cmd/component-apply.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -63,12 +64,17 @@ func runApply(cmd *cobra.Command, args []string) {
 		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
 	}
 
-	if err := applyComponents(lokoConfig, kubeconfig, componentsToApply...); err != nil {
+	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
+	if err != nil {
+		contextLogger.Fatalf("Failed to read kubeconfig file: %q: %v", kubeconfig, err)
+	}
+
+	if err := applyComponents(lokoConfig, kubeconfigContent, componentsToApply...); err != nil {
 		contextLogger.Fatal(err)
 	}
 }
 
-func applyComponents(lokoConfig *config.Config, kubeconfig string, componentNames ...string) error {
+func applyComponents(lokoConfig *config.Config, kubeconfig []byte, componentNames ...string) error {
 	for _, componentName := range componentNames {
 		fmt.Printf("Applying component '%s'...\n", componentName)
 

--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -15,20 +15,14 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"helm.sh/helm/v3/pkg/action"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
-	"github.com/kinvolk/lokomotive/pkg/k8sutil"
 )
 
 var componentDeleteCmd = &cobra.Command{
@@ -106,7 +100,7 @@ func deleteComponents(kubeconfig string, componentObjects ...components.Componen
 	for _, compObj := range componentObjects {
 		fmt.Printf("Deleting component '%s'...\n", compObj.Metadata().Name)
 
-		if err := deleteHelmRelease(compObj, kubeconfig, deleteNamespace); err != nil {
+		if err := util.UninstallComponent(compObj, kubeconfig, deleteNamespace); err != nil {
 			return err
 		}
 
@@ -115,78 +109,6 @@ func deleteComponents(kubeconfig string, componentObjects ...components.Componen
 
 	// Add a line to distinguish between info logs and errors, if any.
 	fmt.Println()
-
-	return nil
-}
-
-// deleteComponent deletes a component.
-func deleteHelmRelease(c components.Component, kubeconfig string, deleteNSBool bool) error {
-	name := c.Metadata().Name
-	if name == "" {
-		// This should never fail in real user usage, if this does that means the component was not
-		// created with all the needed information.
-		panic(fmt.Errorf("component name is empty"))
-	}
-
-	ns := c.Metadata().Namespace
-	if ns == "" {
-		// This should never fail in real user usage, if this does that means the component was not
-		// created with all the needed information.
-		panic(fmt.Errorf("component %s namespace is empty", name))
-	}
-
-	cfg, err := util.HelmActionConfig(ns, kubeconfig)
-	if err != nil {
-		return fmt.Errorf("failed preparing helm client: %w", err)
-	}
-
-	history := action.NewHistory(cfg)
-	// Check if the component's release exists. If it does only then proceed to delete.
-	//
-	// Note: It is assumed that this call will return error only when the release does not exist.
-	// The error check is ignored to make `lokoctl component delete ..` idempotent.
-	// We rely on the fact that the 'component name' == 'release name'. Since component's name is
-	// hardcoded and unlikely to change release name won't change as well. And they will be
-	// consistent if installed by lokoctl. So it is highly unlikely that following call will return
-	// any other error than "release not found".
-	if _, err := history.Run(name); err == nil {
-		uninstall := action.NewUninstall(cfg)
-
-		// Ignore the err when we have deleted the release already or it does not exist for some reason.
-		if _, err := uninstall.Run(name); err != nil {
-			return err
-		}
-	}
-
-	if deleteNSBool {
-		if err := deleteNS(ns, kubeconfig); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func deleteNS(ns string, kubeconfig string) error {
-	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
-	if err != nil {
-		return fmt.Errorf("failed to read kubeconfig file: %v", err)
-	}
-
-	cs, err := k8sutil.NewClientset(kubeconfigContent)
-	if err != nil {
-		return err
-	}
-
-	// Delete the manually created namespace which was not created by helm.
-	if err = cs.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{}); err != nil {
-		// Ignore error when the namespace does not exist.
-		if errors.IsNotFound(err) {
-			return nil
-		}
-
-		return err
-	}
 
 	return nil
 }

--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -92,12 +91,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
 	}
 
-	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
-	if err != nil {
-		contextLogger.Fatalf("Failed to read kubeconfig file: %q: %v", kubeconfig, err)
-	}
-
-	if err := deleteComponents(kubeconfigContent, componentsObjects...); err != nil {
+	if err := deleteComponents(kubeconfig, componentsObjects...); err != nil {
 		contextLogger.Fatal(err)
 	}
 }

--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -91,12 +92,17 @@ func runDelete(cmd *cobra.Command, args []string) {
 		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
 	}
 
-	if err := deleteComponents(kubeconfig, componentsObjects...); err != nil {
+	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
+	if err != nil {
+		contextLogger.Fatalf("Failed to read kubeconfig file: %q: %v", kubeconfig, err)
+	}
+
+	if err := deleteComponents(kubeconfigContent, componentsObjects...); err != nil {
 		contextLogger.Fatal(err)
 	}
 }
 
-func deleteComponents(kubeconfig string, componentObjects ...components.Component) error {
+func deleteComponents(kubeconfig []byte, componentObjects ...components.Component) error {
 	for _, compObj := range componentObjects {
 		fmt.Printf("Deleting component '%s'...\n", compObj.Metadata().Name)
 

--- a/cli/cmd/health.go
+++ b/cli/cmd/health.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"text/tabwriter"
 
@@ -48,12 +47,7 @@ func runHealth(cmd *cobra.Command, args []string) {
 		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
 	}
 
-	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
-	if err != nil {
-		contextLogger.Fatalf("Failed to read kubeconfig file: %v", err)
-	}
-
-	cs, err := k8sutil.NewClientset(kubeconfigContent)
+	cs, err := k8sutil.NewClientset(kubeconfig)
 	if err != nil {
 		contextLogger.Fatalf("Error in creating setting up Kubernetes client: %q", err)
 	}

--- a/cli/cmd/health.go
+++ b/cli/cmd/health.go
@@ -28,10 +28,9 @@ import (
 )
 
 var healthCmd = &cobra.Command{
-	Use:               "health",
-	Short:             "Get the health of a cluster",
-	Run:               runHealth,
-	PersistentPreRunE: doesKubeconfigExist,
+	Use:   "health",
+	Short: "Get the health of a cluster",
+	Run:   runHealth,
 }
 
 func init() {

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/kinvolk/lokomotive/pkg/backend"
@@ -159,19 +158,6 @@ func assetsKubeconfigPath() (string, error) {
 
 func assetsKubeconfig(assetDir string) string {
 	return filepath.Join(assetDir, "cluster-assets", "auth", "kubeconfig")
-}
-
-// doesKubeconfigExist checks if the kubeconfig provided by user exists
-func doesKubeconfigExist(*cobra.Command, []string) error {
-	var err error
-	kubeconfig, err := getKubeconfig()
-	if err != nil {
-		return err
-	}
-	if _, err = os.Stat(kubeconfig); os.IsNotExist(err) {
-		return fmt.Errorf("Kubeconfig %q not found", kubeconfig)
-	}
-	return err
 }
 
 func getLokoConfig() (*config.Config, hcl.Diagnostics) {

--- a/pkg/components/util/install.go
+++ b/pkg/components/util/install.go
@@ -191,7 +191,7 @@ func ReleaseExists(actionConfig action.Configuration, name string) (bool, error)
 }
 
 // UninstallComponent uninstalls a component and optionally removes it's namespace.
-func UninstallComponent(c components.Component, kubeconfig string, deleteNSBool bool) error {
+func UninstallComponent(c components.Component, kubeconfig []byte, deleteNSBool bool) error {
 	name := c.Metadata().Name
 	if name == "" {
 		// This should never fail in real user usage, if this does that means the component was not
@@ -206,12 +206,7 @@ func UninstallComponent(c components.Component, kubeconfig string, deleteNSBool 
 		panic(fmt.Errorf("component %s namespace is empty", name))
 	}
 
-	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
-	if err != nil {
-		return fmt.Errorf("failed to read kubeconfig file %q: %v", kubeconfig, err)
-	}
-
-	cfg, err := HelmActionConfig(ns, kubeconfigContent)
+	cfg, err := HelmActionConfig(ns, kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed preparing helm client: %w", err)
 	}
@@ -243,13 +238,8 @@ func UninstallComponent(c components.Component, kubeconfig string, deleteNSBool 
 	return nil
 }
 
-func deleteNS(ns string, kubeconfig string) error {
-	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
-	if err != nil {
-		return fmt.Errorf("failed to read kubeconfig file: %v", err)
-	}
-
-	cs, err := k8sutil.NewClientset(kubeconfigContent)
+func deleteNS(ns string, kubeconfig []byte) error {
+	cs, err := k8sutil.NewClientset(kubeconfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/components/util/install.go
+++ b/pkg/components/util/install.go
@@ -189,3 +189,75 @@ func ReleaseExists(actionConfig action.Configuration, name string) (bool, error)
 
 	return err != driver.ErrReleaseNotFound, nil
 }
+
+// UninstallComponent uninstalls a component and optionally removes it's namespace.
+func UninstallComponent(c components.Component, kubeconfig string, deleteNSBool bool) error {
+	name := c.Metadata().Name
+	if name == "" {
+		// This should never fail in real user usage, if this does that means the component was not
+		// created with all the needed information.
+		panic(fmt.Errorf("component name is empty"))
+	}
+
+	ns := c.Metadata().Namespace
+	if ns == "" {
+		// This should never fail in real user usage, if this does that means the component was not
+		// created with all the needed information.
+		panic(fmt.Errorf("component %s namespace is empty", name))
+	}
+
+	cfg, err := HelmActionConfig(ns, kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed preparing helm client: %w", err)
+	}
+
+	history := action.NewHistory(cfg)
+	// Check if the component's release exists. If it does only then proceed to delete.
+	//
+	// Note: It is assumed that this call will return error only when the release does not exist.
+	// The error check is ignored to make `lokoctl component delete ..` idempotent.
+	// We rely on the fact that the 'component name' == 'release name'. Since component's name is
+	// hardcoded and unlikely to change release name won't change as well. And they will be
+	// consistent if installed by lokoctl. So it is highly unlikely that following call will return
+	// any other error than "release not found".
+	if _, err := history.Run(name); err == nil {
+		uninstall := action.NewUninstall(cfg)
+
+		// Ignore the err when we have deleted the release already or it does not exist for some reason.
+		if _, err := uninstall.Run(name); err != nil {
+			return err
+		}
+	}
+
+	if deleteNSBool {
+		if err := deleteNS(ns, kubeconfig); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteNS(ns string, kubeconfig string) error {
+	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
+	if err != nil {
+		return fmt.Errorf("failed to read kubeconfig file: %v", err)
+	}
+
+	cs, err := k8sutil.NewClientset(kubeconfigContent)
+	if err != nil {
+		return err
+	}
+
+	// Delete the manually created namespace which was not created by helm.
+	if err = cs.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{}); err != nil {
+		// Ignore error when the namespace does not exist.
+		if errors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/components/util/install.go
+++ b/pkg/components/util/install.go
@@ -17,7 +17,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -31,12 +30,7 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/k8sutil"
 )
 
-func ensureNamespaceExists(name string, kubeconfigPath string) error {
-	kubeconfig, err := ioutil.ReadFile(kubeconfigPath) // #nosec G304
-	if err != nil {
-		return fmt.Errorf("reading kubeconfig file: %w", err)
-	}
-
+func ensureNamespaceExists(name string, kubeconfig []byte) error {
 	cs, err := k8sutil.NewClientset(kubeconfig)
 	if err != nil {
 		return fmt.Errorf("creating clientset: %w", err)
@@ -60,7 +54,7 @@ func ensureNamespaceExists(name string, kubeconfigPath string) error {
 }
 
 // InstallComponent installs given component using given kubeconfig as a Helm release using a Helm client.
-func InstallComponent(c components.Component, kubeconfig string) error {
+func InstallComponent(c components.Component, kubeconfig []byte) error {
 	name := c.Metadata().Name
 	ns := c.Metadata().Namespace
 
@@ -68,12 +62,7 @@ func InstallComponent(c components.Component, kubeconfig string) error {
 		return fmt.Errorf("failed ensuring that namespace %q for component %q exists: %w", ns, name, err)
 	}
 
-	kubeconfigContent, err := ioutil.ReadFile(kubeconfig) // #nosec G304
-	if err != nil {
-		return fmt.Errorf("failed to read kubeconfig file %q: %v", kubeconfig, err)
-	}
-
-	actionConfig, err := HelmActionConfig(ns, kubeconfigContent)
+	actionConfig, err := HelmActionConfig(ns, kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed preparing helm client: %w", err)
 	}

--- a/pkg/components/util/install_test.go
+++ b/pkg/components/util/install_test.go
@@ -1,8 +1,6 @@
 package util_test
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/kinvolk/lokomotive/pkg/components/util"
@@ -30,51 +28,13 @@ contexts:
 )
 
 func TestHelmActionConfigFromValidKubeconfigFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "lokoctl-tests-")
-	if err != nil {
-		t.Fatalf("creating tmp file should succeed, got: %v", err)
-	}
-
-	defer func() {
-		if err := os.Remove(tmpFile.Name()); err != nil {
-			t.Logf("failed to remove tmp file %q: %v", tmpFile.Name(), err)
-		}
-	}()
-
-	if _, err := tmpFile.Write([]byte(validKubeconfig)); err != nil {
-		t.Fatalf("writing to tmp file %q should succeed, got: %v", tmpFile.Name(), err)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		t.Fatalf("closing tmp file %q should succeed, got: %v", tmpFile.Name(), err)
-	}
-
-	if _, err := util.HelmActionConfig("foo", tmpFile.Name()); err != nil {
+	if _, err := util.HelmActionConfig("foo", []byte(validKubeconfig)); err != nil {
 		t.Fatalf("creating helm action config from valid kubeconfig file should succeed, got: %v", err)
 	}
 }
 
 func TestHelmActionConfigFromInvalidKubeconfigFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "lokoctl-tests-")
-	if err != nil {
-		t.Fatalf("creating tmp file should succeed, got: %v", err)
-	}
-
-	defer func() {
-		if err := os.Remove(tmpFile.Name()); err != nil {
-			t.Logf("failed to remove tmp file %q: %v", tmpFile.Name(), err)
-		}
-	}()
-
-	if _, err := tmpFile.Write([]byte("foo")); err != nil {
-		t.Fatalf("writing to tmp file %q should succeed, got: %v", tmpFile.Name(), err)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		t.Fatalf("closing tmp file %q should succeed, got: %v", tmpFile.Name(), err)
-	}
-
-	if _, err := util.HelmActionConfig("foo", tmpFile.Name()); err == nil {
+	if _, err := util.HelmActionConfig("foo", []byte("foo")); err == nil {
 		t.Fatalf("creating helm action config from invalid kubeconfig file should fail")
 	}
 }

--- a/pkg/components/util/install_test.go
+++ b/pkg/components/util/install_test.go
@@ -1,0 +1,80 @@
+package util_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/kinvolk/lokomotive/pkg/components/util"
+)
+
+const (
+	validKubeconfig = `
+apiVersion: v1
+kind: Config
+clusters:
+- name: admin
+  cluster:
+    server: https://nonexistent:6443
+users:
+- name: admin
+  user:
+    token: "foo.bar"
+current-context: admin
+contexts:
+- name: admin
+  context:
+    cluster: admin
+    user: admin
+`
+)
+
+func TestHelmActionConfigFromValidKubeconfigFile(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "lokoctl-tests-")
+	if err != nil {
+		t.Fatalf("creating tmp file should succeed, got: %v", err)
+	}
+
+	defer func() {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			t.Logf("failed to remove tmp file %q: %v", tmpFile.Name(), err)
+		}
+	}()
+
+	if _, err := tmpFile.Write([]byte(validKubeconfig)); err != nil {
+		t.Fatalf("writing to tmp file %q should succeed, got: %v", tmpFile.Name(), err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("closing tmp file %q should succeed, got: %v", tmpFile.Name(), err)
+	}
+
+	if _, err := util.HelmActionConfig("foo", tmpFile.Name()); err != nil {
+		t.Fatalf("creating helm action config from valid kubeconfig file should succeed, got: %v", err)
+	}
+}
+
+func TestHelmActionConfigFromInvalidKubeconfigFile(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "lokoctl-tests-")
+	if err != nil {
+		t.Fatalf("creating tmp file should succeed, got: %v", err)
+	}
+
+	defer func() {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			t.Logf("failed to remove tmp file %q: %v", tmpFile.Name(), err)
+		}
+	}()
+
+	if _, err := tmpFile.Write([]byte("foo")); err != nil {
+		t.Fatalf("writing to tmp file %q should succeed, got: %v", tmpFile.Name(), err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("closing tmp file %q should succeed, got: %v", tmpFile.Name(), err)
+	}
+
+	if _, err := util.HelmActionConfig("foo", tmpFile.Name()); err == nil {
+		t.Fatalf("creating helm action config from invalid kubeconfig file should fail")
+	}
+}

--- a/pkg/k8sutil/doc.go
+++ b/pkg/k8sutil/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package k8sutil provides helper for interacting with Kubernetes API.
+package k8sutil

--- a/pkg/k8sutil/getter.go
+++ b/pkg/k8sutil/getter.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Getter implements k8s.io/cli-runtime/pkg/genericclioptions.RESTClientGetter interface.
+type Getter struct {
+	c clientcmd.ClientConfig
+}
+
+// ToRESTMapper is part of k8s.io/cli-runtime/pkg/genericclioptions.RESTClientGetter interface.
+func (c *Getter) ToRESTMapper() (meta.RESTMapper, error) {
+	d, err := c.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(d)
+	expander := restmapper.NewShortcutExpander(mapper, d)
+
+	return expander, nil
+}
+
+// ToDiscoveryClient is part of k8s.io/cli-runtime/pkg/genericclioptions.RESTClientGetter interface.
+func (c *Getter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	cc, err := c.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	d, err := discovery.NewDiscoveryClientForConfig(cc)
+	if err != nil {
+		return nil, err
+	}
+
+	return memory.NewMemCacheClient(d), nil
+}
+
+// ToRawKubeConfigLoader is part of k8s.io/cli-runtime/pkg/genericclioptions.RESTClientGetter interface.
+func (c *Getter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return c.c
+}
+
+// ToRESTConfig is part of k8s.io/cli-runtime/pkg/genericclioptions.RESTClientGetter interface.
+func (c *Getter) ToRESTConfig() (*rest.Config, error) {
+	return c.c.ClientConfig()
+}
+
+// NewGetter takes content of kubeconfig file as an argument and returns implementation of
+// RESTClientGetter k8s interface.
+func NewGetter(data []byte) (*Getter, error) {
+	c, err := clientcmd.NewClientConfigFromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Getter{
+		c: c,
+	}, nil
+}

--- a/pkg/k8sutil/getter_test.go
+++ b/pkg/k8sutil/getter_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil_test
+
+import (
+	"testing"
+
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
+)
+
+func TestGetter(t *testing.T) {
+	g, err := k8sutil.NewGetter([]byte(validKubeconfig))
+	if err != nil {
+		t.Fatalf("Creating getter from valid kubeconfig should succeed, got: %v", err)
+	}
+
+	if _, err := g.ToDiscoveryClient(); err != nil {
+		t.Errorf("Turning getter into discovery client should succeed, got: %v", err)
+	}
+
+	if _, err := g.ToRESTMapper(); err != nil {
+		t.Errorf("Turning getter into REST mapper should succeed, got: %v", err)
+	}
+
+	if c := g.ToRawKubeConfigLoader(); c == nil {
+		t.Errorf("Turning getter into RawKubeConfigLoader should succeed")
+	}
+}
+
+func TestGetterInvalidKubeconfig(t *testing.T) {
+	if _, err := k8sutil.NewGetter([]byte("foo")); err == nil {
+		t.Fatalf("Creating getter from invalid kubeconfig should fail")
+	}
+}

--- a/test/components/install_test.go
+++ b/test/components/install_test.go
@@ -50,7 +50,8 @@ component "flatcar-linux-update-operator" {}
 		t.Fatalf("Valid config should not return error, got: %s", diagnostics)
 	}
 
-	k := testutil.KubeconfigPath(t)
+	k := testutil.Kubeconfig(t)
+
 	if err := util.InstallComponent(c, k); err != nil {
 		t.Fatalf("Installing component as release should succeed, got: %v", err)
 	}

--- a/test/components/util/util.go
+++ b/test/components/util/util.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -45,6 +46,19 @@ func KubeconfigPath(t *testing.T) string {
 	}
 
 	return kubeconfig
+}
+
+// Kubeconfig returns content of kubeconfig file defined with KUBECONFIG
+// environment variable.
+func Kubeconfig(t *testing.T) []byte {
+	path := KubeconfigPath(t)
+
+	k, err := ioutil.ReadFile(path) // #nosec:G304
+	if err != nil {
+		t.Fatalf("reading KUBECONFIG file from %q failed: %v", path, err)
+	}
+
+	return k
 }
 
 // buildKubeConfig reads the environment variable KUBECONFIG and then builds the rest client config

--- a/vendor/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/vendor/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"sync"
+	"syscall"
+
+	"github.com/googleapis/gnostic/OpenAPIv2"
+
+	errorsutil "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	restclient "k8s.io/client-go/rest"
+)
+
+type cacheEntry struct {
+	resourceList *metav1.APIResourceList
+	err          error
+}
+
+// memCacheClient can Invalidate() to stay up-to-date with discovery
+// information.
+//
+// TODO: Switch to a watch interface. Right now it will poll after each
+// Invalidate() call.
+type memCacheClient struct {
+	delegate discovery.DiscoveryInterface
+
+	lock                   sync.RWMutex
+	groupToServerResources map[string]*cacheEntry
+	groupList              *metav1.APIGroupList
+	cacheValid             bool
+}
+
+// Error Constants
+var (
+	ErrCacheNotFound = errors.New("not found")
+)
+
+var _ discovery.CachedDiscoveryInterface = &memCacheClient{}
+
+// isTransientConnectionError checks whether given error is "Connection refused" or
+// "Connection reset" error which usually means that apiserver is temporarily
+// unavailable.
+func isTransientConnectionError(err error) bool {
+	urlError, ok := err.(*url.Error)
+	if !ok {
+		return false
+	}
+	opError, ok := urlError.Err.(*net.OpError)
+	if !ok {
+		return false
+	}
+	errno, ok := opError.Err.(syscall.Errno)
+	if !ok {
+		return false
+	}
+	return errno == syscall.ECONNREFUSED || errno == syscall.ECONNRESET
+}
+
+func isTransientError(err error) bool {
+	if isTransientConnectionError(err) {
+		return true
+	}
+
+	if t, ok := err.(errorsutil.APIStatus); ok && t.Status().Code >= 500 {
+		return true
+	}
+
+	return errorsutil.IsTooManyRequests(err)
+}
+
+// ServerResourcesForGroupVersion returns the supported resources for a group and version.
+func (d *memCacheClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if !d.cacheValid {
+		if err := d.refreshLocked(); err != nil {
+			return nil, err
+		}
+	}
+	cachedVal, ok := d.groupToServerResources[groupVersion]
+	if !ok {
+		return nil, ErrCacheNotFound
+	}
+
+	if cachedVal.err != nil && isTransientError(cachedVal.err) {
+		r, err := d.serverResourcesForGroupVersion(groupVersion)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", groupVersion, err))
+		}
+		cachedVal = &cacheEntry{r, err}
+		d.groupToServerResources[groupVersion] = cachedVal
+	}
+
+	return cachedVal.resourceList, cachedVal.err
+}
+
+// ServerResources returns the supported resources for all groups and versions.
+// Deprecated: use ServerGroupsAndResources instead.
+func (d *memCacheClient) ServerResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerResources(d)
+}
+
+// ServerGroupsAndResources returns the groups and supported resources for all groups and versions.
+func (d *memCacheClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return discovery.ServerGroupsAndResources(d)
+}
+
+func (d *memCacheClient) ServerGroups() (*metav1.APIGroupList, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if !d.cacheValid {
+		if err := d.refreshLocked(); err != nil {
+			return nil, err
+		}
+	}
+	return d.groupList, nil
+}
+
+func (d *memCacheClient) RESTClient() restclient.Interface {
+	return d.delegate.RESTClient()
+}
+
+func (d *memCacheClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerPreferredResources(d)
+}
+
+func (d *memCacheClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerPreferredNamespacedResources(d)
+}
+
+func (d *memCacheClient) ServerVersion() (*version.Info, error) {
+	return d.delegate.ServerVersion()
+}
+
+func (d *memCacheClient) OpenAPISchema() (*openapi_v2.Document, error) {
+	return d.delegate.OpenAPISchema()
+}
+
+func (d *memCacheClient) Fresh() bool {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	// Return whether the cache is populated at all. It is still possible that
+	// a single entry is missing due to transient errors and the attempt to read
+	// that entry will trigger retry.
+	return d.cacheValid
+}
+
+// Invalidate enforces that no cached data that is older than the current time
+// is used.
+func (d *memCacheClient) Invalidate() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.cacheValid = false
+	d.groupToServerResources = nil
+	d.groupList = nil
+}
+
+// refreshLocked refreshes the state of cache. The caller must hold d.lock for
+// writing.
+func (d *memCacheClient) refreshLocked() error {
+	// TODO: Could this multiplicative set of calls be replaced by a single call
+	// to ServerResources? If it's possible for more than one resulting
+	// APIResourceList to have the same GroupVersion, the lists would need merged.
+	gl, err := d.delegate.ServerGroups()
+	if err != nil || len(gl.Groups) == 0 {
+		utilruntime.HandleError(fmt.Errorf("couldn't get current server API group list: %v", err))
+		return err
+	}
+
+	wg := &sync.WaitGroup{}
+	resultLock := &sync.Mutex{}
+	rl := map[string]*cacheEntry{}
+	for _, g := range gl.Groups {
+		for _, v := range g.Versions {
+			gv := v.GroupVersion
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer utilruntime.HandleCrash()
+
+				r, err := d.serverResourcesForGroupVersion(gv)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", gv, err))
+				}
+
+				resultLock.Lock()
+				defer resultLock.Unlock()
+				rl[gv] = &cacheEntry{r, err}
+			}()
+		}
+	}
+	wg.Wait()
+
+	d.groupToServerResources, d.groupList = rl, gl
+	d.cacheValid = true
+	return nil
+}
+
+func (d *memCacheClient) serverResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	r, err := d.delegate.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return r, err
+	}
+	if len(r.APIResources) == 0 {
+		return r, fmt.Errorf("Got empty response for: %v", groupVersion)
+	}
+	return r, nil
+}
+
+// NewMemCacheClient creates a new CachedDiscoveryInterface which caches
+// discovery information in memory and will stay up-to-date if Invalidate is
+// called with regularity.
+//
+// NOTE: The client will NOT resort to live lookups on cache misses.
+func NewMemCacheClient(delegate discovery.DiscoveryInterface) discovery.CachedDiscoveryInterface {
+	return &memCacheClient{
+		delegate:               delegate,
+		groupToServerResources: map[string]*cacheEntry{},
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -615,6 +615,7 @@ k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.18.0
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
+k8s.io/client-go/discovery/cached/memory
 k8s.io/client-go/dynamic
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme


### PR DESCRIPTION
**This PR includes commits from #628, please review this one first and don't leave commit comments for this PR here.**

This PR changes a lot of the code to accept kubeconfig content rather than kubeconfig path, so we will be able to read it from Terraform state/output in the future, which is needed for #608. It also shows, how poorly the code is structured, as such change requite so much code changes. We should make most of this function to execute in the scope/context (so make them have a receiver), which already has access to the kubeconfig content, as the kubeconfig content is almost constant in calls of this functions.

Please review the PR commit by commit, as each of them contains small, logical and independent changes, described a bit in commit message.

Now that reading kubeconfig file is in single place, we can implement reading it from Terraform state.

Closes #623

Part of #608 