### PR TITLE
baremetal quickstart: Add double quotes

### DIFF
--- a/docs/quickstarts/baremetal.md
+++ b/docs/quickstarts/baremetal.md
@@ -125,7 +125,7 @@ cluster "bare-metal" {
   asset_dir = "./lokomotive-assets"
 
   # Cluster name.
-  cluster_name = baremetalcluster
+  cluster_name = "baremetalcluster"
 
   # SSH Public keys.
   ssh_pubkeys = [


### PR DESCRIPTION
The clustername was missing double quotes `"` hence add those so that
config is usable after copy pasting.
