### PR TITLE
Revert "ci/aws: Remove duplicate info in worker pool name"

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -32,7 +32,8 @@ storage:
         id: 500
 EOF
   ]
-  worker_pool "wp" {
+
+  worker_pool "$CLUSTER_ID-wp" {
     count         = 2
     ssh_pubkeys   = ["$PUB_KEY"]
     disk_size     = 30


### PR DESCRIPTION
This reverts commit 1a4dd255efd381d8fa883f573dd3b1c27d75c3d0.

In 20b7b696a61ba6ec706140feeaae6c25dfb3dfae we reverted the naming of
worker pools so we need this again for CI to behave.