### PR TITLE
rook-ceph: Allow volume resizing

### DIFF
--- a/pkg/components/rook-ceph/manifests.go
+++ b/pkg/components/rook-ceph/manifests.go
@@ -110,6 +110,7 @@ metadata:
     {{- if .StorageClass.Default }}
     storageclass.kubernetes.io/is-default-class: "true"
     {{- end }}
+allowVolumeExpansion: true
 provisioner: {{ .Namespace }}.rbd.csi.ceph.com
 parameters:
   clusterID: {{ .Namespace }}
@@ -127,6 +128,8 @@ parameters:
   csi.storage.k8s.io/provisioner-secret-namespace: {{ .Namespace }}
   csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
   csi.storage.k8s.io/node-stage-secret-namespace: {{ .Namespace }}
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ .Namespace }}
 
   # Specify the filesystem type of the volume. If not specified, csi-provisioner
   # will set default as 'ext4'.


### PR DESCRIPTION
This adds parameters to the storage class `rook-ceph-block` created by rook-ceph component. This will enable the PVs created by the storage class to be resized on the fly.

---

### Upgrade process on existing clusters:


Once this is merged one can update the `StorageClass` by simply applying the `rook-ceph` component again by running following command:

```bash
lokoctl component apply rook-ceph
```

All the PVs created with older `StorageClass` lack following information:

```yaml
apiVersion: v1
kind: PersistentVolume
...
spec:
  csi:
    controllerExpandSecretRef:
      name: rook-csi-rbd-provisioner
      namespace: rook
```

This can be patched, but it has to be done manually:

```bash
export namespace=default
export pvcname=populate-1
kubectl patch pv $(kubectl -n $namespace get pvc $pvcname -o jsonpath='{.spec.volumeName}') --patch '{"spec":{"csi":{"controllerExpandSecretRef":{"name":"rook-csi-rbd-provisioner","namespace":"rook"}}}}'
```

If not done then PVs don't resize and we might see errors like the one mentioned in the description of this issue: https://github.com/rook/rook/issues/5670#issue-641183590.