### PR TITLE
rook-ceph: Add toolbox configs

### DIFF
--- a/docs/configuration-reference/components/rook-ceph.md
+++ b/docs/configuration-reference/components/rook-ceph.md
@@ -27,8 +27,9 @@ Rook-Ceph component configuration example:
 ```tf
 component "rook-ceph" {
   # Optional arguments
-  namespace = "rook-test"
-  monitor_count = 3
+  namespace       = "rook-test"
+  monitor_count   = 3
+  enable_toolbox  = true
   metadata_device = "md127"
   node_affinity {
     key      = "node-role.kubernetes.io/storage"
@@ -51,10 +52,11 @@ component "rook-ceph" {
   }
 
   storage_class {
-    enable = true
+    enable  = true
     default = true
   }
 }
+
 ```
 
 The Ceph cluster needs to be deployed in the same namespace as the Rook operator at the moment.
@@ -67,17 +69,16 @@ Table of all the arguments accepted by the component.
 
 Example:
 
-
 | Argument                | Description                                                                                                                                      | Default | Type                                                                                                           | Required |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|:-------:|:---------------------------------------------------------------------------------------------------------------|:--------:|
 | `namespace`             | Namespace to deploy the Ceph cluster into. Must be the same as the rook operator.                                                                | "rook"  | string                                                                                                         |  false   |
 | `monitor_count`         | Number of Ceph monitors to deploy. An odd number like 3 or 5 is recommended which should also be sufficient for most cases.                      |    1    | number                                                                                                         |  false   |
+| `enable_toolbox`        | Deploy the [toolbox pod](https://rook.io/docs/rook/master/ceph-toolbox.html) to debug and manage the Ceph cluster.                               | false   | bool                                                                                                           |  false   |
 | `node_affinity`         | Node affinity for deploying the Ceph cluster pods.                                                                                               |    -    | list(object({key = string, operator = string, values = list(string)}))                                         |  false   |
 | `toleration`            | Tolerations that the Ceph cluster pods will tolerate.                                                                                            |    -    | list(object({key = string, effect = string, operator = string, value = string, toleration_seconds = string })) |  false   |
 | `metadata_device`       | Name of the device to store the metadata on each storage machine. **Note**: Provide just the name of the device and skip prefixing with `/dev/`. |    -    | string                                                                                                         |  false   |
 | `storage_class.enable`  | Install Storage Class config.                                                                                                                    |  false  | bool                                                                                                           |  false   |
 | `storage_class.default` | Make this Storage Class as a default one.                                                                                                        |  false  | bool                                                                                                           |  false   |
-
 
 ## Applying
 

--- a/pkg/components/rook-ceph/component.go
+++ b/pkg/components/rook-ceph/component.go
@@ -40,6 +40,7 @@ type component struct {
 	Tolerations    []util.Toleration   `hcl:"toleration,block"`
 	TolerationsRaw string
 	StorageClass   *StorageClass `hcl:"storage_class,block"`
+	EnableToolbox  bool          `hcl:"enable_toolbox,optional"`
 }
 
 // StorageClass provides struct to enable it or make it default.

--- a/pkg/components/rook-ceph/manifests.go
+++ b/pkg/components/rook-ceph/manifests.go
@@ -139,4 +139,56 @@ parameters:
 reclaimPolicy: Delete
 {{- end }}
 `,
+
+	"ceph-toolbox.yaml": `
+{{- if .EnableToolbox }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-tools
+  namespace: {{ .Namespace }}
+  labels:
+    app: rook-ceph-tools
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-tools
+  template:
+    metadata:
+      labels:
+        app: rook-ceph-tools
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: rook-ceph-tools
+        image: rook/ceph:master
+        command: ["/tini"]
+        args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: ROOK_ADMIN_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: rook-ceph-mon
+              key: admin-secret
+        volumeMounts:
+        - mountPath: /etc/ceph
+          name: ceph-config
+        - name: mon-endpoint-volume
+          mountPath: /etc/rook
+      volumes:
+      - name: mon-endpoint-volume
+        configMap:
+          name: rook-ceph-mon-endpoints
+          items:
+          - key: data
+            path: mon-endpoints
+      - name: ceph-config
+        emptyDir: {}
+{{- if .TolerationsRaw }}
+      tolerations: {{ .TolerationsRaw }}
+{{- end }}
+{{- end }}
+`,
 }


### PR DESCRIPTION
Add a variable `enable_toolbox` to install Rook Ceph toolbox pod to
manage and configure Ceph.

Fixes https://github.com/kinvolk/lokomotive/issues/594