### PR TITLE
Makefile: add codespell target with configuration

### DIFF
--- a/.codespell.ignorewords
+++ b/.codespell.ignorewords
@@ -1,0 +1,5 @@
+aks
+aci
+cas
+mitre
+iam

--- a/.codespell.skip
+++ b/.codespell.skip
@@ -1,0 +1,10 @@
+./vendor
+./.git
+./lokoctl
+*.png
+./assets/components/rook-ceph
+./assets/components/prometheus-operator/manifests
+./assets/components/velero
+./assets/components/cluster-autoscaler
+./assets/components/contour/crds
+./assets/components/openebs/README.md

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build-test:
 	go test -run=nonexistent -mod=$(MOD) -tags=$(ALL_BUILD_TAGS) -covermode=atomic -buildmode=exe -v ./... > /dev/null
 
 .PHONY: all
-all: build build-test test lint
+all: build build-test test lint codespell
 
 .PHONY: update-assets
 update-assets:
@@ -154,3 +154,10 @@ docs:
 build-and-publish-release: SHELL:=/bin/bash
 build-and-publish-release:
 	goreleaser --release-notes <(./scripts/print-version-changelog.sh)
+
+.PHONY: codespell
+codespell: CODESPELL_SKIP := $(shell cat .codespell.skip | tr \\n ',')
+codespell: CODESPELL_BIN := codespell
+codespell:
+	which $(CODESPELL_BIN) >/dev/null 2>&1 || (echo "$(CODESPELL_BIN) binary not found, skipping spell checking"; exit 0)
+	$(CODESPELL_BIN) --skip $(CODESPELL_SKIP) --ignore-words .codespell.ignorewords --check-filenames --check-hidden


### PR DESCRIPTION
This commit adds 'codespell' target to the Makefile and adds it to 'all'
target, so it is run when all checks are requested, but only if the
binary is present, as some people may not have it installed.

Part of #573

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>