### PR TITLE
.codespell.skip: ignore typos in Calico CDRs

### DIFF
--- a/.codespell.skip
+++ b/.codespell.skip
@@ -8,3 +8,4 @@
 ./assets/components/cluster-autoscaler
 ./assets/components/contour/crds
 ./assets/components/openebs/README.md
+./assets/lokomotive-kubernetes/bootkube/resources/charts/calico/crds


### PR DESCRIPTION
So when we enable spell checking on CI, builds will still be passing.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>