### PR TITLE
goreleaser: stop marking releases as pre-releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,8 +32,5 @@ release:
   # publishing.
   draft: true
 
-  # Mark release as prerelease for now.
-  prerelease: true
-
 archives:
 - wrap_in_directory: true


### PR DESCRIPTION
Originally the idea with marking releases as pre-releases was that
releases before 1.0.0 should be pre-releases.

However, this doesn't seem to be the intention of the check. It's more
oriented towards alpha or RC releases before a final release is cut.

Marking a release as pre-release also prevents it from appearing on the
main repo page.