### PR TITLE
Change external-dns policy to sync

### DIFF
--- a/docs/configuration-reference/components/external-dns.md
+++ b/docs/configuration-reference/components/external-dns.md
@@ -45,7 +45,7 @@ component "external-dns" {
   # Optional arguments.
   sources = ["ingress"]
   namespace = "external-dns"
-  policy = "upsert-only"
+  policy = "sync"
   metrics = false
 }
 ```
@@ -60,7 +60,7 @@ Example:
 |-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------:|:------------:|:--------:|
 | `sources`                   | Kubernetes resources type to be observed for new DNS entries by ExternalDNS.                                                                           |  ["ingress"]   | list(string) |  false   |
 | `namespace`                 | Namespace to install ExternalDNS.                                                                                                                      | "external-dns" |    string    |  false   |
-| `policy`                    | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only).                                                     | "upsert-only"  |    string    |  false   |
+| `policy`                    | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only).                                                     | "sync"  |    string    |  false   |
 | `metrics`                   | Enable metrics collection by Prometheus. Needs [Prometheus Operator component](prometheus-operator.md) installed.                                      |     false      |     bool     |  false   |
 | `owner_id`                  | A name that identifies this instance of ExternalDNS. Set it to a unique value across the DNS zone that doesn't change for the lifetime of the cluster. |       -        |    string    |   true   |
 | `aws`                       | Configuration block for AWS Route53 DNS provider.                                                                                                      |       -        |    object    |   true   |

--- a/pkg/components/external-dns/component.go
+++ b/pkg/components/external-dns/component.go
@@ -91,7 +91,7 @@ func newComponent() *component {
 		AwsConfig: AwsConfig{
 			ZoneType: "public",
 		},
-		Policy:         "upsert-only",
+		Policy:         "sync",
 		Metrics:        false,
 		ServiceMonitor: false,
 	}

--- a/pkg/components/external-dns/component_test.go
+++ b/pkg/components/external-dns/component_test.go
@@ -55,8 +55,9 @@ func TestDefaultValues(t *testing.T) {
 	if len(c.Sources) != 1 || c.Sources[0] != "ingress" {
 		t.Fatal("Default sources should be ingress only.")
 	}
-	if c.Policy != "upsert-only" {
-		t.Fatal("Default policy should be upsert-only.")
+
+	if c.Policy != "sync" {
+		t.Fatal("Default policy should be sync.")
 	}
 	if c.AwsConfig.ZoneType != "public" {
 		t.Fatal("Default zone type in AWS should be public.")
@@ -69,7 +70,7 @@ func TestAwsConfigWithoutProvidingCredentials(t *testing.T) {
  component "external-dns" {
    sources = ["ingress"]
    metrics =  false
-   policy = "upsert-only"
+   policy = "sync"
    owner_id = "test-owner"
    aws {
      zone_id = "TESTZONEID"
@@ -99,7 +100,7 @@ func TestAwsConfigBySettingEnvVariables(t *testing.T) {
   component "external-dns" {
     sources = ["ingress"]
     metrics =  false
-    policy = "upsert-only"
+    policy = "sync"
     owner_id = "test-owner"
     aws {
       zone_id = "TESTZONEID"
@@ -136,7 +137,7 @@ func TestAwsConfigBySettingEmptyEnvVariables(t *testing.T) {
   component "external-dns" {
     sources = ["ingress"]
     metrics =  false
-    policy = "upsert-only"
+    policy = "sync"
     owner_id = "test-owner"
     aws {
       zone_id = "TESTZONEID"
@@ -172,7 +173,7 @@ func TestAwsConfigBySettingConfigFields(t *testing.T) {
   component "external-dns" {
     sources = ["ingress"]
     metrics =  false
-    policy = "upsert-only"
+    policy = "sync"
     owner_id = "test-owner"
     aws {
       zone_id = "TESTZONEID"


### PR DESCRIPTION
We have added tests in CI to test for component deletion. Now
external-dns can clear records from the given provider.

Signed-off-by: knrt10 <kautilya@kinvolk.io>