### PR TITLE
cli/cmd: implement kubeconfig fallback to Terraform state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ GOFORMAT_FILES := $(shell find . -name '*.go' | grep -v '^./vendor')
 
 .PHONY: run-unit-tests
 run-unit-tests:
-	go test -mod=$(MOD) -covermode=atomic -buildmode=exe -v ./...
+	go test -mod=$(MOD) -covermode=atomic -buildmode=exe ./...
 
 .PHONY: format-go-code
 ## Formats any go file that differs from gofmt's style

--- a/cli/cmd/cluster-apply.go
+++ b/cli/cmd/cluster-apply.go
@@ -81,7 +81,7 @@ func runClusterApply(cmd *cobra.Command, args []string) {
 
 	fmt.Printf("\nYour configurations are stored in %s\n", assetDir)
 
-	kubeconfig, err := getKubeconfig()
+	kubeconfig, err := getKubeconfig(ctxLogger, lokoConfig, true)
 	if err != nil {
 		ctxLogger.Fatalf("Failed to get kubeconfig: %v", err)
 	}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -49,17 +49,13 @@ func initialize(ctxLogger *logrus.Entry) (*terraform.Executor, platform.Platform
 		ctxLogger.Fatal(diags)
 	}
 
-	p, diags := getConfiguredPlatform()
+	p, diags := getConfiguredPlatform(lokoConfig, true)
 	if diags.HasErrors() {
 		for _, diagnostic := range diags {
 			ctxLogger.Error(diagnostic.Error())
 		}
 
 		ctxLogger.Fatal("Errors found while loading cluster configuration")
-	}
-
-	if p == nil {
-		ctxLogger.Fatal("No cluster configured")
 	}
 
 	// Get the configured backend for the cluster. Backend types currently supported: local, s3.

--- a/cli/cmd/component-apply.go
+++ b/cli/cmd/component-apply.go
@@ -76,7 +76,8 @@ func runApply(cmd *cobra.Command, args []string) {
 
 	kubeconfig, err := getKubeconfig(contextLogger, lokoConfig, false)
 	if err != nil {
-		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
+		contextLogger.Debugf("Error in finding kubeconfig file: %s", err)
+		contextLogger.Fatal("Suitable kubeconfig file not found. Did you run 'lokoctl cluster apply' ?")
 	}
 
 	if err := applyComponents(lokoConfig, kubeconfig, componentsToApply...); err != nil {

--- a/cli/cmd/component-apply.go
+++ b/cli/cmd/component-apply.go
@@ -47,6 +47,7 @@ var debug bool
 func init() {
 	componentCmd.AddCommand(componentApplyCmd)
 	pf := componentApplyCmd.PersistentFlags()
+	addKubeconfigFileFlag(pf)
 	pf.BoolVarP(&debug, "debug", "", false, "Print debug messages")
 }
 

--- a/cli/cmd/component-apply.go
+++ b/cli/cmd/component-apply.go
@@ -41,8 +41,13 @@ When run with no arguments, all components listed in the configuration are appli
 	},
 }
 
+var debug bool
+
+// nolint:gochecknoinits
 func init() {
 	componentCmd.AddCommand(componentApplyCmd)
+	pf := componentApplyCmd.PersistentFlags()
+	pf.BoolVarP(&debug, "debug", "", false, "Print debug messages")
 }
 
 func runApply(cmd *cobra.Command, args []string) {
@@ -50,6 +55,10 @@ func runApply(cmd *cobra.Command, args []string) {
 		"command": "lokoctl component apply",
 		"args":    args,
 	})
+
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	}
 
 	lokoConfig, diags := getLokoConfig()
 	if len(diags) > 0 {

--- a/cli/cmd/component-apply.go
+++ b/cli/cmd/component-apply.go
@@ -65,7 +65,7 @@ func runApply(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	kubeconfig, err := getKubeconfig()
+	kubeconfig, err := getKubeconfig(contextLogger, lokoConfig, false)
 	if err != nil {
 		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
 	}

--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -48,6 +48,7 @@ func init() {
 	pf := componentDeleteCmd.PersistentFlags()
 	pf.BoolVarP(&deleteNamespace, "delete-namespace", "", false, "Delete namespace with component")
 	pf.BoolVarP(&confirm, "confirm", "", false, "Delete component without asking for confirmation")
+	pf.BoolVarP(&debug, "debug", "", false, "Print debug messages")
 }
 
 func runDelete(cmd *cobra.Command, args []string) {
@@ -55,6 +56,10 @@ func runDelete(cmd *cobra.Command, args []string) {
 		"command": "lokoctl component delete",
 		"args":    args,
 	})
+
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	}
 
 	lokoCfg, diags := getLokoConfig()
 	if len(diags) > 0 {

--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -100,7 +100,8 @@ func runDelete(cmd *cobra.Command, args []string) {
 
 	kubeconfig, err := getKubeconfig(contextLogger, lokoCfg, false)
 	if err != nil {
-		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
+		contextLogger.Debugf("Error in finding kubeconfig file: %s", err)
+		contextLogger.Fatal("Suitable kubeconfig file not found. Did you run 'lokoctl cluster apply' ?")
 	}
 
 	if err := deleteComponents(kubeconfig, componentsObjects...); err != nil {

--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -46,6 +46,7 @@ var deleteNamespace bool
 func init() {
 	componentCmd.AddCommand(componentDeleteCmd)
 	pf := componentDeleteCmd.PersistentFlags()
+	addKubeconfigFileFlag(pf)
 	pf.BoolVarP(&deleteNamespace, "delete-namespace", "", false, "Delete namespace with component")
 	pf.BoolVarP(&confirm, "confirm", "", false, "Delete component without asking for confirmation")
 	pf.BoolVarP(&debug, "debug", "", false, "Print debug messages")

--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -93,7 +93,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	kubeconfig, err := getKubeconfig()
+	kubeconfig, err := getKubeconfig(contextLogger, lokoCfg, false)
 	if err != nil {
 		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
 	}

--- a/cli/cmd/health.go
+++ b/cli/cmd/health.go
@@ -60,7 +60,8 @@ func runHealth(cmd *cobra.Command, args []string) {
 
 	kubeconfig, err := getKubeconfig(contextLogger, lokoConfig, true)
 	if err != nil {
-		contextLogger.Fatalf("Error in finding kubeconfig file: %s", err)
+		contextLogger.Debugf("Error in finding kubeconfig file: %s", err)
+		contextLogger.Fatal("Suitable kubeconfig file not found. Did you run 'lokoctl cluster apply' ?")
 	}
 
 	cs, err := k8sutil.NewClientset(kubeconfig)

--- a/cli/cmd/health.go
+++ b/cli/cmd/health.go
@@ -66,7 +66,7 @@ func runHealth(cmd *cobra.Command, args []string) {
 
 	cs, err := k8sutil.NewClientset(kubeconfig)
 	if err != nil {
-		contextLogger.Fatalf("Error in creating setting up Kubernetes client: %q", err)
+		contextLogger.Fatalf("Error in creating Kubernetes client: %q", err)
 	}
 
 	// We can skip error checking here, as getKubeconfig() already checks it.

--- a/cli/cmd/health.go
+++ b/cli/cmd/health.go
@@ -32,8 +32,11 @@ var healthCmd = &cobra.Command{
 	Run:   runHealth,
 }
 
+// nolint:gochecknoinits
 func init() {
 	RootCmd.AddCommand(healthCmd)
+	pf := healthCmd.PersistentFlags()
+	pf.BoolVarP(&debug, "debug", "", false, "Print debug messages")
 }
 
 func runHealth(cmd *cobra.Command, args []string) {
@@ -41,6 +44,10 @@ func runHealth(cmd *cobra.Command, args []string) {
 		"command": "lokoctl health",
 		"args":    args,
 	})
+
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	}
 
 	lokoConfig, diags := getLokoConfig()
 	if diags.HasErrors() {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	// Register platforms by adding an anonymous import.
@@ -47,13 +48,8 @@ const (
 	kubeconfigFlag = "kubeconfig-file"
 )
 
-func init() {
-	cobra.OnInitialize(cobraInit)
-
-	RootCmd.DisableAutoGenTag = true
-
-	// Add kubeconfig flag.
-	RootCmd.PersistentFlags().String(
+func addKubeconfigFileFlag(pf *flag.FlagSet) {
+	pf.String(
 		kubeconfigFlag,
 		"", // Special empty default, use getKubeconfig()
 		"Path to a kubeconfig file. If empty, the following precedence order is used:\n"+
@@ -61,9 +57,15 @@ func init() {
 			"  2. KUBECONFIG environment variable.\n"+
 			"  3. ~/.kube/config file.")
 
-	if err := viper.BindPFlag(kubeconfigFlag, RootCmd.PersistentFlags().Lookup(kubeconfigFlag)); err != nil {
+	if err := viper.BindPFlag(kubeconfigFlag, pf.Lookup(kubeconfigFlag)); err != nil {
 		panic("failed registering kubeconfig flag")
 	}
+}
+
+func init() { //nolint:gochecknoinits
+	cobra.OnInitialize(cobraInit)
+
+	RootCmd.DisableAutoGenTag = true
 
 	RootCmd.PersistentFlags().String("lokocfg", "./", "Path to lokocfg directory or file")
 	viper.BindPFlag("lokocfg", RootCmd.PersistentFlags().Lookup("lokocfg"))

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -137,9 +137,15 @@ func getKubeconfigSource(contextLogger *logrus.Entry, lokoConfig *config.Config,
 		return nil, fmt.Errorf("loading cluster configuration")
 	}
 
-	// Viper takes precedence over all other options.
-	if path := viper.GetString(kubeconfigFlag); path != "" {
-		return []string{path}, nil
+	for _, k := range viper.AllKeys() {
+		if k != kubeconfigFlag {
+			continue
+		}
+
+		// Viper takes precedence over all other options.
+		if path := viper.GetString(kubeconfigFlag); path != "" {
+			return []string{path}, nil
+		}
 	}
 
 	// If platform is not configured and not required, fallback to global kubeconfig files.

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/mitchellh/go-homedir"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
 	"github.com/kinvolk/lokomotive/pkg/backend"
@@ -30,8 +31,9 @@ import (
 )
 
 const (
-	kubeconfigEnvVariable = "KUBECONFIG"
-	defaultKubeconfigPath = "~/.kube/config"
+	kubeconfigEnvVariable        = "KUBECONFIG"
+	defaultKubeconfigPath        = "~/.kube/config"
+	kubeconfigTerraformOutputKey = "kubeconfig"
 )
 
 // getConfiguredBackend loads a backend from the given configuration file.
@@ -54,15 +56,19 @@ func getConfiguredBackend(lokoConfig *config.Config) (backend.Backend, hcl.Diagn
 }
 
 // getConfiguredPlatform loads a platform from the given configuration file.
-func getConfiguredPlatform() (platform.Platform, hcl.Diagnostics) {
-	lokoConfig, diags := getLokoConfig()
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	if lokoConfig.RootConfig.Cluster == nil {
+func getConfiguredPlatform(lokoConfig *config.Config, require bool) (platform.Platform, hcl.Diagnostics) {
+	if lokoConfig.RootConfig.Cluster == nil && !require {
 		// No cluster defined and no configuration error
 		return nil, hcl.Diagnostics{}
+	}
+
+	if lokoConfig.RootConfig.Cluster == nil && require {
+		return nil, hcl.Diagnostics{
+			{
+				Severity: hcl.DiagError,
+				Summary:  "no platform configured",
+			},
+		}
 	}
 
 	platform, err := platform.GetPlatform(lokoConfig.RootConfig.Cluster.Name)
@@ -77,82 +83,88 @@ func getConfiguredPlatform() (platform.Platform, hcl.Diagnostics) {
 	return platform, platform.LoadConfig(&lokoConfig.RootConfig.Cluster.Config, lokoConfig.EvalContext)
 }
 
-// getAssetDir extracts the asset path from the cluster configuration.
-// It is empty if there is no cluster defined. An error is returned if the
-// cluster configuration has problems.
-func getAssetDir() (string, error) {
-	cfg, diags := getConfiguredPlatform()
-	if diags.HasErrors() {
-		return "", fmt.Errorf("cannot load config: %s", diags)
-	}
-	if cfg == nil {
-		// No cluster defined and no configuration error
-		return "", nil
-	}
-
-	return cfg.Meta().AssetDir, nil
-}
-
-func getKubeconfig() ([]byte, error) {
-	path, err := getKubeconfigPath()
+// getKubeconfig finds the right kubeconfig file to use for an action and returns it's content.
+//
+// If platform is required and user do not have it configured, an error is returned.
+func getKubeconfig(contextLogger *logrus.Entry, lokoConfig *config.Config, platformRequired bool) ([]byte, error) {
+	sources, err := getKubeconfigSource(contextLogger, lokoConfig, platformRequired)
 	if err != nil {
-		return nil, fmt.Errorf("failed getting kubeconfig path: %w", err)
+		return nil, fmt.Errorf("selecting kubeconfig source: %w", err)
 	}
 
-	if expandedPath, err := homedir.Expand(path); err == nil {
-		path = expandedPath
+	// If no sources has been returned, it means we should read from Terraform state.
+	if len(sources) == 0 {
+		return readKubeconfigFromTerraformState(contextLogger)
 	}
 
-	// homedir.Expand is too restrictive for the ~ prefix,
-	// i.e., it errors on "~somepath" which is a valid path,
-	// so just read from the original path.
-	return ioutil.ReadFile(path) // #nosec G304
-}
-
-// getKubeconfig finds the kubeconfig to be used. The precedence is the following:
-// - --kubeconfig-file flag OR KUBECONFIG_FILE environment variable (the latter
-// is a side-effect of cobra/viper and should NOT be documented because it's
-// confusing).
-// - Asset directory from cluster configuration.
-// - KUBECONFIG environment variable.
-// - ~/.kube/config path, which is the default for kubectl.
-func getKubeconfigPath() (string, error) {
-	assetKubeconfig, err := assetsKubeconfigPath()
-	if err != nil {
-		return "", fmt.Errorf("reading kubeconfig path from configuration failed: %w", err)
-	}
-
-	paths := []string{
-		viper.GetString(kubeconfigFlag),
-		assetKubeconfig,
-		os.Getenv(kubeconfigEnvVariable),
-		defaultKubeconfigPath,
-	}
-
-	for _, path := range paths {
-		if path != "" {
-			return path, nil
+	// Select first non-empty source and read it.
+	for _, source := range sources {
+		if source != "" {
+			return expandAndRead(source)
 		}
 	}
 
-	return "", nil
+	// This should never occur, since we always fallback to ~/.kube/config.
+	return nil, fmt.Errorf("no kubeconfig source found")
 }
 
-// assetsKubeconfigPath reads the lokocfg configuration and returns
-// the kubeconfig path defined in it.
+// getKubeconfigSource defines how we select which kubeconfig file to use. If source slice is empty, it means
+// kubeconfig from Terraform state should be used.
 //
-// If no configuration is defined, empty string is returned.
-func assetsKubeconfigPath() (string, error) {
-	assetDir, err := getAssetDir()
-	if err != nil {
-		return "", err
+// If multiple sources are returned, first non-empty should be used.
+//
+// The precedence is the following:
+//
+// - If platform configuration is not required, --kubeconfig-file or KUBECONFIG_FILE environment variable
+// 	 always takes precedence.
+//
+// - Kubeconfig in the assets directory.
+//
+// - If platform is configured, kubeconfig from the Terraform state.
+//
+// - kubeconfig from KUBECONFIG environment variable.
+//
+// - kubeconfig from ~/.kube/config file.
+//
+func getKubeconfigSource(contextLogger *logrus.Entry, lokoConfig *config.Config, platformRequired bool) ([]string, error) { //nolint:lll
+	// Always try reading platform configuration.
+	p, diags := getConfiguredPlatform(lokoConfig, platformRequired)
+	if diags.HasErrors() {
+		for _, diagnostic := range diags {
+			contextLogger.Error(diagnostic.Error())
+		}
+
+		return nil, fmt.Errorf("loading cluster configuration")
 	}
 
-	if assetDir != "" {
-		return assetsKubeconfig(assetDir), nil
+	// Viper takes precedence over all other options.
+	if path := viper.GetString(kubeconfigFlag); path != "" {
+		return []string{path}, nil
 	}
 
-	return "", nil
+	// If platform is not configured and not required, fallback to global kubeconfig files.
+	if p == nil {
+		return []string{
+			os.Getenv(kubeconfigEnvVariable),
+			defaultKubeconfigPath,
+		}, nil
+	}
+
+	// Next, try reading kubeconfig file from assets directory.
+	kubeconfigPath := assetsKubeconfig(p.Meta().AssetDir)
+
+	kubeconfig, err := expandAndRead(kubeconfigPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("reading kubeconfig file %q: %w", kubeconfigPath, err)
+	}
+
+	if len(kubeconfig) != 0 {
+		return []string{kubeconfigPath}, nil
+	}
+
+	// If reading from assets gave no result and platform is defined, let's indicate, that kubeconfig
+	// should be read from the Terraform state, by returning empty source slice.
+	return []string{}, nil
 }
 
 func assetsKubeconfig(assetDir string) string {
@@ -161,6 +173,36 @@ func assetsKubeconfig(assetDir string) string {
 
 func getLokoConfig() (*config.Config, hcl.Diagnostics) {
 	return config.LoadConfig(viper.GetString("lokocfg"), viper.GetString("lokocfg-vars"))
+}
+
+// readKubeconfigFromTerraformState initializes Terraform and
+// reads content of cluster kubeconfig file from the Terraform.
+func readKubeconfigFromTerraformState(contextLogger *logrus.Entry) ([]byte, error) {
+	contextLogger.Warn("Kubeconfig file not found in assets directory, pulling kubeconfig from " +
+		"Terraform state, this might be slow. Run 'lokoctl cluster apply' to fix it.")
+
+	ex, _, _, _ := initialize(contextLogger) //nolint:dogsled
+
+	kubeconfig := ""
+
+	if err := ex.Output(kubeconfigTerraformOutputKey, &kubeconfig); err != nil {
+		return nil, fmt.Errorf("reading kubeconfig file content from Terraform state: %w", err)
+	}
+
+	return []byte(kubeconfig), nil
+}
+
+// expandAndRead optimistically tries to expand ~ in given path and then reads
+// the entire content of the file and returns it to the user.
+func expandAndRead(path string) ([]byte, error) {
+	if expandedPath, err := homedir.Expand(path); err == nil {
+		path = expandedPath
+	}
+
+	// homedir.Expand is too restrictive for the ~ prefix,
+	// i.e., it errors on "~somepath" which is a valid path,
+	// so just read from the original path.
+	return ioutil.ReadFile(path) // #nosec G304
 }
 
 // askForConfirmation asks the user to confirm an action.

--- a/docs/cli/lokoctl.md
+++ b/docs/cli/lokoctl.md
@@ -9,13 +9,9 @@ Manage Lokomotive clusters
 ### Options
 
 ```
-  -h, --help                     help for lokoctl
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+  -h, --help                  help for lokoctl
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_cluster.md
+++ b/docs/cli/lokoctl_cluster.md
@@ -15,12 +15,8 @@ Manage a cluster
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_cluster_apply.md
+++ b/docs/cli/lokoctl_cluster_apply.md
@@ -25,12 +25,8 @@ lokoctl cluster apply [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_cluster_destroy.md
+++ b/docs/cli/lokoctl_cluster_destroy.md
@@ -21,12 +21,8 @@ lokoctl cluster destroy [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_completion.md
+++ b/docs/cli/lokoctl_completion.md
@@ -33,12 +33,8 @@ Generate the completion code for the specified shell
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_completion_bash.md
+++ b/docs/cli/lokoctl_completion_bash.md
@@ -38,12 +38,8 @@ lokoctl completion bash
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_completion_zsh.md
+++ b/docs/cli/lokoctl_completion_zsh.md
@@ -31,12 +31,8 @@ lokoctl completion zsh
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_component.md
+++ b/docs/cli/lokoctl_component.md
@@ -15,12 +15,8 @@ Manage components
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_component_apply.md
+++ b/docs/cli/lokoctl_component_apply.md
@@ -15,19 +15,19 @@ lokoctl component apply [flags]
 ### Options
 
 ```
-      --debug   Print debug messages
-  -h, --help    help for apply
+      --debug                    Print debug messages
+  -h, --help                     help for apply
+      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
+                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
+                                   2. KUBECONFIG environment variable.
+                                   3. ~/.kube/config file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_component_apply.md
+++ b/docs/cli/lokoctl_component_apply.md
@@ -15,7 +15,8 @@ lokoctl component apply [flags]
 ### Options
 
 ```
-  -h, --help   help for apply
+      --debug   Print debug messages
+  -h, --help    help for apply
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/lokoctl_component_delete.md
+++ b/docs/cli/lokoctl_component_delete.md
@@ -15,6 +15,7 @@ lokoctl component delete [flags]
 
 ```
       --confirm            Delete component without asking for confirmation
+      --debug              Print debug messages
       --delete-namespace   Delete namespace with component
   -h, --help               help for delete
 ```

--- a/docs/cli/lokoctl_component_delete.md
+++ b/docs/cli/lokoctl_component_delete.md
@@ -14,21 +14,21 @@ lokoctl component delete [flags]
 ### Options
 
 ```
-      --confirm            Delete component without asking for confirmation
-      --debug              Print debug messages
-      --delete-namespace   Delete namespace with component
-  -h, --help               help for delete
+      --confirm                  Delete component without asking for confirmation
+      --debug                    Print debug messages
+      --delete-namespace         Delete namespace with component
+  -h, --help                     help for delete
+      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
+                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
+                                   2. KUBECONFIG environment variable.
+                                   3. ~/.kube/config file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_component_list.md
+++ b/docs/cli/lokoctl_component_list.md
@@ -19,12 +19,8 @@ lokoctl component list [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_component_render-manifest.md
+++ b/docs/cli/lokoctl_component_render-manifest.md
@@ -19,12 +19,8 @@ lokoctl component render-manifest [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_health.md
+++ b/docs/cli/lokoctl_health.md
@@ -20,12 +20,8 @@ lokoctl health [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/docs/cli/lokoctl_health.md
+++ b/docs/cli/lokoctl_health.md
@@ -13,7 +13,8 @@ lokoctl health [flags]
 ### Options
 
 ```
-  -h, --help   help for health
+      --debug   Print debug messages
+  -h, --help    help for health
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/lokoctl_version.md
+++ b/docs/cli/lokoctl_version.md
@@ -19,12 +19,8 @@ lokoctl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig-file string   Path to a kubeconfig file. If empty, the following precedence order is used:
-                                   1. Cluster asset dir when a lokocfg file is present in the current directory.
-                                   2. KUBECONFIG environment variable.
-                                   3. ~/.kube/config file.
-      --lokocfg string           Path to lokocfg directory or file (default "./")
-      --lokocfg-vars string      Path to lokocfg.vars file (default "./lokocfg.vars")
+      --lokocfg string        Path to lokocfg directory or file (default "./")
+      --lokocfg-vars string   Path to lokocfg.vars file (default "./lokocfg.vars")
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/pkg/platform/aks/template.go
+++ b/pkg/platform/aks/template.go
@@ -223,4 +223,9 @@ output "initialized" {
   value     = true
   sensitive = true
 }
+
+output "kubeconfig" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config_raw
+  sensitive = true
+}
 `

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -259,4 +259,9 @@ output "bootstrap-secrets_values" {
   value     = module.aws-{{.Config.ClusterName}}.bootstrap-secrets_values
   sensitive = true
 }
+
+output "kubeconfig" {
+  value     = module.aws-{{.Config.ClusterName}}.kubeconfig-admin
+  sensitive = true
+}
 `

--- a/pkg/platform/baremetal/template.go
+++ b/pkg/platform/baremetal/template.go
@@ -132,4 +132,9 @@ output "bootstrap-secrets_values" {
   value     = module.bare-metal-{{.ClusterName}}.bootstrap-secrets_values
   sensitive = true
 }
+
+output "kubeconfig" {
+  value     = module.bare-metal-{{.ClusterName}}.kubeconfig-admin
+  sensitive = true
+}
 `

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -326,4 +326,9 @@ output "bootstrap-secrets_values" {
   value     = module.packet-{{.Config.ClusterName}}.bootstrap-secrets_values
   sensitive = true
 }
+
+output "kubeconfig" {
+  value     = module.packet-{{.Config.ClusterName}}.kubeconfig-admin
+  sensitive = true
+}
 `


### PR DESCRIPTION
**This PR includes commits from #631, please review this one first and don't leave commit comments for this PR here.**

TODO:
- [x] Running `lokoctl health` is now slower, as on every run, it initializes the Terraform and reads the output. Should we try to read file from assets dir first and then fallback to Terraform output? Maybe we should cache somehow the `kubeconfig` file content?
- [x] Update and add new tests

Closes #608

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>