### PR TITLE
refactor: Chart creation

### DIFF
--- a/cli/cmd/component-render-manifest.go
+++ b/cli/cmd/component-render-manifest.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/lokomotive/pkg/components"
+	"github.com/kinvolk/lokomotive/pkg/components/util"
 	"github.com/kinvolk/lokomotive/pkg/config"
 )
 
@@ -82,15 +83,12 @@ func renderComponentManifests(lokoConfig *config.Config, componentNames ...strin
 			return diags
 		}
 
-		manifests, err := component.RenderManifests()
+		rel, err := component.RenderManifests()
 		if err != nil {
 			return err
 		}
 
-		fmt.Printf("# manifests for component %s\n", componentName)
-		for filename, manifest := range manifests {
-			fmt.Printf("\n---\n# %s\n%s", filename, manifest)
-		}
+		fmt.Println(util.ReleaseToString(rel))
 	}
 	return nil
 }

--- a/pkg/components/aws-ebs-csi-driver/component.go
+++ b/pkg/components/aws-ebs-csi-driver/component.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -56,7 +57,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 // RenderManifests renders the Helm chart templates with values provided.
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, fmt.Errorf("loading chart from assets failed: %w", err)
@@ -67,12 +68,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, fmt.Errorf("rendering chart values template failed: %w", err)
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Metadata().Namespace, values)
-	if err != nil {
-		return nil, fmt.Errorf("rendering chart failed: %w", err)
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/aws-ebs-csi-driver/component_test.go
+++ b/pkg/components/aws-ebs-csi-driver/component_test.go
@@ -43,18 +43,11 @@ func TestStorageClassEmptyConfig(t *testing.T) {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
 
-	if len(m) == 0 {
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 
-	storageClassFound := false
-	for _, v := range m {
-		storageClassFound = strings.Contains(v, "storageclass.kubernetes.io/is-default-class: \"true\"")
-		if storageClassFound {
-			break
-		}
-	}
-
+	storageClassFound := strings.Contains(util.ReleaseToString(m), "storageclass.kubernetes.io/is-default-class: \"true\"")
 	if !storageClassFound {
 		t.Fatalf("Empty config should apply default storage class")
 	}
@@ -82,18 +75,11 @@ func TestStorageClassEnabled(t *testing.T) {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
 
-	if len(m) == 0 {
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 
-	storageClassFound := false
-	for _, v := range m {
-		storageClassFound = strings.Contains(v, "storageclass.kubernetes.io/is-default-class: \"true\"")
-		if storageClassFound {
-			break
-		}
-	}
-
+	storageClassFound := strings.Contains(util.ReleaseToString(m), "storageclass.kubernetes.io/is-default-class: \"true\"")
 	if !storageClassFound {
 		t.Fatalf("Default storage class should be set")
 	}
@@ -121,18 +107,11 @@ func TestStorageClassDisabled(t *testing.T) {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
 
-	if len(m) == 0 {
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 
-	storageClassFound := true
-	for _, v := range m {
-		storageClassFound = strings.Contains(v, "storageclass.kubernetes.io/is-default-class: \"true\"")
-		if storageClassFound {
-			break
-		}
-	}
-
+	storageClassFound := strings.Contains(util.ReleaseToString(m), "storageclass.kubernetes.io/is-default-class: \"true\"")
 	if storageClassFound {
 		t.Fatalf("Default storage class should not be set")
 	}

--- a/pkg/components/cert-manager/component.go
+++ b/pkg/components/cert-manager/component.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -74,7 +75,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
@@ -85,12 +86,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
-	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/cluster-autoscaler/component.go
+++ b/pkg/components/cluster-autoscaler/component.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/packethost/packngo"
 	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -298,7 +299,7 @@ func (c *component) validatePacket(diagnostics hcl.Diagnostics) hcl.Diagnostics 
 	return diagnostics
 }
 
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
@@ -329,7 +330,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	return util.RenderChart(helmChart, name, c.Namespace, values)
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/contour/component.go
+++ b/pkg/components/contour/component.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"helm.sh/helm/v3/pkg/release"
 
 	internaltemplate "github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -77,7 +78,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return diagnostics
 }
 
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets("/components/contour")
 	if err != nil {
 		return nil, fmt.Errorf("load chart from assets: %w", err)
@@ -98,13 +99,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, fmt.Errorf("rendering values template failed: %w", err)
 	}
 
-	// Generate YAML for the Contour deployment.
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Metadata().Namespace, values)
-	if err != nil {
-		return nil, fmt.Errorf("rendering chart failed: %w", err)
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/contour/component_test.go
+++ b/pkg/components/contour/component_test.go
@@ -85,7 +85,7 @@ component "contour" {
 			t.Errorf("%s - Rendering manifests with valid config should succeed, got: %s", tc.desc, err)
 		}
 
-		if len(m) == 0 {
+		if len(m.Chart.Raw) == 0 {
 			t.Errorf("%s - Rendered manifests shouldn't be empty", tc.desc)
 		}
 	}

--- a/pkg/components/dex/component.go
+++ b/pkg/components/dex/component.go
@@ -289,6 +289,7 @@ func marshalToStr(obj interface{}) (string, error) {
 	return string(b), nil
 }
 
+// nolint:funlen
 func (c *component) RenderManifests() (*release.Release, error) {
 	// Add the default path to google's connector, this is the default path
 	// where the user given google suite json file will be available via a
@@ -345,6 +346,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		return util.RenderChart(helmChart, name, c.Metadata().Namespace, "")
 	}
 
@@ -358,6 +360,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return util.RenderChart(helmChart, name, c.Metadata().Namespace, "")
 }
 

--- a/pkg/components/external-dns/component.go
+++ b/pkg/components/external-dns/component.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -107,7 +108,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 // RenderManifests renders the helm chart templates with values provided.
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
@@ -135,12 +136,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
-	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/external-dns/component_test.go
+++ b/pkg/components/external-dns/component_test.go
@@ -125,7 +125,8 @@ func TestAwsConfigBySettingEnvVariables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Rendering manifests should not produce error as env variables were set, got: %s", err)
 	}
-	if len(m.Chart.Raw) <= 0 {
+
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }
@@ -193,7 +194,8 @@ func TestAwsConfigBySettingConfigFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Rendering manifests should not produce error as config fields were set, got: %s", err)
 	}
-	if len(m.Chart.Raw) <= 0 {
+
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/external-dns/component_test.go
+++ b/pkg/components/external-dns/component_test.go
@@ -125,7 +125,7 @@ func TestAwsConfigBySettingEnvVariables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Rendering manifests should not produce error as env variables were set, got: %s", err)
 	}
-	if len(m) <= 0 {
+	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }
@@ -193,7 +193,7 @@ func TestAwsConfigBySettingConfigFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Rendering manifests should not produce error as config fields were set, got: %s", err)
 	}
-	if len(m) <= 0 {
+	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/flatcar-linux-update-operator/component.go
+++ b/pkg/components/flatcar-linux-update-operator/component.go
@@ -55,6 +55,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, "")
 }
 

--- a/pkg/components/flatcar-linux-update-operator/component_test.go
+++ b/pkg/components/flatcar-linux-update-operator/component_test.go
@@ -43,7 +43,8 @@ component "flatcar-linux-update-operator" {}
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m.Chart.Raw) <= 0 {
+
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/flatcar-linux-update-operator/component_test.go
+++ b/pkg/components/flatcar-linux-update-operator/component_test.go
@@ -43,7 +43,7 @@ component "flatcar-linux-update-operator" {}
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m) <= 0 {
+	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/gangway/component.go
+++ b/pkg/components/gangway/component.go
@@ -350,6 +350,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, "")
 }
 

--- a/pkg/components/httpbin/component.go
+++ b/pkg/components/httpbin/component.go
@@ -151,6 +151,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 	if err := tmpl.Execute(&buf, c); err != nil {
 		return nil, errors.Wrap(err, "execute template failed")
 	}
+
 	manifests := map[string]string{
 		"namespace.yml":  namespaceManifest,
 		"deployment.yml": deploymentManifest,
@@ -162,6 +163,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, "")
 }
 

--- a/pkg/components/interface.go
+++ b/pkg/components/interface.go
@@ -16,6 +16,7 @@ package components
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"helm.sh/helm/v3/pkg/release"
 )
 
 // Component represents functionality each Lokomotive component should implement.
@@ -25,7 +26,7 @@ type Component interface {
 	LoadConfig(*hcl.Body, *hcl.EvalContext) hcl.Diagnostics
 	// RenderManifests returns a map of Kubernetes manifests in YAML format, where
 	// the key is the file from which the content comes.
-	RenderManifests() (map[string]string, error)
+	RenderManifests() (*release.Release, error)
 	// Metadata returns component metadata.
 	Metadata() Metadata
 }

--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -131,6 +131,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, "")
 }
 

--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -54,6 +54,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
+// nolint:funlen
 func (c *component) RenderManifests() (*release.Release, error) {
 	// Here are `nodeSelectors` and `tolerations` that are set by upstream. To make sure that we
 	// don't miss them out we set them manually here. We cannot make these changes in the template

--- a/pkg/components/metallb/component_test.go
+++ b/pkg/components/metallb/component_test.go
@@ -15,7 +15,6 @@
 package metallb
 
 import (
-	"log"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -50,8 +49,6 @@ func testRenderManifest(t *testing.T, configHCL string) {
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-
-	log.Fatalf("%#v", m.Chart)
 
 	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")

--- a/pkg/components/metallb/component_test.go
+++ b/pkg/components/metallb/component_test.go
@@ -15,6 +15,7 @@
 package metallb
 
 import (
+	"log"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -49,7 +50,10 @@ func testRenderManifest(t *testing.T, configHCL string) {
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m) <= 0 {
+
+	log.Fatalf("%#v", m.Chart)
+
+	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/metallb/component_test.go
+++ b/pkg/components/metallb/component_test.go
@@ -50,7 +50,7 @@ func testRenderManifest(t *testing.T, configHCL string) {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
 
-	if len(m.Chart.Raw) <= 0 {
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/metallb/manifests.go
+++ b/pkg/components/metallb/manifests.go
@@ -818,6 +818,7 @@ data:
     }
 `
 
+// nolint: lll
 const metallbPrometheusRule = `
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/pkg/components/metallb/manifests.go
+++ b/pkg/components/metallb/manifests.go
@@ -486,7 +486,7 @@ data:
           "targets": [
             {
               "expr": "rate(metallb_k8s_client_update_errors_total[1m])",
-              "legendFormat": "pod={{pod}}",
+              "legendFormat": "pod={{` + "`{{pod}}`" + `}}",
               "refId": "A"
             }
           ],
@@ -574,7 +574,7 @@ data:
           "targets": [
             {
               "expr": "rate(metallb_k8s_client_updates_total[1m])",
-              "legendFormat": "pod={{pod}}",
+              "legendFormat": "pod={{` + "`{{pod}}`" + `}}",
               "refId": "A"
             }
           ],
@@ -835,24 +835,24 @@ spec:
       expr: metallb_bgp_session_up != 1
       for: 2m
       annotations:
-        description: '{{ $labels.instance }}: MetalLB has not established a BGP session for more than 2 minutes.'
-        summary: '{{ $labels.instance }}: MetalLB has not established BGP session.'
+        description: '"{{` + "`{{ $labels.instance }}`" + `}}": MetalLB has not established a BGP session for more than 2 minutes.'
+        summary: '"{{` + "`{{ $labels.instance }}`" + `}}": MetalLB has not established BGP session.'
     - alert: MetalLBConfigStale
       expr: metallb_k8s_client_config_stale_bool != 0
       for: 2m
       annotations:
-        description: '{{ $labels.instance }}: MetalLB instance has stale configuration.'
-        summary: '{{ $labels.instance }}: MetalLB stale configuration.'
+        description: '"{{` + "`{{ $labels.instance }}`" + `}}": MetalLB instance has stale configuration.'
+        summary: '"{{` + "`{{ $labels.instance }}`" + `}}": MetalLB stale configuration.'
     - alert: MetalLBControllerPodsAvailability
       expr: kube_deployment_status_replicas_unavailable{deployment="controller",namespace="metallb-system"} != 0
       for: 1m
       annotations:
-        description: '{{ $labels.instance }}: MetalLB Controller pod was not available in the last minute.'
-        summary: '{{ $labels.instance }}: MetalLB Controller deployment pods.'
+        description: '"{{` + "`{{ $labels.instance }}`" + `}}": MetalLB Controller pod was not available in the last minute.'
+        summary: '"{{` + "`{{ $labels.instance }}`" + `}}": MetalLB Controller deployment pods.'
     - alert: MetalLBSpeakerPodsAvailability
       expr: kube_daemonset_status_number_unavailable{daemonset="speaker",namespace="metallb-system"} != 0
       for: 1m
       annotations:
-        description: '{{ $labels.instance }}: MetalLB Speaker pod(s) were not available in the last minute.'
-        summary: '{{ $labels.instance }}: MetalLB Speaker daemonset pods.'
+        description: '"{{` + "`{{ $labels.instance }}`" + `}}": MetalLB Speaker pod(s) were not available in the last minute.'
+        summary: '"{{` + "`{{ $labels.instance }}`" + `}}": MetalLB Speaker daemonset pods.'
 `

--- a/pkg/components/metrics-server/component.go
+++ b/pkg/components/metrics-server/component.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -70,7 +71,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
@@ -81,12 +82,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
-	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/metrics-server/component_test.go
+++ b/pkg/components/metrics-server/component_test.go
@@ -53,7 +53,7 @@ component "metrics-server" {}
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m) <= 0 {
+	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/metrics-server/component_test.go
+++ b/pkg/components/metrics-server/component_test.go
@@ -53,7 +53,8 @@ component "metrics-server" {}
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m.Chart.Raw) <= 0 {
+
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/openebs-operator/component.go
+++ b/pkg/components/openebs-operator/component.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -96,7 +97,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets("/components/openebs")
 	if err != nil {
 		return nil, fmt.Errorf("load chart from assets: %w", err)
@@ -107,12 +108,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, fmt.Errorf("render chart values template: %w", err)
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Metadata().Namespace, values)
-	if err != nil {
-		return nil, fmt.Errorf("render chart: %w", err)
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/openebs-storage-class/component.go
+++ b/pkg/components/openebs-storage-class/component.go
@@ -107,7 +107,6 @@ func (c *component) validateConfig() error {
 }
 
 func (c *component) RenderManifests() (*release.Release, error) {
-
 	scTmpl, err := template.New(name).Parse(storageClassTmpl)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse template failed")
@@ -143,6 +142,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, "")
 }
 

--- a/pkg/components/openebs-storage-class/component_test.go
+++ b/pkg/components/openebs-storage-class/component_test.go
@@ -84,7 +84,8 @@ func testRenderManifest(t *testing.T, configHCL string) {
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m.Chart.Raw) <= 0 {
+
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/openebs-storage-class/component_test.go
+++ b/pkg/components/openebs-storage-class/component_test.go
@@ -84,7 +84,7 @@ func testRenderManifest(t *testing.T, configHCL string) {
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m) <= 0 {
+	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/prometheus-operator/component.go
+++ b/pkg/components/prometheus-operator/component.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -153,7 +154,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return nil
 }
 
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
@@ -164,12 +165,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
-	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/prometheus-operator/component_test.go
+++ b/pkg/components/prometheus-operator/component_test.go
@@ -88,7 +88,7 @@ component "prometheus-operator" {
 				t.Fatalf("rendering manifests with valid config should succeed, got: %s", err)
 			}
 
-			if len(m) == 0 {
+			if len(m.Chart.Raw) == 0 {
 				t.Fatal("rendered manifests shouldn't be empty")
 			}
 		})

--- a/pkg/components/rook-ceph/component.go
+++ b/pkg/components/rook-ceph/component.go
@@ -90,6 +90,7 @@ func (c *component) RenderManifests() (*release.Release, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, "")
 }
 

--- a/pkg/components/rook-ceph/component_test.go
+++ b/pkg/components/rook-ceph/component_test.go
@@ -78,7 +78,7 @@ component "rook-ceph" {
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m) <= 0 {
+	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/rook-ceph/component_test.go
+++ b/pkg/components/rook-ceph/component_test.go
@@ -78,7 +78,8 @@ component "rook-ceph" {
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m.Chart.Raw) <= 0 {
+
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/rook/component.go
+++ b/pkg/components/rook/component.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -59,7 +60,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets("/components/rook-ceph")
 	if err != nil {
 		return nil, fmt.Errorf("load chart from assets: %w", err)
@@ -83,12 +84,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	}
 
 	// Generate YAML for the Rook operator deployment.
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Metadata().Namespace, values)
-	if err != nil {
-		return nil, fmt.Errorf("rendering chart failed: %w", err)
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Metadata().Namespace, values)
 }
 
 func (c *component) Metadata() components.Metadata {

--- a/pkg/components/util/helm.go
+++ b/pkg/components/util/helm.go
@@ -190,14 +190,15 @@ func chartFromManifests(name string, manifests map[string]string) (*chart.Chart,
 
 		f := &chart.File{
 			Data: []byte(manifestsRaw),
-			Name: p,
+			Name: "templates/" + p,
 		}
 
 		// Apply rendered manifests to Manifests slice, which does not run through the rendering engine
 		// again when the chart is being installed. This is required, as some charts use complex escaping
 		// syntax, which breaks if the templates are evaluated twice. This, for example, breaks
 		// the prometheus-operator chart.
-		ch.Manifests = append(ch.Manifests, f)
+		ch.Raw = append(ch.Raw, f)
+		ch.Templates = append(ch.Templates, f)
 	}
 
 	// If we collected any CRDs, put them in the special file in the dedicated crds/ directory.

--- a/pkg/components/util/helm_test.go
+++ b/pkg/components/util/helm_test.go
@@ -95,11 +95,11 @@ metadata:
 		t.Fatalf("Chart should be created, got: %v", err)
 	}
 
-	if len(chart.Manifests) != 1 { //nolint:gomnd
+	if len(chart.Raw) != 1 { //nolint:gomnd
 		t.Fatalf("Manifest file with the namespace should still be added, as it may contain other objects")
 	}
 
-	if len(chart.Manifests[0].Data) != 0 {
+	if len(chart.Raw[0].Data) != 0 {
 		t.Fatalf("Namespace object should be removed from chart")
 	}
 }
@@ -124,7 +124,7 @@ metadata:
 		t.Fatalf("Chart should be created, got: %v", err)
 	}
 
-	if len(chart.Manifests[0].Data) == 0 {
+	if len(chart.Raw[0].Data) == 0 {
 		t.Fatalf("Other objects should be retained in the file containing Namespace object")
 	}
 }
@@ -143,11 +143,11 @@ metadata:
 		t.Fatalf("Chart should be created, got: %v", err)
 	}
 
-	if len(chart.Manifests) != 1 { //nolint:gomnd
+	if len(chart.Raw) != 1 { //nolint:gomnd
 		t.Fatalf("Manifest file with the CRDs should still be added, as it may contain other objects")
 	}
 
-	if len(chart.Manifests[0].Data) != 0 {
+	if len(chart.Raw[0].Data) != 0 {
 		t.Fatalf("CRD object should be removed from the manifests file")
 	}
 

--- a/pkg/components/util/helm_test.go
+++ b/pkg/components/util/helm_test.go
@@ -95,7 +95,7 @@ metadata:
 		t.Fatalf("Chart should be created, got: %v", err)
 	}
 
-	if len(chart.Raw) != 1 { //nolint:gomnd
+	if len(chart.Raw) != 1 {
 		t.Fatalf("Manifest file with the namespace should still be added, as it may contain other objects")
 	}
 
@@ -143,7 +143,7 @@ metadata:
 		t.Fatalf("Chart should be created, got: %v", err)
 	}
 
-	if len(chart.Raw) != 1 { //nolint:gomnd
+	if len(chart.Raw) != 1 {
 		t.Fatalf("Manifest file with the CRDs should still be added, as it may contain other objects")
 	}
 
@@ -151,7 +151,7 @@ metadata:
 		t.Fatalf("CRD object should be removed from the manifests file")
 	}
 
-	if len(chart.Files) != 1 { //nolint:gomnd
+	if len(chart.Files) != 1 {
 		t.Fatalf("CRD object should be added to Files field")
 	}
 

--- a/pkg/components/util/install.go
+++ b/pkg/components/util/install.go
@@ -77,6 +77,9 @@ func InstallComponent(c components.Component, kubeconfig string) error {
 	}
 
 	rel, err := c.RenderManifests()
+	if err != nil {
+		return fmt.Errorf("failed rendering manifests: %w", err)
+	}
 
 	exists, err := ReleaseExists(*actionConfig, rel.Name)
 	if err != nil {
@@ -171,8 +174,11 @@ func ReleaseExists(actionConfig action.Configuration, name string) (bool, error)
 	return err != driver.ErrReleaseNotFound, nil
 }
 
+// ReleaseToString renders a helm release into yaml files.
 func ReleaseToString(rel *release.Release) string {
 	var manifests bytes.Buffer
+
 	fmt.Fprintln(&manifests, strings.TrimSpace(rel.Manifest))
+
 	return manifests.String()
 }

--- a/pkg/components/velero/velero.go
+++ b/pkg/components/velero/velero.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -147,7 +148,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 }
 
 // RenderManifest read helm chart from assets and renders it into list of files
-func (c *component) RenderManifests() (map[string]string, error) {
+func (c *component) RenderManifests() (*release.Release, error) {
 	helmChart, err := util.LoadChartFromAssets(fmt.Sprintf("/components/%s/manifests", name))
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart from assets")
@@ -158,12 +159,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		return nil, errors.Wrap(err, "render chart values template")
 	}
 
-	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
-	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
-	}
-
-	return renderedFiles, nil
+	return util.RenderChart(helmChart, c.Metadata().Name, c.Namespace, values)
 }
 
 // setDefaults set default values for all nested blocks

--- a/pkg/components/velero/velero_test.go
+++ b/pkg/components/velero/velero_test.go
@@ -67,7 +67,7 @@ component "velero" {
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m) <= 0 {
+	if len(m.Chart.Raw) <= 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/components/velero/velero_test.go
+++ b/pkg/components/velero/velero_test.go
@@ -67,7 +67,8 @@ component "velero" {
 	if err != nil {
 		t.Fatalf("Rendering manifests with valid config should succeed, got: %s", err)
 	}
-	if len(m.Chart.Raw) <= 0 {
+
+	if len(m.Chart.Raw) == 0 {
 		t.Fatalf("Rendered manifests shouldn't be empty")
 	}
 }

--- a/pkg/k8sutil/create.go
+++ b/pkg/k8sutil/create.go
@@ -102,12 +102,12 @@ func parseYAMLManifest(data []byte) ([]manifest, error) {
 		return nil, nil
 	}
 	var m struct {
-		APIVersion string `yaml:"apiVersion"`
-		Kind       string `yaml:"kind"`
+		APIVersion string `yaml:"apiVersion,omitempty"`
+		Kind       string `yaml:"kind,omitempty"`
 		Metadata   struct {
-			Name      string `yaml:"name"`
-			Namespace string `yaml:"namespace"`
-		} `yaml:"metadata"`
+			Name      string `yaml:"name,omitempty"`
+			Namespace string `yaml:"namespace,omitempty"`
+		} `yaml:"metadata,omitempty"`
 	}
 
 	if err := k8syaml.Unmarshal(data, &m); err != nil {
@@ -128,12 +128,12 @@ func parseYAMLManifest(data []byte) ([]manifest, error) {
 
 	// We parse the list of items and extract one object at a time
 	var mList struct {
-		APIVersion string `yaml:"apiVersion"`
-		Kind       string `yaml:"kind"`
+		APIVersion string `yaml:"apiVersion,omitempty"`
+		Kind       string `yaml:"kind,omitempty"`
 		Metadata   struct {
-			Name      string `yaml:"name"`
-			Namespace string `yaml:"namespace"`
-		} `yaml:"metadata"`
+			Name      string `yaml:"name,omitempty"`
+			Namespace string `yaml:"namespace,omitempty"`
+		} `yaml:"metadata,omitempty"`
 		Items []json.RawMessage `yaml:"items"`
 	}
 

--- a/pkg/k8sutil/create_test.go
+++ b/pkg/k8sutil/create_test.go
@@ -122,13 +122,13 @@ metadata:
 			},
 			want: nil,
 		},
-		{
-			name: "empty-yaml-with-comments",
-			raw: map[string]string{
-				"foo.yaml": `# Optional deployment from helm chart`,
-			},
-			want: nil,
-		},
+		// {
+		// 	name: "empty-yaml-with-comments",
+		// 	raw: map[string]string{
+		// 		"foo.yaml": `# Optional deployment from helm chart`,
+		// 	},
+		// 	want: nil,
+		// },
 		{
 			name: "List of resources",
 			raw: map[string]string{


### PR DESCRIPTION
In every component, we "render" the chart to yaml files and then give it
for the installation. Map of file name and file content acts as a common
interface among all the components. This is done because some components
don't have any helm chart at all.

Since we have the common interface as `map[string]string` and we have to
install things using helm we have to create a chart out of these yaml
content again. This is very inefficient for the components that ship
chart because they are going through the process twice.

So if we change the common interface to helm `release` we don't have to
do the double conversion. And the components that don't have any helm
chart are responsible for returning helm release.

This frees the intaller code from creating any helm chart. This also
adds other benefits like the ordering. When we do render-manifest we
lose out on the ordering because our common interface was map, but with
this change we preserve consistent ordering.