### PR TITLE
prometheus-operator: Fix the redirects

### DIFF
--- a/pkg/components/prometheus-operator/template.go
+++ b/pkg/components/prometheus-operator/template.go
@@ -117,7 +117,7 @@ prometheus:
   {{ end }}
   prometheusSpec:
     {{ if .Prometheus.Ingress }}
-    externalUrl: {{.Prometheus.Ingress.Host}}
+    externalUrl: https://{{.Prometheus.Ingress.Host}}
     {{ end }}
     {{ if .Prometheus.NodeSelector }}
     nodeSelector:


### PR DESCRIPTION
Add the http scheme to the `externalUrl` field to avoid redirects when deployed.

Fixes: https://github.com/kinvolk/lokomotive/issues/729