### PR TITLE
Packet Quickstart: add machine types to the example config

### DIFF
--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -116,6 +116,8 @@ cluster "packet" {
   facility = "ams1"
   project_id = "89273817-4f44-4b41-9f0c-cb00bf538542"
 
+  controller_type = "c3.small.x86"
+
   ssh_pubkeys       = ["ssh-rsa AAAA..."]
   management_cidrs  = ["0.0.0.0/0"]
   node_private_cidr = "10.0.0.0/8"
@@ -124,6 +126,7 @@ cluster "packet" {
 
   worker_pool "pool-1" {
     count       = 2
+    node_type = "c3.small.x86"
   }
 }
 


### PR DESCRIPTION
Currently it's not possible to deploy the latest lokomotive release on Packet without specifying the machine type. Figuring out the right parameters in the config takes a while. Make this easier by adding them to the example config.