### PR TITLE
Make it obvious that cert-manager is required

### DIFF
--- a/docs/configuration-reference/components/prometheus-operator.md
+++ b/docs/configuration-reference/components/prometheus-operator.md
@@ -23,6 +23,10 @@ instances.
   [built-in](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes)
   plugins.
 
+* An ingress controller such as [Contour](contour.md) for HTTP ingress.
+
+* The [cert-manager component](cert-manager.md) is required for enabling HTTPS.
+
 ## Configuration
 
 Prometheus Operator component configuration example:


### PR DESCRIPTION
When installing the prometheus-operator component, the instructions don't mention that the cert-manager component is needed if HTTPS is going to work. The example config assumes there is such a cert as it includes a `certmanager_cluster_issuer = "letsencrypt-production"` line, but doesn't point to the separate component.

This commit adds a link to the component as a requirement. I wasn't sure on the exact wording. Better wording welcome.