### PR TITLE
Fix link to the dex component reference

### DIFF
--- a/docs/how-to-guides/authentication-with-dex-gangway.md
+++ b/docs/how-to-guides/authentication-with-dex-gangway.md
@@ -330,7 +330,7 @@ Verify you've configured RBAC correctly in step 7.
 ## Additional resources
 
 To configure authentication with Google as an identity provider,visit the [Dex component
-documentation](../../configuration-reference/components/dex.md) for configuration changes.
+documentation](../configuration-reference/components/dex.md) for configuration changes.
 
 For more information about OpenID Connect, see [OpenID Connect](https://openid.net/connect)
 website.


### PR DESCRIPTION
The link is currently broken because it has two ../ instead of just one.