### PR TITLE
pkg/components/util: only filter release namespace

### DIFF
--- a/pkg/components/util/helm.go
+++ b/pkg/components/util/helm.go
@@ -159,7 +159,7 @@ func chartFromComponent(c components.Component) (*chart.Chart, error) {
 		return nil, fmt.Errorf("rendering manifests failed: %w", err)
 	}
 
-	ch, err := chartFromManifests(c.Metadata().Name, m)
+	ch, err := chartFromManifests(c.Metadata(), m)
 	if err != nil {
 		return nil, fmt.Errorf("creating chart from manifests failed: %w", err)
 	}
@@ -172,11 +172,11 @@ func chartFromComponent(c components.Component) (*chart.Chart, error) {
 }
 
 // chartFromManifests creates Helm chart object in memory from given manifests.
-func chartFromManifests(name string, manifests map[string]string) (*chart.Chart, error) {
+func chartFromManifests(metadata components.Metadata, manifests map[string]string) (*chart.Chart, error) {
 	ch := &chart.Chart{
 		Metadata: &chart.Metadata{
 			APIVersion: chart.APIVersionV2,
-			Name:       name,
+			Name:       metadata.Name,
 			// TODO Remove hardcode version, which is installed.
 			Version: "0.1.0",
 		},
@@ -202,8 +202,7 @@ func chartFromManifests(name string, manifests map[string]string) (*chart.Chart,
 			}
 
 			// Drop Namespace resource as we take care of its creation at another level and we don't want resources to collide.
-			// TODO: Remove only the namespace in which the chart is installed.
-			if pm.Kind() == "Namespace" {
+			if pm.Kind() == "Namespace" && pm.Name() == metadata.Namespace {
 				continue
 			}
 

--- a/pkg/k8sutil/create.go
+++ b/pkg/k8sutil/create.go
@@ -55,6 +55,10 @@ func (m manifest) Raw() []byte {
 	return m.raw
 }
 
+func (m manifest) Name() string {
+	return m.name
+}
+
 // LoadManifests parses a map of Kubernetes manifests.
 func LoadManifests(files map[string]string) ([]manifest, error) {
 	var manifests []manifest


### PR DESCRIPTION
As part of upstream Helm chart sanitization, we remove all Namespace
objects, as we create them manually before the release is installed,
otherwise Helm will complain. This is the solution from times, where
charts were not updates to not include or conditionally include the
namespace and Helm (v2) was storing all release objects in kube-system
namespace.

This commit changes this behavior to only filter single namespace
object, which is where we will be installing the release. This patch
aims to fix the installation of charts, which spans across multiple
namespaces like for example linkerd.

Right now, many helm charts offers an option to disable namespace
creation already, which we should eventually utilize and disable the
filtering completely, as it is confusing and brings non-obvious results,
especially when comparing 'lokoctl component install' with 'helm
install'. However, this is out of scope for this changeset.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>