### PR TITLE
test/components/prometheus-operator: reduce test timeout

### DIFF
--- a/test/components/prometheus-operator/prometheus_operator_test.go
+++ b/test/components/prometheus-operator/prometheus_operator_test.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	retryInterval     = time.Second * 5
-	timeout           = time.Minute * 10
+	timeout           = time.Minute * 9
 	namespace         = "monitoring"
 	grafanaDeployment = "prometheus-operator-grafana"
 )


### PR DESCRIPTION
As global 'go test' timeout is 10 minutes, having 10 minutes here as
well results in triggering the panic caused by global timeout.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>