### PR TITLE
Refactor Terraform executor

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -61,37 +61,39 @@ func (c *Config) Validate() error {
 	return fmt.Errorf("invalid DNS provider %q", c.Provider)
 }
 
-// AskToConfigure reads the required DNS entries from a Terraform output,
-// asks the user to configure them and checks if the configuration is correct.
-func (c *Config) AskToConfigure(ex *terraform.Executor) error {
-	dnsEntries, err := readDNSEntries(ex)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Please configure the following DNS entries at the DNS provider which hosts %q:\n", c.Zone)
-	prettyPrintDNSEntries(dnsEntries)
-
-	for {
-		fmt.Printf("Press Enter to check the entries or type \"skip\" to continue the installation: ")
-
-		var input string
-		fmt.Scanln(&input)
-
-		if input == "skip" {
-			break
-		} else if input != "" {
-			continue
+// ManualConfigPrompt returns a terraform.ExecutionHook which prompts the user to configure DNS
+// entries manually and verifies the entries were created successfully.
+func (c *Config) ManualConfigPrompt() terraform.ExecutionHook {
+	return func(ex *terraform.Executor) error {
+		dnsEntries, err := readDNSEntries(ex)
+		if err != nil {
+			return err
 		}
 
-		if checkDNSEntries(dnsEntries) {
-			break
+		fmt.Printf("Please configure the following DNS entries at the DNS provider which hosts %q:\n", c.Zone)
+		prettyPrintDNSEntries(dnsEntries)
+
+		for {
+			fmt.Printf("Press Enter to check the entries or type \"skip\" to continue the installation: ")
+
+			var input string
+			fmt.Scanln(&input)
+
+			if input == "skip" {
+				break
+			} else if input != "" {
+				continue
+			}
+
+			if checkDNSEntries(dnsEntries) {
+				break
+			}
+
+			fmt.Println("Entries are not correctly configured, please verify.")
 		}
 
-		fmt.Println("Entries are not correctly configured, please verify.")
+		return nil
 	}
-
-	return nil
 }
 
 func readDNSEntries(ex *terraform.Executor) ([]dnsEntry, error) {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -107,7 +107,7 @@ func (c *Config) ManualConfigPrompt() terraform.ExecutionHook {
 }
 
 func readDNSEntries(ex *terraform.Executor) ([]dnsEntry, error) {
-	output, err := ex.ExecuteSync("output", "-json", "dns_entries")
+	output, err := ex.OutputBytes("dns_entries")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get DNS entries")
 	}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -15,11 +15,14 @@
 package dns
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/kinvolk/lokomotive/pkg/terraform"
 	"github.com/pkg/errors"
@@ -77,11 +80,18 @@ func (c *Config) ManualConfigPrompt() terraform.ExecutionHook {
 			fmt.Printf("Press Enter to check the entries or type \"skip\" to continue the installation: ")
 
 			var input string
-			fmt.Scanln(&input)
 
-			if input == "skip" {
+			reader := bufio.NewReader(os.Stdin)
+
+			input, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("reading user input: %w", err)
+			}
+
+			v := strings.TrimSpace(input)
+			if v == "skip" {
 				break
-			} else if input != "" {
+			} else if v != "" {
 				continue
 			}
 

--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -70,6 +70,34 @@ const (
 	ExecutionStatusFailure ExecutionStatus = "Failure"
 )
 
+// ExecutionHook represents a callback function which should be run prior to executing a Terraform
+// operation.
+type ExecutionHook func(*Executor) error
+
+// ExecutionStep represents a single Terraform operation.
+type ExecutionStep struct {
+	// A short string describing the step in a way that is meaningful to the user. The string
+	// should begin with a lowercase letter, be in the imperative tense and have no period at the
+	// end.
+	//
+	// Examples:
+	// - "create DNS resources"
+	// - "deploy virtual machines"
+	Description string
+	// A list of arguments to be passed to the `terraform` command. Note that for "apply"
+	// operations the "-auto-approve" argument should always be included to avoid halting the
+	// Terraform execution with interactive prompts.
+	//
+	// Examples:
+	// - []string{"apply", "-target=module.foo", "-auto-approve"}
+	// - []string{"refresh"}
+	// - []string{"apply", "-auto-approve"}
+	Args []string
+	// A function which should be run prior to executing the Terraform operation. If specified and
+	// the function returns an error, execution is halted.
+	PreExecutionHook ExecutionHook
+}
+
 // Executor enables calling Terraform from Go, across platforms, with any
 // additional providers/provisioners that the currently executing binary
 // exposes.
@@ -126,25 +154,28 @@ func NewExecutor(conf Config) (*Executor, error) {
 	return ex, nil
 }
 
-// Init() is a wrapper function that runs
-// `terraform init`.
+// Init is a wrapper function that runs `terraform init`.
 func (ex *Executor) Init() error {
-	ex.logger.Println("Initializing Terraform working directory")
-	return ex.Execute("init")
+	return ex.Execute(ExecutionStep{
+		Description: "initialize Terraform",
+		Args:        []string{"init"},
+	})
 }
 
-// Apply() is a wrapper function that runs
-// `terraform apply -auto-approve`.
+// Apply is a wrapper function that runs `terraform apply -auto-approve`.
 func (ex *Executor) Apply() error {
-	ex.logger.Println("Applying Terraform configuration. This creates infrastructure so it might take a long time...")
-	return ex.Execute("apply", "-auto-approve")
+	return ex.Execute(ExecutionStep{
+		Description: "create infrastructure",
+		Args:        []string{"apply", "-auto-approve"},
+	})
 }
 
-// Destroy() is a wrapper function that runs
-// `terraform destroy -auto-approve`.
+// Destroy is a wrapper function that runs `terraform destroy -auto-approve`.
 func (ex *Executor) Destroy() error {
-	ex.logger.Println("Destroying Terraform-managed infrastructure")
-	return ex.Execute("destroy", "-auto-approve")
+	return ex.Execute(ExecutionStep{
+		Description: "destroy infrastructure",
+		Args:        []string{"destroy", "-auto-approve"},
+	})
 }
 
 // tailFile will indefinitely tail logs from the given file path, until
@@ -176,14 +207,27 @@ func tailFile(path string, done chan struct{}, wg *sync.WaitGroup) {
 	wg.Done()
 }
 
-// Execute runs the given command and arguments against Terraform, and returns
-// any errors that occur during the execution.
-//
-// An error is returned if the Terraform binary could not be found, or if the
-// Terraform call itself failed, in which case, details can be found in the
-// output.
-func (ex *Executor) Execute(args ...string) error {
-	return ex.execute(ex.verbose, args...)
+// Execute accepts one or more ExecutionSteps and executes them sequentially in the order they were
+// provided. If a step has a PreExecutionHook defined, the hook is run prior to executing the step.
+// If any error is encountered, the error is returned and the execution is halted.
+func (ex *Executor) Execute(steps ...ExecutionStep) error {
+	for _, s := range steps {
+		if s.PreExecutionHook != nil {
+			ex.logger.Printf("Running pre-execution hook for step %q", s.Description)
+
+			if err := s.PreExecutionHook(ex); err != nil {
+				return fmt.Errorf("running pre-execution hook: %w", err)
+			}
+		}
+
+		ex.logger.Printf("Executing step %q", s.Description)
+
+		if err := ex.execute(ex.verbose, s.Args...); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (ex *Executor) executeVerbose(args ...string) error {
@@ -193,7 +237,10 @@ func (ex *Executor) executeVerbose(args ...string) error {
 func (ex *Executor) execute(verbose bool, args ...string) error {
 	pid, done, err := ex.ExecuteAsync(args...)
 	if err != nil {
-		return fmt.Errorf("failed executing Terraform command with arguments '%s' in directory %s: %w", strings.Join(args, " "), ex.WorkingDirectory(), err)
+		return fmt.Errorf(
+			"executing Terraform with arguments '%s' in directory %s: %w",
+			strings.Join(args, " "), ex.WorkingDirectory(), err,
+		)
 	}
 
 	var wg sync.WaitGroup
@@ -351,7 +398,11 @@ func (ex *Executor) ExecuteSync(args ...string) ([]byte, error) {
 func (ex *Executor) Plan() error {
 	ex.logger.Println("Generating Terraform execution plan")
 
-	if err := ex.Execute("refresh"); err != nil {
+	s := ExecutionStep{
+		Description: "refresh Terraform state",
+		Args:        []string{"refresh"},
+	}
+	if err := ex.Execute(s); err != nil {
 		return err
 	}
 

--- a/pkg/terraform/executor_test.go
+++ b/pkg/terraform/executor_test.go
@@ -33,7 +33,7 @@ func executor(t *testing.T) *Executor {
 func TestExecuteCheckErrors(t *testing.T) {
 	ex := executor(t)
 
-	if err := ex.Execute("apply"); err == nil {
+	if err := ex.Apply(); err == nil {
 		t.Fatalf("Applying on empty directory should fail")
 	}
 }


### PR DESCRIPTION
This PR paves the way towards https://github.com/kinvolk/lokomotive/issues/716. By making `terraform.Executor` accept an arbitrary series of "steps" we can now declaratively define the infrastructure pieces a platform is composed of.

Example:

```go
steps := []terraform.ExecutionStep{
    {
        Description: "create controllers",
        Args: []string{
            "apply",
            "-auto-approve",
            fmt.Sprintf("-target=module.packet-%s.packet_device.controllers", c.ClusterName),
        },
    },
    {
        Description: "create DNS records",
        Args:        []string{"apply", "-auto-approve", "-target=module.dns"},
    },
    {
        Description: "refresh Terraform state",
        Args:        []string{"refresh"},
    },
    {
        Description:      "complete infrastructure creation",
        Args:             []string{"apply", "-auto-approve"},
        // Verify DNS entries were manually created by the user before proceeding.
        PreExecutionHook: dns.ManualConfigPrompt(&c.DNS),
    },
}
```

I've deliberately avoided refactoring all the various platforms to keep the scope of this PR narrow. I've only refactored `platform/packet` (which is our most complex platform implementation at the moment) to demonstrate how the new structure can be used. The rest of the platforms will be refactored in subsequent PRs.