### PR TITLE
Add the kvm-libvirt platform to lokoctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Follow one of the quickstart guides for the supported platforms:
 * [Packet quickstart](docs/quickstarts/packet.md)
 * [AWS quickstart](docs/quickstarts/aws.md)
 * [Bare metal quickstart](docs/quickstarts/baremetal.md)
+* [KVM libvirt quickstart](docs/quickstarts/kvm-libvirt.md)
 
 ## Documentation
 

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,3 +1,8 @@
+locals {
+  # api_server = module.bootkube.api_servers
+  api_server = data.template_file.controllernames[0].rendered
+}
+
 module "bootkube" {
   source       = "../../../bootkube"
   cluster_name = var.cluster_name
@@ -23,6 +28,9 @@ module "bootkube" {
   disable_self_hosted_kubelet = var.disable_self_hosted_kubelet
   # Extra flags to API server.
   kube_apiserver_extra_flags = var.kube_apiserver_extra_flags
+
+  bootstrap_tokens     = var.enable_tls_bootstrap ? concat([local.controller_bootstrap_token], var.worker_bootstrap_tokens) : []
+  enable_tls_bootstrap = var.enable_tls_bootstrap
 
   certs_validity_period_hours = var.certs_validity_period_hours
 }

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -19,6 +19,11 @@ module "bootkube" {
   enable_aggregation    = var.enable_aggregation
   encrypt_pod_traffic   = var.encrypt_pod_traffic
 
+  # Disable the self hosted kubelet.
+  disable_self_hosted_kubelet = var.disable_self_hosted_kubelet
+  # Extra flags to API server.
+  kube_apiserver_extra_flags = var.kube_apiserver_extra_flags
+
   certs_validity_period_hours = var.certs_validity_period_hours
 }
 

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/bootstrap-configs.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/bootstrap-configs.tf
@@ -1,0 +1,24 @@
+locals {
+  controller_bootstrap_token = var.enable_tls_bootstrap ? {
+    token_id     = random_string.bootstrap_token_id[0].result
+    token_secret = random_string.bootstrap_token_secret[0].result
+  } : {}
+}
+
+# Generate a cryptographically random token id (public).
+resource random_string "bootstrap_token_id" {
+  count = var.enable_tls_bootstrap == true ? 1 : 0
+
+  length  = 6
+  upper   = false
+  special = false
+}
+
+# Generate a cryptographically random token secret.
+resource random_string "bootstrap_token_secret" {
+  count = var.enable_tls_bootstrap == true ? 1 : 0
+
+  length  = 16
+  upper   = false
+  special = false
+}

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -88,7 +88,13 @@ systemd:
           --cni-conf-dir=/etc/cni/net.d \
           --config=/etc/kubernetes/kubelet.config \
           --exit-on-lock-contention \
+          %{~ if enable_tls_bootstrap ~}
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+          --rotate-certificates \
+          %{~ else ~}
           --kubeconfig=/etc/kubernetes/kubeconfig \
+          %{~ endif ~}
           --lock-file=/var/run/lock/kubelet.lock \
           --hostname-override=${etcd_domain} \
           --network-plugin=cni \

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
@@ -11,7 +11,7 @@ resource "libvirt_pool" "volumetmp" {
 
 resource "libvirt_volume" "base" {
   name   = "${var.cluster_name}-base"
-  source = var.os_image_unpacked
+  source = var.os_image
   pool   = libvirt_pool.volumetmp.name
   format = "qcow2"
 }

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
@@ -38,3 +38,15 @@ output "calico_values" {
 output "lokomotive_values" {
   value = module.bootkube.lokomotive_values
 }
+
+output "ca_cert" {
+  value = module.bootkube.ca_cert
+}
+
+output "bootstrap-secrets_values" {
+  value = module.bootkube.bootstrap-secrets_values
+}
+
+output "apiserver" {
+  value = local.api_server
+}

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
@@ -6,18 +6,6 @@ output "kubeconfig" {
   value = module.bootkube.kubeconfig-kubelet
 }
 
-output "machine_domain" {
-  value = var.machine_domain
-}
-
-output "cluster_name" {
-  value = var.cluster_name
-}
-
-output "ssh_keys" {
-  value = var.ssh_keys
-}
-
 output "libvirtpool" {
   value = libvirt_pool.volumetmp.name
 }

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -129,3 +129,13 @@ variable "encrypt_pod_traffic" {
   type        = bool
   default     = false
 }
+
+variable "worker_bootstrap_tokens" {
+  description = "List of token-id and token-secret of each node."
+  type        = list(any)
+}
+
+variable "enable_tls_bootstrap" {
+  description = "Enable TLS Bootstrap for Kubelet."
+  type        = bool
+}

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
 }
 
 # Nodes
-variable "os_image_unpacked" {
+variable "os_image" {
   type        = string
   description = "Path to unpacked Flatcar Container Linux image flatcar_production_qemu_image.img (probably after a qemu-img resize IMG +5G)"
 }
@@ -103,6 +103,17 @@ variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to true)"
   type        = bool
   default     = true
+}
+
+variable "kube_apiserver_extra_flags" {
+  description = "Extra flags passed to self-hosted kube-apiserver."
+  type        = list(string)
+  default     = []
+}
+
+variable "disable_self_hosted_kubelet" {
+  description = "Disable the self hosted kubelet installed by default"
+  type        = bool
 }
 
 # Certificates

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/versions.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/versions.tf
@@ -1,13 +1,23 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13"
 
   required_providers {
-    ct       = "0.6.0"
+
+    ct = {
+      source  = "poseidon/ct"
+      version = "0.6.1"
+    }
+
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      uri     = "qemu:///system"
+      version = "0.6.2"
+    }
+
     null     = "2.1.2"
     template = "2.1.2"
-    libvirt  = "0.6.0"
     random   = "2.3.0"
   }
 }

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/bootstrap-configs.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/bootstrap-configs.tf
@@ -1,0 +1,24 @@
+locals {
+  worker_bootstrap_token = var.enable_tls_bootstrap ? {
+    token_id     = random_string.bootstrap_token_id[0].result
+    token_secret = random_string.bootstrap_token_secret[0].result
+  } : {}
+}
+
+# Generate a cryptographically random token id (public).
+resource random_string "bootstrap_token_id" {
+  count = var.enable_tls_bootstrap == true ? 1 : 0
+
+  length  = 6
+  upper   = false
+  special = false
+}
+
+# Generate a cryptographically random token secret.
+resource random_string "bootstrap_token_secret" {
+  count = var.enable_tls_bootstrap == true ? 1 : 0
+
+  length  = 16
+  upper   = false
+  special = false
+}

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/bootstrap-kubeconfig.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/bootstrap-kubeconfig.yaml.tmpl
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: ${server}
+    certificate-authority-data: ${ca_cert}
+users:
+- name: kubelet
+  user:
+    token: ${token_id}.${token_secret}
+contexts:
+- context:
+    cluster: local
+    user: kubelet

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -65,7 +65,13 @@ systemd:
           --cni-conf-dir=/etc/cni/net.d \
           --config=/etc/kubernetes/kubelet.config \
           --exit-on-lock-contention \
+          %{~ if enable_tls_bootstrap ~}
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+          --rotate-certificates \
+          %{~ else ~}
           --kubeconfig=/etc/kubernetes/kubeconfig \
+          %{~ endif ~}
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
           --node-labels=$${NODE_LABELS} \
@@ -146,7 +152,11 @@ storage:
             --net=host \
             --dns=host \
             -- \
+            %{~ if enable_tls_bootstrap ~}
+            kubectl --kubeconfig=/var/lib/kubelet/kubeconfig delete node $(hostname)
+            %{~ else ~}
             kubectl --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)
+            %{~ endif ~}
 passwd:
   users:
     - name: core

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/outputs.tf
@@ -1,0 +1,3 @@
+output "worker_bootstrap_token" {
+  value = local.worker_bootstrap_token
+}

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
@@ -83,3 +83,18 @@ EOD
   type    = string
   default = "10.2.0.0/16"
 }
+
+variable "ca_cert" {
+  description = "Kubernetes CA certificate needed in the kubeconfig file."
+  type        = string
+}
+
+variable "apiserver" {
+  description = "Apiserver private endpoint needed in the kubeconfig file."
+  type        = string
+}
+
+variable "enable_tls_bootstrap" {
+  description = "Enable TLS Bootstrap for Kubelet."
+  type        = bool
+}

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/versions.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/versions.tf
@@ -1,11 +1,19 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13"
 
   required_providers {
-    ct       = "0.6.0"
+    ct = {
+      source  = "poseidon/ct"
+      version = "0.6.1"
+    }
+
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      uri     = "qemu:///system"
+      version = "0.6.2"
+    }
     template = "2.1.2"
-    libvirt  = "0.6.0"
   }
 }

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
@@ -48,8 +48,14 @@ data "template_file" "worker-config" {
   template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
+    enable_tls_bootstrap   = var.enable_tls_bootstrap
     domain_name            = "${var.cluster_name}-${var.pool_name}-worker-${count.index}.${var.machine_domain}"
-    kubeconfig             = indent(10, var.kubeconfig)
+		kubeconfig = var.enable_tls_bootstrap ? indent(10, templatefile("${path.module}/cl/bootstrap-kubeconfig.yaml.tmpl", {
+			token_id     = random_string.bootstrap_token_id[0].result
+			token_secret = random_string.bootstrap_token_secret[0].result
+			ca_cert      = var.ca_cert
+			server       = "https://${var.apiserver}:6443"
+		})) : indent(10, var.kubeconfig)
     ssh_keys               = jsonencode(var.ssh_keys)
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     cluster_domain_suffix  = var.cluster_domain_suffix

--- a/ci/kvm-libvirt/kvm-libvirt-cluster.lokocfg.envsubst
+++ b/ci/kvm-libvirt/kvm-libvirt-cluster.lokocfg.envsubst
@@ -1,0 +1,11 @@
+cluster "kvm-libvirt" {
+  asset_dir         = pathexpand("~/lokoctl-assets")
+  ssh_pubkeys       = [file(pathexpand("~/.ssh/id_rsa.pub"))]
+  cluster_name      = "vmcluster"
+  machine_domain    = "vmcluster.k8s"
+  os_image          = "file:///var/tmp/flatcar_production_qemu_image.img"
+
+  worker_pool "one" {
+    count = 2
+  }
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/kinvolk/lokomotive/pkg/platform/aks"
 	_ "github.com/kinvolk/lokomotive/pkg/platform/aws"
 	_ "github.com/kinvolk/lokomotive/pkg/platform/baremetal"
+	_ "github.com/kinvolk/lokomotive/pkg/platform/kvmlibvirt"
 	_ "github.com/kinvolk/lokomotive/pkg/platform/packet"
 
 	// Register backends by adding an anonymous import.

--- a/docs/configuration-reference/platforms/kvm-libvirt.md
+++ b/docs/configuration-reference/platforms/kvm-libvirt.md
@@ -66,6 +66,8 @@ cluster "kvm-libvirt" {
 
   certs_validity_period_hours = 8760
 
+  enable_tls_bootstrap = true
+
   worker_pool "worker-pool-1" {
     count = 2
 
@@ -116,6 +118,7 @@ EOF
 | `pod_cidr`                            | CIDR IPv4 range to assign Kubernetes pods.                                                                                                                                                                                                                                        |    "10.2.0.0/16"   |    string    |  false   |
 | `service_cidr`                        | CIDR IPv4 range to assign Kubernetes services.                                                                                                                                                                                                                                    |    "10.3.0.0/16"   |    string    |  false   |
 | `ssh_pubkeys`                         | List of SSH public keys for user `core`. Each element must be specified in a valid OpenSSH public key format, as defined in RFC 4253 Section 6.6, e.g. "ssh-rsa AAAAB3N...".                                                                                                      |          -         | list(string) |   true   |
+| `enable_tls_bootstrap`                | Enable TLS bootstrapping for Kubelet.                                                                                                                                                                                                                                             |        true        |     bool     |  false   |
 | `worker_pool.clc_snippets`            | Flatcar Container Linux Config snippets for nodes in the worker pool.                                                                                                                                                                                                             |          []        | list(string) |  false   |
 | `worker_pool`                         | Configuration block for worker pools. There can be more than one.                                                                                                                                                                                                                 |          -         | list(object) |   true   |
 | `worker_pool.count`                   | Number of workers in the worker pool. Can be changed afterwards to add or delete workers.                                                                                                                                                                                         |          1         |    number    |   true   |

--- a/docs/configuration-reference/platforms/kvm-libvirt.md
+++ b/docs/configuration-reference/platforms/kvm-libvirt.md
@@ -1,0 +1,142 @@
+# Lokomotive KVM libvirt configuration reference
+
+## Contents
+
+* [Introduction](#introduction)
+* [Prerequisites](#prerequisites)
+* [Configuration](#configuration)
+* [Attribute reference](#attribute-reference)
+* [Applying](#applying)
+* [Destroying](#destroying)
+
+## Introduction
+
+This configuration reference provides information on configuring a Lokomotive cluster on KVM libvirt VMs
+with all the configuration options available to the user.
+
+## Prerequisites
+
+* Terraform providers and libvirt setup from the [quickstart guide](../../quickstarts/kvm-libvirt.md)
+* `lokoctl` [installed locally.](../../installer/lokoctl.md)
+* `kubectl` installed locally to access the Kubernetes cluster.
+
+### Configuration
+
+To create a Lokomotive cluster, we need to define a configuration.
+
+Example configuration file:
+
+```tf
+
+cluster "kvm-libvirt" {
+
+  asset_dir = pathexpand("./assets")
+
+  cluster_name = "vmcluster"
+
+  machine_domain = "vmcluster.k8s"
+
+  os_image = "file:///home/myuser/Downloads/flatcar_production_qemu_image.img"
+
+  ssh_pubkeys = [file(pathexpand("~/.ssh/id_rsa.pub"))]
+
+  controller_count = 1
+
+  node_ip_pool = "192.168.192.0/24"
+
+  disable_self_hosted_kubelet = false
+
+  kube_apiserver_extra_flags = []
+
+  controller_virtual_cpus = 1
+  controller_virtual_memory = 2048
+
+  controller_clc_snippets = []
+
+  network_mtu = 1480
+  network_ip_autodetection_method = "first-found"
+
+  pod_cidr = "10.1.0.0/16"
+  service_cidr = "10.2.0.0/16"
+
+  cluster_domain_suffix = "cluster.local"
+
+  enable_reporting = false
+  enable_aggregation = true
+
+  certs_validity_period_hours = 8760
+
+  worker_pool "worker-pool-1" {
+    count = 2
+
+    virtual_cpus = 1
+    virtual_memory = 2048
+
+    labels = "foo=oof,bar=,baz=zab"
+
+    clc_snippets = [
+  <<EOF
+systemd:
+  units:
+  - name: helloworld.service
+    dropins:
+      - name: 10-helloworld.conf
+        contents: |
+          [Install]
+          WantedBy=multi-user.target
+EOF
+        ,
+  ]
+
+  }
+}
+```
+
+
+## Attribute reference
+
+| Argument                              | Description                                                                                                                                                                                                                                                                       |       Default      |     Type     | Required |
+|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------:|:------------:|:--------:|
+| `asset_dir`                           | Location where Lokomotive stores cluster assets.                                                                                                                                                                                                                                  |          -         |    string    |   true   |
+| `certs_validity_period_hours`         | Validity of all the certificates in hours.                                                                                                                                                                                                                                        |        8760        |    number    |  false   |
+| `cluster_domain_suffix`               | Cluster's DNS domain.                                                                                                                                                                                                                                                             |   "cluster.local"  |    string    |  false   |
+| `cluster_name`                        | Name of the cluster.                                                                                                                                                                                                                                                              |          -         |    string    |   true   |
+| `controller_clc_snippets`             | Controller Flatcar Container Linux Config snippets.                                                                                                                                                                                                                               |          []        | list(string) |  false   |
+| `controller_count`                    | Number of controller nodes.                                                                                                                                                                                                                                                       |          1         |    number    |  false   |
+| `controller_virtual_cpus`             | Number of virtual CPUs for the controller VMs.                                                                                                                                                                                                                                    |          1         |      int     |  false   |
+| `controller_virtual_memory`           | Virtual RAM in MB for the controller VMs.                                                                                                                                                                                                                                         |         2048       |      int     |  false   |
+| `disable_self_hosted_kubelet`         | Disable self-hosting the kubelet as pod on the cluster.                                                                                                                                                                                                                           |        false       |     bool     |  false   |
+| `enable_aggregation`                  | Enable the Kubernetes Aggregation Layer.                                                                                                                                                                                                                                          |        true        |     bool     |  false   |
+| `enable_reporting`                    | Enables usage or analytics reporting to upstream.                                                                                                                                                                                                                                 |        false       |     bool     |  false   |
+| `kube_apiserver_extra_flags`          | Extra flags to pass to the kube-apiserver binary.                                                                                                                                                                                                                                 |          []        | list(string) |  false   |
+| `machine_domain`                      | DNS zone of the cluster, used by nodes to find each other as HOSTNAME.machine_domain.                                                                                                                                                                                             |          -         |    string    |   true   |
+| `network_mtu`                         | CNI interface MTU                                                                                                                                                                                                                                                                 |        1480        |    number    |  false   |
+| `node_ip_pool`                        | Unique VM IP CIDR.                                                                                                                                                                                                                                                                | "192.168.192.0/24" |    string    |  false   |
+| `os_image`                            | Path to unpacked Flatcar Container Linux image flatcar_production_qemu_image.img (probably after a qemu-img resize IMG +5G).                                                                                                                                                      |          -         |    string    |   true   |
+| `pod_cidr`                            | CIDR IPv4 range to assign Kubernetes pods.                                                                                                                                                                                                                                        |    "10.2.0.0/16"   |    string    |  false   |
+| `service_cidr`                        | CIDR IPv4 range to assign Kubernetes services.                                                                                                                                                                                                                                    |    "10.3.0.0/16"   |    string    |  false   |
+| `ssh_pubkeys`                         | List of SSH public keys for user `core`. Each element must be specified in a valid OpenSSH public key format, as defined in RFC 4253 Section 6.6, e.g. "ssh-rsa AAAAB3N...".                                                                                                      |          -         | list(string) |   true   |
+| `worker_pool.clc_snippets`            | Flatcar Container Linux Config snippets for nodes in the worker pool.                                                                                                                                                                                                             |          []        | list(string) |  false   |
+| `worker_pool`                         | Configuration block for worker pools. There can be more than one.                                                                                                                                                                                                                 |          -         | list(object) |   true   |
+| `worker_pool.count`                   | Number of workers in the worker pool. Can be changed afterwards to add or delete workers.                                                                                                                                                                                         |          1         |    number    |   true   |
+| `worker_pool.labels`                  | Custom labels to assign to worker nodes.                                                                                                                                                                                                                                          |          -         |    string    |  false   |
+| `worker_pool.virtual_cpus`            | List of tags that will be propagated to nodes in the worker pool.                                                                                                                                                                                                                 |          -         | map(string)  |  false   |
+| `worker_pool.virtual_memory`          | Disable BGP on nodes. Nodes won't be able to connect to Packet BGP peers.                                                                                                                                                                                                         |        false       |     bool     |  false   |
+
+
+## Applying
+
+To create the cluster, execute the following command:
+
+```console
+lokoctl cluster apply
+```
+
+## Destroying
+
+To destroy the Lokomotive cluster, execute the following command:
+
+```console
+lokoctl cluster destroy --confirm
+```
+

--- a/docs/quickstarts/kvm-libvirt.md
+++ b/docs/quickstarts/kvm-libvirt.md
@@ -1,0 +1,284 @@
+# Lokomotive KVM libvirt quickstart guide
+
+## Contents
+
+* [Introduction](#introduction)
+* [Requirements](#requirements)
+* [Step 1: Install lokoctl](#step-1-install-lokoctl)
+* [Step 2: Prepare the VM Image](#step-2-prepare-the-vm-image)
+* [Step 3: libvirtd Setup](#step-3-libvirtd-setup)
+* [Step 4: User Setup](#step-4-user-setup)
+* [Step 5: Create a cluster configuration](#step-5-create-a-cluster-configuration)
+* [Step 6: Check ssh-agent](#step-6-check-ssh-agent)
+* [Step 7: Deploy the cluster](#step-7-deploy-the-cluster)
+* [Verification](#verification)
+* [Using the cluster](#using-the-cluster)
+* [Cleanup](#cleanup)
+* [Troubleshooting](#troubleshooting)
+
+## Introduction
+
+This guide shows how to create a Lokomotive cluster with Flatcar Container Linux VMs on your local machine.
+By the end of this guide, you'll have a basic Lokomotive cluster running that consist of controller and worker nodes.
+
+Controllers are provisioned to run an `etcd-member` peer and a `kubelet` service.
+Workers run just a `kubelet` service. A one-time [bootkube](https://github.com/kubernetes-incubator/bootkube)
+bootstrap process schedules the `apiserver`, `scheduler`, `controller-manager`, and `coredns` pods on the controllers
+and schedules `kube-proxy` and `calico` on every node.
+A generated `kubeconfig` provides `kubectl` access to the cluster.
+
+## Requirements
+
+* A Linux host OS.
+* At least 4 GB of available RAM.
+* An SSH key pair.
+* Terraform `v0.12.x`
+  [installed](https://learn.hashicorp.com/terraform/getting-started/install.html#install-terraform).
+* [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct),
+  and [terraform-provider-libvirt](https://github.com/dmacvicar/terraform-provider-libvirt)
+  installed locally, e.g., as two binaries `~/.terraform.d/plugins/terraform-provider-ct_v0.5.0`
+  and `~/.terraform.d/plugins/terraform-provider-libvirt_v0.6.1`.
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed.
+
+
+## Steps
+
+### Step 1: Install lokoctl
+
+
+`lokoctl` is the command-line interface for managing Lokomotive clusters.
+
+Download the latest `lokoctl` binary:
+
+```console
+export release=$(curl -s https://api.github.com/repos/kinvolk/lokomotive/releases | jq -r '.[0].name' | tr -d v)
+curl -LO "https://github.com/kinvolk/lokomotive/releases/download/v${release}/lokoctl_${release}_linux_amd64.tar.gz"
+```
+
+Extract the binary and copy it to a place under your `$PATH`:
+
+```console
+tar zxvf lokoctl_${release}_linux_amd64.tar.gz
+cp lokoctl_${release}_linux_amd64/lokoctl ~/.local/bin/
+rm -rf lokoctl_${release}_linux_amd64*
+```
+
+### Step 2: Prepare the VM Image
+
+Download a Flatcar Container Linux image. The example below uses the Alpha Flatcar Container Linux channel.
+You need to increase its size depending on your use case because the initial size
+is only enough for some small pods to be loaded. Starting pods with normal-sized
+container images may already fail when the disk space is filled.
+That's why the example below directly increases the image size by 5 GB to make
+sure that a couple of container images fit on the node.
+
+```console
+# On Fedora/RHEL/CentOS
+sudo dnf install wget bzip2 qemu-img
+# On Ubuntu/Debian
+sudo apt install wget bzip2 qemu-utils
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
+bunzip2 flatcar_production_qemu_image.img.bz2
+qemu-img resize flatcar_production_qemu_image.img +5G
+```
+
+Do not use this image file with QEMU directly because it needs to stay clean for Ignition to run on first boot.
+
+### Step 3: libvirtd Setup
+
+Ensure that libvirtd is set up.
+
+```console
+# On Fedora/RHEL/CentOS
+sudo dnf install libvirt-daemon
+# On Ubuntu/Debian
+sudo apt install libvirt-daemon
+sudo systemctl start libvirtd
+```
+
+#### AppArmor and libvirt issues
+
+If you use Ubuntu or Debian with AppArmor, you need to disable AppArmor because it disallows
+using temporary paths for the storage pool. Open `/etc/libvirt/qemu.conf` and add the
+following line below any existing commented `#security_driver = "selinux"` line:
+
+```
+security_driver = "none"
+```
+
+Restart libvirtd using `sudo systemctl restart libvirtd`.
+
+### Step 4: User Setup
+
+Ensure that libvirt is accessible for the current user because the user needs to create
+system-wide virtual machines with libvirt:
+
+```console
+groups
+```
+
+If you see some group names like `myuser wheel postgres docker` but not `libvirt` you need to
+add the current user to the libvirt group.
+
+```console
+sudo usermod -a -G libvirt $(whoami)
+newgrp libvirt
+```
+
+If `newgrp` was used you have to continue to use this terminal session or run `newgrp libvirt`
+in every new terminal sessons or log your user out and in again.
+
+### Step 5: Create a cluster configuration
+
+Create a directory for the cluster-related files and navigate to it:
+
+```console
+mkdir lokomotive-demo && cd lokomotive-demo
+```
+
+Create a file called `cluster.lokocfg` with these contents but remember to change and
+check the image path and check the SSH public key path:
+
+```hcl
+cluster "kvm-libvirt" {
+  asset_dir = pathexpand("./assets")
+  # Your SSH public key
+  ssh_pubkeys = [file(pathexpand("~/.ssh/id_rsa.pub"))]
+  cluster_name = "vmcluster"
+  machine_domain = "vmcluster.k8s"
+  # Path to the prepared image file. Note the absolute path notation with the three slashes.
+  os_image = "file:///var/tmp/lokomotive-demo/flatcar_production_qemu_image.img"
+
+  worker_pool "one" {
+    count = 1
+  }
+}
+```
+
+Again, check the contents of `cluster.lokocfg`.
+Check if you need to change the SSH key entry to match your `~/.ssh/id_*.pub` and
+change the `os_image` path to point to the image location from the VM image preparation.
+
+The rest of the parameters may be left as-is. For more information about the configuration options
+see the [configuration reference](../configuration-reference/platforms/kvm-libvirt.md).
+
+
+### Step 6: Check ssh-agent
+
+Check that your SSH key is known to `ssh-agent` so that it is unlocked if it was secured with a passphrase:
+
+```console
+ssh-add -L
+```
+
+This should normally be the case when the key was created with the GNOME _Passwords and Keys_ tool.
+Otherwise add the key:
+
+```console
+ssh-add ~/.ssh/id_rsa
+```
+
+### Step 7: Deploy the cluster
+
+Deploy the cluster with `lokoctl`:
+
+```console
+lokoctl cluster apply
+INFO[0000] Initializing Terraform working directory      phase=infrastructure
+
+You can find the logs in "assets/terraform/logs/3213353.log"
+INFO[0001] Applying Terraform configuration. This creates infrastructure so it might take a long time...  phase=infrastructure
+
+You can find the logs in "assets/terraform/logs/3213406.log"
+
+Your configurations are stored in ./assets
+
+Now checking health and readiness of the cluster nodes ...
+
+Node                                    Ready    Reason          Message
+
+vmcluster-controller-0.vmcluster.k8s    True     KubeletReady    kubelet is posting ready status
+vmcluster-one-worker-0.vmcluster.k8s    True     KubeletReady    kubelet is posting ready status
+
+Success - cluster is healthy and nodes are ready!
+INFO[0498] Applying component configuration              args="[]" command="lokoctl cluster apply"
+```
+
+The deployment process typically takes 3-6 minutes, the Lokomotive cluster is be ready, depending on your internet connection and hardware.
+
+## Verification
+
+Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes:
+
+```console
+export KUBECONFIG=$(pwd)/assets/cluster-assets/auth/kubeconfig
+kubectl get nodes
+NAME                                   STATUS   ROLES               AGE     VERSION
+vmcluster-controller-0.vmcluster.k8s   Ready    controller,master   5h28m   v1.14.1
+vmcluster-one-worker-0.vmcluster.k8s   Ready    node                5h28m   v1.14.1
+```
+
+List the pods.
+
+```console
+kubectl get pods --all-namespaces
+kube-system   calico-node-x5cgr                          1/1     Running   0          5h28m
+kube-system   calico-node-zp2bl                          1/1     Running   0          5h28m
+kube-system   coredns-5644c585c9-58w2r                   1/1     Running   2          5h28m
+kube-system   coredns-5644c585c9-vtknk                   1/1     Running   1          5h28m
+kube-system   kube-apiserver-8fxjs                       1/1     Running   3          5h28m
+kube-system   kube-controller-manager-865f9f995d-cj8hp   1/1     Running   1          5h28m
+kube-system   kube-controller-manager-865f9f995d-jtmqf   1/1     Running   1          5h28m
+kube-system   kube-proxy-jxsz4                           1/1     Running   0          5h28m
+kube-system   kube-proxy-r24jn                           1/1     Running   0          5h28m
+kube-system   kube-scheduler-57c444dcc8-54zpq            1/1     Running   1          5h28m
+kube-system   kube-scheduler-57c444dcc8-6gv94            1/1     Running   0          5h28m
+kube-system   pod-checkpointer-8qdrt                     1/1     Running   0          5h28m
+```
+
+
+## Using the cluster
+
+At this point you should have access to a Lokomotive cluster and can use it to deploy applications.
+
+If you don't have any Kubernetes experience, you can check out the [Kubernetes
+Basics](https://kubernetes.io/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/) tutorial.
+
+When you don't need the cluster for some time, shut the VMs down in `virt-manager` to free up RAM.
+
+>NOTE: Lokomotive uses a relatively restrictive Pod Security Policy by default. This policy
+>disallows running containers as root. Refer to the
+>[Pod Security Policy documentation](../concepts/securing-lokomotive-cluster.md#cluster-wide-pod-security-policy)
+>for more details.
+
+## Cleanup
+
+To destroy the cluster, execute the following command:
+
+```console
+lokoctl cluster destroy
+```
+
+Confirm you want to destroy the cluster by typing `yes` and hitting **Enter**.
+
+You can now safely delete the directory created for this guide if you no longer need it.
+
+## Troubleshooting
+
+If you want to log in using SSH for debugging purposes, use the Flatcar Container Linux default user `core`.
+
+You can look up the node IP address in `virt-manager` or resolve them from the hostnames,
+using the libvirt DNS server:
+
+```console
+host vmcluster-controller-0.vmcluster.k8s 192.168.192.1
+Using domain server:
+Name: 192.168.192.1
+Address: 192.168.192.1#53
+Aliases: 
+
+vmcluster-controller-0.vmcluster.k8s has address 192.168.192.10
+```
+
+On each node list the containers with `docker ps` and follow the system logs with `journalctl -f`.
+

--- a/pkg/platform/kvmlibvirt/kvmlibvirt.go
+++ b/pkg/platform/kvmlibvirt/kvmlibvirt.go
@@ -1,0 +1,198 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvmlibvirt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/mitchellh/go-homedir"
+
+	"github.com/kinvolk/lokomotive/pkg/platform"
+	"github.com/kinvolk/lokomotive/pkg/terraform"
+)
+
+type workerPool struct {
+	Name          string   `hcl:"pool_name,label"`
+	Count         int      `hcl:"count"`
+	VirtualCPUs   int      `hcl:"virtual_cpus,optional"`
+	VirtualMemory int      `hcl:"virtual_memory,optional"`
+	CLCSnippets   []string `hcl:"clc_snippets,optional"`
+	Labels        string   `hcl:"labels,optional"`
+}
+
+type config struct {
+	AssetDir                     string       `hcl:"asset_dir"`
+	ClusterName                  string       `hcl:"cluster_name"`
+	ControllerCount              int          `hcl:"controller_count,optional"`
+	MachineDomain                string       `hcl:"machine_domain"`
+	OSImage                      string       `hcl:"os_image"`
+	NodeIpPool                   string       `hcl:"node_ip_pool,optional"`
+	SSHPubKeys                   []string     `hcl:"ssh_pubkeys"`
+	WorkerPools                  []workerPool `hcl:"worker_pool,block"`
+	DisableSelfHostedKubelet     bool         `hcl:"disable_self_hosted_kubelet,optional"`
+	KubeAPIServerExtraFlags      []string     `hcl:"kube_apiserver_extra_flags,optional"`
+	ControllerVirtualCPUs        int          `hcl:"controller_virtual_cpus,optional"`
+	ControllerVirtualMemory      int          `hcl:"controller_virtual_memory,optional"`
+	ControllerCLCSnippets        []string     `hcl:"controller_clc_snippets,optional"`
+	NetworkMTU                   int          `hcl:"network_mtu,optional"`
+	NetworkIpAutodetectionMethod string       `hcl:"network_ip_autodetection_method,optional"`
+	PodCidr                      string       `hcl:"pod_cidr,optional"`
+	ServiceCidr                  string       `hcl:"service_cidr,optional"`
+	ClusterDomainSuffix          string       `hcl:"cluster_domain_suffix,optional"`
+	EnableReporting              bool         `hcl:"enable_reporting,optional"`
+	EnableAggregation            bool         `hcl:"enable_aggregation,optional"`
+	CertsValidityPeriodHours     int          `hcl:"certs_validity_period_hours,optional"`
+}
+
+func init() {
+	platform.Register("kvm-libvirt", NewConfig())
+}
+
+func (c *config) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContext) hcl.Diagnostics {
+	if configBody == nil {
+		return hcl.Diagnostics{}
+	}
+
+	if diags := gohcl.DecodeBody(*configBody, evalContext, c); diags.HasErrors() {
+		return diags
+	}
+
+	return c.checkValidConfig()
+}
+
+// Meta is part of Platform interface and returns common information about the platform configuration.
+func (c *config) Meta() platform.Meta {
+	nodes := c.ControllerCount
+	for _, workerpool := range c.WorkerPools {
+		nodes += workerpool.Count
+	}
+	return platform.Meta{
+		AssetDir:      c.AssetDir,
+		ExpectedNodes: nodes,
+	}
+}
+
+func NewConfig() *config {
+	return &config{}
+}
+
+func (c *config) Apply(ex *terraform.Executor) error {
+	if err := c.Initialize(ex); err != nil {
+		return err
+	}
+
+	return ex.Apply()
+}
+
+func (c *config) Destroy(ex *terraform.Executor) error {
+	if err := c.Initialize(ex); err != nil {
+		return err
+	}
+
+	return ex.Destroy()
+}
+
+func (c *config) Initialize(ex *terraform.Executor) error {
+	assetDir, err := homedir.Expand(c.AssetDir)
+	if err != nil {
+		return err
+	}
+
+	terraformRootDir := terraform.GetTerraformRootDir(assetDir)
+
+	return createTerraformConfigFile(c, terraformRootDir)
+}
+
+func createTerraformConfigFile(cfg *config, terraformRootDir string) error {
+	tmplName := "cluster.tf"
+	t := template.New(tmplName).Funcs(template.FuncMap{"StringsJoin": strings.Join})
+	t, err := t.Parse(terraformConfigTmpl)
+	if err != nil {
+		return fmt.Errorf("parsing template: %w", err)
+	}
+
+	path := filepath.Join(terraformRootDir, tmplName)
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating file %q: %w", path, err)
+	}
+	defer f.Close()
+
+	terraformCfg := struct {
+		Config config
+	}{
+		Config: *cfg,
+	}
+
+	if err := t.Execute(f, terraformCfg); err != nil {
+		return fmt.Errorf("executing template: %w", err)
+	}
+
+	return nil
+}
+
+// checkValidConfig validates cluster configuration.
+func (c *config) checkValidConfig() hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	diagnostics = append(diagnostics, c.checkNotEmptyWorkers()...)
+	diagnostics = append(diagnostics, c.checkWorkerPoolNamesUnique()...)
+
+	return diagnostics
+}
+
+// checkNotEmptyWorkers checks if the cluster has at least 1 node pool defined.
+func (c *config) checkNotEmptyWorkers() hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if len(c.WorkerPools) == 0 {
+		diagnostics = append(diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "At least one worker pool must be defined",
+			Detail:   "Make sure to define at least one worker pool block in your cluster block",
+		})
+	}
+
+	return diagnostics
+}
+
+// checkWorkerPoolNamesUnique verifies that all worker pool names are unique.
+func (c *config) checkWorkerPoolNamesUnique() hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	dup := make(map[string]bool)
+
+	for _, w := range c.WorkerPools {
+		if !dup[w.Name] {
+			dup[w.Name] = true
+			continue
+		}
+
+		// It is duplicated.
+		diagnostics = append(diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Worker pools name should be unique",
+			Detail:   fmt.Sprintf("Worker pool '%v' is duplicated", w.Name),
+		})
+	}
+
+	return diagnostics
+}

--- a/pkg/platform/kvmlibvirt/kvmlibvirt.go
+++ b/pkg/platform/kvmlibvirt/kvmlibvirt.go
@@ -116,6 +116,28 @@ func (c *config) Initialize(ex *terraform.Executor) error {
 		return err
 	}
 
+	// TODO: A transient change which shall be reverted in a follow up PR to handle
+	// https://github.com/kinvolk/lokomotive/issues/716.
+	// Extract control plane chart files to cluster assets directory.
+	for _, c := range platform.CommonControlPlaneCharts() {
+		src := filepath.Join(assets.ControlPlaneSource, c.Name)
+		dst := filepath.Join(assetDir, "cluster-assets", "charts", c.Namespace, c.Name)
+		if err := assets.Extract(src, dst); err != nil {
+			return fmt.Errorf("extracting charts: %w", err)
+		}
+	}
+
+	// TODO: A transient change which shall be reverted in a follow up PR to handle
+	// https://github.com/kinvolk/lokomotive/issues/716.
+	// Extract self-hosted kubelet chart only when enabled in config.
+	if !c.DisableSelfHostedKubelet {
+		src := filepath.Join(assets.ControlPlaneSource, "kubelet")
+		dst := filepath.Join(assetDir, "cluster-assets", "charts", "kube-system", "kubelet")
+		if err := assets.Extract(src, dst); err != nil {
+			return fmt.Errorf("extracting kubelet chart: %w", err)
+		}
+	}
+
 	terraformRootDir := terraform.GetTerraformRootDir(assetDir)
 
 	return createTerraformConfigFile(c, terraformRootDir)

--- a/pkg/platform/kvmlibvirt/kvmlibvirt.go
+++ b/pkg/platform/kvmlibvirt/kvmlibvirt.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/mitchellh/go-homedir"
 
+	"github.com/kinvolk/lokomotive/pkg/assets"
 	"github.com/kinvolk/lokomotive/pkg/platform"
 	"github.com/kinvolk/lokomotive/pkg/terraform"
 )
@@ -60,6 +61,7 @@ type config struct {
 	EnableReporting              bool         `hcl:"enable_reporting,optional"`
 	EnableAggregation            bool         `hcl:"enable_aggregation,optional"`
 	CertsValidityPeriodHours     int          `hcl:"certs_validity_period_hours,optional"`
+	EnableTLSBootstrap           bool         `hcl:"enable_tls_bootstrap,optional"`
 }
 
 func init() {
@@ -91,7 +93,9 @@ func (c *config) Meta() platform.Meta {
 }
 
 func NewConfig() *config {
-	return &config{}
+	return &config{
+		EnableTLSBootstrap: true,
+	}
 }
 
 func (c *config) Apply(ex *terraform.Executor) error {

--- a/pkg/platform/kvmlibvirt/template.go
+++ b/pkg/platform/kvmlibvirt/template.go
@@ -28,8 +28,8 @@ module "kvm-libvirt-{{.Config.ClusterName}}" {
 
   machine_domain = "{{.Config.MachineDomain}}"
 
-  {{- if .Config.NodeIpPool}}
-  node_ip_pool   = "{{.Config.NodeIpPool}}"
+  {{- if .Config.NodeIPPool}}
+  node_ip_pool   = "{{.Config.NodeIPPool}}"
   {{- end }}
 
   {{- if .Config.ControllerCount}}
@@ -48,8 +48,8 @@ module "kvm-libvirt-{{.Config.ClusterName}}" {
   network_mtu = {{.Config.NetworkMTU}}
   {{- end }}
 
-  {{- if .Config.NetworkIpAutodetectionMethod }}
-  network_ip_autodetection_method = {{ .Config.NetworkIpAutodetectionMethod }}
+  {{- if .Config.NetworkIPAutodetectionMethod }}
+  network_ip_autodetection_method = {{ .Config.NetworkIPAutodetectionMethod }}
   {{- end }}
 
   {{- if .Config.PodCidr }}

--- a/pkg/platform/kvmlibvirt/template.go
+++ b/pkg/platform/kvmlibvirt/template.go
@@ -1,0 +1,186 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvmlibvirt
+
+var terraformConfigTmpl = `
+module "kvm-libvirt-{{.Config.ClusterName}}" {
+  source = "../terraform-modules/kvm-libvirt/flatcar-linux/kubernetes"
+
+  cluster_name = "{{.Config.ClusterName}}"
+
+  ssh_keys = {{ StringsJoin .Config.SSHPubKeys "\", \"" | printf "[%q]" }}
+
+  asset_dir = "../cluster-assets"
+
+  os_image = "{{.Config.OSImage}}"
+
+  machine_domain = "{{.Config.MachineDomain}}"
+
+  {{- if .Config.NodeIpPool}}
+  node_ip_pool   = "{{.Config.NodeIpPool}}"
+  {{- end }}
+
+  {{- if .Config.ControllerCount}}
+  controller_count = {{.Config.ControllerCount}}
+  {{- end }}
+
+  {{- if .Config.ControllerVirtualCPUs}}
+  virtual_cpus = {{ .Config.ControllerVirtualCPUs}}
+  {{- end }}
+
+  {{- if .Config.ControllerVirtualMemory}}
+  virtual_memory {{ .Config.ControllerVirtualMemory}}
+  {{- end }}
+
+  {{- if .Config.NetworkMTU }}
+  network_mtu = {{.Config.NetworkMTU}}
+  {{- end }}
+
+  {{- if .Config.NetworkIpAutodetectionMethod }}
+  network_ip_autodetection_method = {{ .Config.NetworkIpAutodetectionMethod }}
+  {{- end }}
+
+  {{- if .Config.PodCidr }}
+  pod_cidr = {{.Config.PodCidr }}
+  {{- end }}
+  {{- if .Config.ServiceCidr }}
+  service_cidr = {{.Config.ServiceCidr }}
+  {{- end }}
+
+  {{- if .Config.ClusterDomainSuffix }}
+  cluster_domain_suffix = {{.Config.ClusterDomainSuffix }}
+  {{- end }}
+
+  enable_reporting   = {{.Config.EnableReporting}}
+  enable_aggregation = {{.Config.EnableAggregation}}
+
+  {{- if .Config.ControllerCLCSnippets }}
+  controller_clc_snippets = {{ StringsJoin .Config.ControllerCLCSnippets "\", \"" | printf "[%q]" }}
+  {{- end }}
+
+  disable_self_hosted_kubelet = {{ .Config.DisableSelfHostedKubelet }}
+
+  {{- if .Config.KubeAPIServerExtraFlags }}
+  kube_apiserver_extra_flags = {{ StringsJoin .Config.KubeAPIServerExtraFlags "\", \"" | printf "[%q]" }}
+  {{- end }}
+
+  {{- if .Config.CertsValidityPeriodHours }}
+  certs_validity_period_hours = {{.Config.CertsValidityPeriodHours}}
+  {{- end }}
+}
+
+{{ range $index, $pool := .Config.WorkerPools }}
+module "worker-pool-{{ $index }}" {
+  source = "../terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers"
+
+  ssh_keys = {{ StringsJoin $.Config.SSHPubKeys "\", \"" | printf "[%q]" }}
+  machine_domain        = "{{$.Config.MachineDomain}}"
+  cluster_name          = "{{$.Config.ClusterName}}"
+  {{- if $.Config.ClusterDomainSuffix }}
+  cluster_domain_suffix = {{$.Config.ClusterDomainSuffix }}
+  {{- end }}
+  {{- if $.Config.ServiceCidr }}
+  service_cidr = {{$.Config.ServiceCidr }}
+  {{- end }}
+
+  libvirtpool           = module.kvm-libvirt-{{$.Config.ClusterName}}.libvirtpool
+  libvirtbaseid         = module.kvm-libvirt-{{$.Config.ClusterName}}.libvirtbaseid
+  kubeconfig            = module.kvm-libvirt-{{$.Config.ClusterName}}.kubeconfig
+
+  pool_name             = "{{ $pool.Name }}"
+  worker_count          = "{{ $pool.Count}}"
+
+  {{- if $pool.VirtualCPUs }}
+  virtual_cpus = {{ $pool.VirtualCPUs }}
+  {{- end }}
+
+  {{- if $pool.VirtualMemory }}
+  virtual_memory {{ $pool.VirtualMemory }}
+  {{- end }}
+
+  {{- if $pool.Labels }}
+  labels = {{ $pool.Labels }}
+  {{- end }}
+
+  {{- if $pool.CLCSnippets }}
+  clc_snippets = {{ StringsJoin $pool.CLCSnippets "\", \"" | printf "[%q]" }}
+  {{- end }}
+}
+{{- end }}
+
+provider "libvirt" {
+  uri     = "qemu:///system"
+  version = "~> 0.6.0"
+}
+
+provider "ct" {
+  version = "~> 0.5.0"
+}
+
+provider "local" {
+  version = "~> 1.2"
+}
+
+provider "null" {
+  version = "~> 2.1"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
+provider "tls" {
+  version = "~> 2.0"
+}
+
+provider "random" {
+  version = "~> 2.2"
+}
+
+
+# Stub output, which indicates, that Terraform run at least once.
+# Used when checking, if we should ask user for confirmation, when
+# applying changes to the cluster.
+output "initialized" {
+  value     = true
+  sensitive = true
+}
+
+# values.yaml content for all deployed charts.
+output "pod-checkpointer_values" {
+  value     = module.kvm-libvirt-{{.Config.ClusterName}}.pod-checkpointer_values
+  sensitive = true
+}
+
+output "kube-apiserver_values" {
+  value     = module.kvm-libvirt-{{.Config.ClusterName}}.kube-apiserver_values
+  sensitive = true
+}
+
+output "kubernetes_values" {
+  value     = module.kvm-libvirt-{{.Config.ClusterName}}.kubernetes_values
+  sensitive = true
+}
+
+output "kubelet_values" {
+  value     = module.kvm-libvirt-{{.Config.ClusterName}}.kubelet_values
+  sensitive = true
+}
+
+output "calico_values" {
+  value     = module.kvm-libvirt-{{.Config.ClusterName}}.calico_values
+  sensitive = true
+}
+`

--- a/pkg/platform/kvmlibvirt/template.go
+++ b/pkg/platform/kvmlibvirt/template.go
@@ -120,36 +120,23 @@ module "worker-pool-{{ $index }}" {
 }
 {{- end }}
 
+terraform {
+  required_providers {
+    libvirt = {
+			source = "dmacvicar/libvirt"
+			uri     = "qemu:///system"
+			version = "0.6.2"
+    }
+    ct = {
+			source  = "poseidon/ct"
+			version = "0.6.1"
+    }
+  }
+}
+
 provider "libvirt" {
-  uri     = "qemu:///system"
-  version = "~> 0.6.0"
+	uri     = "qemu:///system"
 }
-
-provider "ct" {
-  version = "~> 0.5.0"
-}
-
-provider "local" {
-  version = "~> 1.2"
-}
-
-provider "null" {
-  version = "~> 2.1"
-}
-
-provider "template" {
-  version = "~> 2.1"
-}
-
-provider "tls" {
-  version = "~> 2.0"
-}
-
-provider "random" {
-  version = "~> 2.2"
-}
-
-
 # Stub output, which indicates, that Terraform run at least once.
 # Used when checking, if we should ask user for confirmation, when
 # applying changes to the cluster.

--- a/pkg/platform/kvmlibvirt/template.go
+++ b/pkg/platform/kvmlibvirt/template.go
@@ -79,6 +79,14 @@ module "kvm-libvirt-{{.Config.ClusterName}}" {
   {{- if .Config.CertsValidityPeriodHours }}
   certs_validity_period_hours = {{.Config.CertsValidityPeriodHours}}
   {{- end }}
+
+ # Enable TLS Bootstrap
+   enable_tls_bootstrap = {{ .Config.EnableTLSBootstrap }}
+  worker_bootstrap_tokens = [
+    {{- range $index, $pool := .Config.WorkerPools }}
+    module.worker-pool-{{$index}}.worker_bootstrap_token,
+    {{- end }}
+  ]
 }
 
 {{ range $index, $pool := .Config.WorkerPools }}
@@ -98,6 +106,10 @@ module "worker-pool-{{ $index }}" {
   libvirtpool           = module.kvm-libvirt-{{$.Config.ClusterName}}.libvirtpool
   libvirtbaseid         = module.kvm-libvirt-{{$.Config.ClusterName}}.libvirtbaseid
   kubeconfig            = module.kvm-libvirt-{{$.Config.ClusterName}}.kubeconfig
+
+  ca_cert              = module.kvm-libvirt-{{ $.Config.ClusterName }}.ca_cert
+  apiserver            = module.kvm-libvirt-{{ $.Config.ClusterName }}.apiserver
+  enable_tls_bootstrap = {{ $.Config.EnableTLSBootstrap }}
 
   pool_name             = "{{ $pool.Name }}"
   worker_count          = "{{ $pool.Count}}"
@@ -168,6 +180,11 @@ output "kubelet_values" {
 
 output "calico_values" {
   value     = module.kvm-libvirt-{{.Config.ClusterName}}.calico_values
+  sensitive = true
+}
+
+output "bootstrap-secrets_values" {
+  value     = module.kvm-libvirt-{{.Config.ClusterName}}.bootstrap-secrets_values
   sensitive = true
 }
 `


### PR DESCRIPTION
The KVM libvirt Terraform module was not yet available from lokoctl
despite it being an easy way to try out Lokomotive without any cloud
provider accounts (and their attached costs). It allows to use
Lokomotive on any Flatcar Container Linux image, even local development
builds. It also gives direct access to the VGA console for debugging.
The cluster VMs can be shut down in virt-manager while they are not
needed.

(Reactivating the CI pipeline for libvirt is the next step.)

Closes: https://github.com/kinvolk/lokomotive/issues/214