### PR TITLE
Makefile: don't use --verbose while running golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test: run-unit-tests
 .PHONY: lint
 lint: build-slim build-test
 	@if [ "$$(git config --get diff.noprefix)" = "true" ]; then printf "\n\ngolangci-lint has a bug and can't run with the current git configuration: 'diff.noprefix' is set to 'true'. To override this setting for this repository, run the following command:\n\n'git config diff.noprefix false'\n\nFor more details, see https://github.com/golangci/golangci-lint/issues/948.\n\n\n"; exit 1; fi
-	golangci-lint run --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "origin/master") HEAD) --verbose ./...
+	golangci-lint run --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "origin/master") HEAD) ./...
 
 .PHONY: lint-docker
 lint-docker:


### PR DESCRIPTION
Linter should be quiet if there is no issues to report. I suspect this
was mistakenly added in ff08e54e1d562289890a14ebada8ca19e3a0529a while
the migration to config file has been tested.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>