### PR TITLE
Use fmt.Errorf instead of errors.Wrap where error handling make sense

### DIFF
--- a/cli/cmd/cluster-apply.go
+++ b/cli/cmd/cluster-apply.go
@@ -143,11 +143,12 @@ func runClusterApply(cmd *cobra.Command, args []string) {
 func verifyCluster(kubeconfig []byte, expectedNodes int) error {
 	cs, err := k8sutil.NewClientset(kubeconfig)
 	if err != nil {
-		return errors.Wrapf(err, "failed to set up clientset")
+		return fmt.Errorf("creating Kubernetes clientset: %w", err)
 	}
 
 	cluster, err := lokomotive.NewCluster(cs, expectedNodes)
 	if err != nil {
+		// TODO: NewCluster should be changed to not return an error.
 		return errors.Wrapf(err, "failed to set up cluster client")
 	}
 

--- a/pkg/components/cert-manager/component.go
+++ b/pkg/components/cert-manager/component.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -83,12 +82,12 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	values, err := template.Render(chartValuesTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart values template")
+		return nil, fmt.Errorf("rendering chart values template: %w", err)
 	}
 
 	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
+		return nil, fmt.Errorf("rendering chart: %w", err)
 	}
 
 	return renderedFiles, nil

--- a/pkg/components/cluster-autoscaler/component.go
+++ b/pkg/components/cluster-autoscaler/component.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/packethost/packngo"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -356,17 +355,17 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	if c.Provider == "packet" {
 		cl, err := packngo.NewClient()
 		if err != nil {
-			return nil, errors.Wrap(err, "create packet API client")
+			return nil, fmt.Errorf("creating Packet API client: %w", err)
 		}
 
 		devices, _, err := cl.Devices.List(c.Packet.ProjectID, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "listing devices in project %q", c.Packet.ProjectID)
+			return nil, fmt.Errorf("listing devices in project %q: %w", c.Packet.ProjectID, err)
 		}
 
 		userData, err := getWorkerUserdata(c.ClusterName, c.Packet.Facility, devices)
 		if err != nil {
-			return nil, errors.Wrapf(err, "getting worker data for cluster %q", c.ClusterName)
+			return nil, fmt.Errorf("getting worker data for cluster %q: %w", c.ClusterName, err)
 		}
 
 		c.Packet.UserData = userData
@@ -375,7 +374,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	values, err := template.Render(chartValuesTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart values template")
+		return nil, fmt.Errorf("rendering chart values template: %w", err)
 	}
 
 	return util.RenderChart(helmChart, name, c.Namespace, values)

--- a/pkg/components/dex/component.go
+++ b/pkg/components/dex/component.go
@@ -288,6 +288,7 @@ func marshalToStr(obj interface{}) (string, error) {
 	return string(b), nil
 }
 
+// TODO: convert to Helm chart.
 func (c *component) RenderManifests() (map[string]string, error) {
 	// Add the default path to google's connector, this is the default path
 	// where the user given google suite json file will be available via a

--- a/pkg/components/external-dns/component.go
+++ b/pkg/components/external-dns/component.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -118,7 +117,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	if c.AwsConfig.AccessKeyID == "" {
 		accessKeyID, ok := os.LookupEnv("AWS_ACCESS_KEY_ID")
 		if !ok || accessKeyID == "" {
-			return nil, errors.New("AWS Credentials not found.")
+			return nil, fmt.Errorf("AWS access key ID not found")
 		}
 		c.AwsConfig.AccessKeyID = accessKeyID
 	}
@@ -126,19 +125,19 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	if c.AwsConfig.SecretAccessKey == "" {
 		secretAccessKey, ok := os.LookupEnv("AWS_SECRET_ACCESS_KEY")
 		if !ok || secretAccessKey == "" {
-			return nil, errors.New("AWS Credentials not found.")
+			return nil, fmt.Errorf("AWS secret access key not found")
 		}
 		c.AwsConfig.SecretAccessKey = secretAccessKey
 	}
 
 	values, err := template.Render(chartValuesTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart values template")
+		return nil, fmt.Errorf("rendering chart values template: %w", err)
 	}
 
 	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
+		return nil, fmt.Errorf("rendering chart: %w", err)
 	}
 
 	return renderedFiles, nil

--- a/pkg/components/flatcar-linux-update-operator/component.go
+++ b/pkg/components/flatcar-linux-update-operator/component.go
@@ -15,11 +15,11 @@
 package flatcarlinuxupdateoperator
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/pkg/assets"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -47,7 +47,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	walk := assets.DumpingWalker(ret, ".yaml")
 	p := filepath.Join("/components", name)
 	if err := assets.Assets.WalkFiles(p, walk); err != nil {
-		return nil, errors.Wrap(err, "failed to walk assets")
+		return nil, fmt.Errorf("traversing assets: %w", err)
 	}
 
 	return ret, nil

--- a/pkg/components/gangway/component.go
+++ b/pkg/components/gangway/component.go
@@ -308,6 +308,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
+// TODO: Convert to Helm chart.
 func (c *component) RenderManifests() (map[string]string, error) {
 	tmpl, err := template.New("config-map").Parse(configMapTmpl)
 	if err != nil {

--- a/pkg/components/httpbin/component.go
+++ b/pkg/components/httpbin/component.go
@@ -141,6 +141,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
+// TODO: Convert to Helm chart.
 func (c *component) RenderManifests() (map[string]string, error) {
 	tmpl, err := template.New("ingress").Parse(ingressTmpl)
 	if err != nil {

--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -15,6 +15,8 @@
 package metallb
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/pkg/errors"
@@ -54,6 +56,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
+// TODO: Convert to Helm chart.
 func (c *component) RenderManifests() (map[string]string, error) {
 	// Here are `nodeSelectors` and `tolerations` that are set by upstream. To make sure that we
 	// don't miss them out we set them manually here. We cannot make these changes in the template
@@ -78,7 +81,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	t, err := util.RenderTolerations(c.SpeakerTolerations)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal speaker tolerations")
+		return nil, fmt.Errorf("marshaling speaker tolerations: %w", err)
 	}
 	c.SpeakerTolerationsJSON = t
 

--- a/pkg/components/metrics-server/component.go
+++ b/pkg/components/metrics-server/component.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -79,12 +78,12 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	values, err := template.Render(chartValuesTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart values template")
+		return nil, fmt.Errorf("rendering chart values template: %w", err)
 	}
 
 	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
+		return nil, fmt.Errorf("rendering chart: %w", err)
 	}
 
 	return renderedFiles, nil

--- a/pkg/components/openebs-storage-class/component.go
+++ b/pkg/components/openebs-storage-class/component.go
@@ -98,13 +98,14 @@ func (c *component) validateConfig() error {
 			maxDefaultStorageClass++
 		}
 		if maxDefaultStorageClass > 1 {
-			return errors.New("cannot have more than one default storage class")
+			return fmt.Errorf("cannot have more than one default storage class")
 		}
 	}
 
 	return nil
 }
 
+// TODO: Convert to Helm chart.
 func (c *component) RenderManifests() (map[string]string, error) {
 
 	scTmpl, err := template.New(name).Parse(storageClassTmpl)

--- a/pkg/components/prometheus-operator/component.go
+++ b/pkg/components/prometheus-operator/component.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -174,12 +173,12 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	values, err := template.Render(chartValuesTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart values template")
+		return nil, fmt.Errorf("rendering chart values template: %w", err)
 	}
 
 	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
+		return nil, fmt.Errorf("rendering chart: %w", err)
 	}
 
 	return renderedFiles, nil

--- a/pkg/components/rook-ceph/component.go
+++ b/pkg/components/rook-ceph/component.go
@@ -66,6 +66,7 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 	return gohcl.DecodeBody(*configBody, evalContext, c)
 }
 
+// TODO: Convert to Helm chart.
 func (c *component) RenderManifests() (map[string]string, error) {
 	// Generate YAML for Ceph cluster.
 	var err error

--- a/pkg/components/velero/velero.go
+++ b/pkg/components/velero/velero.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -156,12 +155,12 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	values, err := template.Render(chartValuesTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart values template")
+		return nil, fmt.Errorf("rendering chart values template: %w", err)
 	}
 
 	renderedFiles, err := util.RenderChart(helmChart, name, c.Namespace, values)
 	if err != nil {
-		return nil, errors.Wrap(err, "render chart")
+		return nil, fmt.Errorf("rendering chart: %w", err)
 	}
 
 	return renderedFiles, nil

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/kinvolk/lokomotive/pkg/terraform"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -109,7 +108,7 @@ func readDNSEntries(ex *terraform.Executor) ([]dnsEntry, error) {
 	var entries []dnsEntry
 
 	if err := ex.Output("dns_entries", &entries); err != nil {
-		return nil, errors.Wrap(err, "failed to get DNS entries")
+		return nil, fmt.Errorf("getting DNS entries: %w", err)
 	}
 
 	return entries, nil

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -16,11 +16,11 @@
 package helm
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
 	"github.com/kinvolk/lokomotive/pkg/assets"
-	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
@@ -39,7 +39,7 @@ type LokomotiveChart struct {
 func ChartFromAssets(location string) (*chart.Chart, error) {
 	tmpDir, err := ioutil.TempDir("", "lokoctl-chart-")
 	if err != nil {
-		return nil, errors.Wrap(err, "creating temporary dir")
+		return nil, fmt.Errorf("creating temporary directory: %w", err)
 	}
 
 	// TODO: os.RemoveAll() returns an error which we currently don't handle. Handling the error
@@ -49,7 +49,7 @@ func ChartFromAssets(location string) (*chart.Chart, error) {
 	// Rendered files could contain secrets - allow r/w access to owner only.
 	walk := assets.CopyingWalker(tmpDir, 0700)
 	if err := assets.Assets.WalkFiles(location, walk); err != nil {
-		return nil, errors.Wrap(err, "walking assets")
+		return nil, fmt.Errorf("traversing assets: %w", err)
 	}
 
 	return loader.Load(tmpDir)

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -15,9 +15,8 @@
 package install
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/pkg/assets"
 	"github.com/kinvolk/lokomotive/pkg/util"
@@ -29,13 +28,13 @@ import (
 func PrepareTerraformRootDir(path string) error {
 	pathExists, err := util.PathExists(path)
 	if err != nil {
-		return errors.Wrapf(err, "failed to stat path %q: %v", path, err)
+		return fmt.Errorf("checking if path %q exists: %w", path, err)
 	}
 	if pathExists {
 		return nil
 	}
 	if err := os.MkdirAll(path, 0755); err != nil {
-		return errors.Wrapf(err, "failed to create terraform assets directory at: %s", path)
+		return fmt.Errorf("creating Terraform assets directory at %q: %w", path, err)
 	}
 	return nil
 }
@@ -51,7 +50,8 @@ func PrepareTerraformRootDir(path string) error {
 func PrepareLokomotiveTerraformModuleAt(path string) error {
 	walk := assets.CopyingWalker(path, 0755)
 	if err := assets.Assets.WalkFiles(assets.TerraformModulesSource, walk); err != nil {
-		return errors.Wrap(err, "failed to walk assets")
+		return fmt.Errorf("traversing assets: %w", err)
 	}
+
 	return nil
 }

--- a/pkg/install/verify.go
+++ b/pkg/install/verify.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/kinvolk/lokomotive/pkg/lokomotive"
 	"github.com/kinvolk/lokomotive/pkg/util/retryutil"
 )
@@ -42,7 +40,7 @@ func Verify(cl *lokomotive.Cluster) error {
 	// Wait for cluster to become available
 	err := retryutil.Retry(clusterPingRetryInterval*time.Second, clusterPingRetries, cl.Ping)
 	if err != nil {
-		return errors.Wrapf(err, "failed to ping cluster for readiness")
+		return fmt.Errorf("pinging cluster for readiness: %w", err)
 	}
 
 	var ns *lokomotive.NodeStatus
@@ -58,7 +56,7 @@ func Verify(cl *lokomotive.Cluster) error {
 		return ns.Ready(), nil // Retry if not ready
 	})
 	if nsErr != nil {
-		return errors.Wrapf(nsErr, "error determining node status within the allowed time")
+		return fmt.Errorf("waiting for nodes: %w", nsErr)
 	}
 	if err != nil {
 		return fmt.Errorf("not all nodes became ready within the allowed time")

--- a/pkg/k8sutil/create.go
+++ b/pkg/k8sutil/create.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +80,7 @@ func LoadManifests(files map[string]string) ([]manifest, error) {
 		r := strings.NewReader(fileContent)
 		ms, err := parseManifests(r)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing file %s:", path)
+			return nil, fmt.Errorf("parsing manifest %q: %w", path, err)
 		}
 		manifests = append(manifests, ms...)
 	}
@@ -132,7 +131,7 @@ func parseJSONManifest(data []byte) ([]manifest, error) {
 		} `json:"metadata"`
 	}
 	if err := json.Unmarshal(data, &m); err != nil {
-		return nil, errors.Wrapf(err, "failed to parse manifest")
+		return nil, fmt.Errorf("unmarshaling manifest: %w", err)
 	}
 
 	// We continue if the object we received was a *List kind. Otherwise if a
@@ -158,7 +157,7 @@ func parseJSONManifest(data []byte) ([]manifest, error) {
 		Items []json.RawMessage `json:"items"`
 	}
 	if err := json.Unmarshal(data, &mList); err != nil {
-		return nil, errors.Wrapf(err, "failed to parse manifest list")
+		return nil, fmt.Errorf("unmarshaling manifest list: %w", err)
 	}
 	var manifests []manifest
 	for _, item := range mList.Items {

--- a/pkg/terraform/util.go
+++ b/pkg/terraform/util.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 
 	"github.com/kinvolk/lokomotive/pkg/assets"
-
-	"github.com/pkg/errors"
 )
 
 const backendFileName = "backend.tf"
@@ -31,7 +29,7 @@ const backendFileName = "backend.tf"
 // provided by the user.
 func Configure(assetDir, renderedBackend string) error {
 	if err := PrepareTerraformDirectoryAndModules(assetDir); err != nil {
-		return errors.Wrapf(err, "Failed to create required terraform directory")
+		return fmt.Errorf("creating Terraform directories: %w", err)
 	}
 
 	// Create backend file only if the backend rendered string isn't empty.
@@ -40,7 +38,7 @@ func Configure(assetDir, renderedBackend string) error {
 	}
 
 	if err := CreateTerraformBackendFile(assetDir, renderedBackend); err != nil {
-		return errors.Wrapf(err, "Failed to create backend configuration file")
+		return fmt.Errorf("creating backend configuration file: %w", err)
 	}
 
 	return nil
@@ -56,7 +54,7 @@ func PrepareTerraformDirectoryAndModules(assetDir string) error {
 	// Ensure Terraform root directory exists.
 	p := filepath.Join(assetDir, "terraform")
 	if err := os.MkdirAll(p, 0755); err != nil {
-		return errors.Wrapf(err, "creating Terraform root directory at %q", p)
+		return fmt.Errorf("creating Terraform root directory at %q: %w", p, err)
 	}
 
 	return nil
@@ -74,16 +72,16 @@ func CreateTerraformBackendFile(assetDir, data string) error {
 	path := filepath.Join(terraformRootDir, backendFileName)
 	f, err := os.Create(path)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create file %q", path)
+		return fmt.Errorf("creating file %q: %w", path, err)
 	}
 	defer f.Close()
 
 	if _, err = f.WriteString(backendString); err != nil {
-		return errors.Wrapf(err, "failed to write to backend file %q", path)
+		return fmt.Errorf("writing to backend file %q: %w", path, err)
 	}
 
 	if err = f.Sync(); err != nil {
-		return errors.Wrapf(err, "failed to flush data to file %q", path)
+		return fmt.Errorf("flushing data to file %q: %w", path, err)
 	}
 
 	return nil

--- a/test/calico/calico_test.go
+++ b/test/calico/calico_test.go
@@ -69,7 +69,7 @@ func TestHostEndpointObjectsExistForPublicInterfacesOnAllNodes(t *testing.T) { /
 	}
 
 	if err := json.Unmarshal(response, &hostEndpoints); err != nil {
-		t.Fatalf("failed unmarshalling response: %v\n\n%s", err, string(response))
+		t.Fatalf("failed unmarshaling response: %v\n\n%s", err, string(response))
 	}
 
 	// Collect all received host endpoints into a map, so we can quickly look up if a


### PR DESCRIPTION
This commit partially addresses issue #59, which encourages to use new
error wrapping semantics available since Go 1.13, using %w formating
verb instead of 3rd party 'pkg/errors' package.

This commit changes errors handling code from using errors.Wrap with
fmt.Errorf where error handling should remain as is. For other uses of
errors.Wrap, it adds a comment with TODO how code should be changed to
either avoid or delegate error handling to someone else.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>