### PR TITLE
docs/quickstarts: Update required ct provider version

### DIFF
--- a/docs/quickstarts/aws.md
+++ b/docs/quickstarts/aws.md
@@ -27,8 +27,8 @@ By the end of this guide, you'll have a production-ready Kubernetes cluster runn
 * Basic understanding of Kubernetes concepts.
 * AWS account and IAM credentials.
 * AWS Route53 DNS Zone (registered Domain Name or delegated subdomain).
-* Terraform v0.12.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) v0.5.0
-  installed locally
+* Terraform v0.12.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) v0.6.1
+  installed locally.
 * An SSH key pair for management access.
 * `kubectl` installed locally to access the Kubernetes cluster.
 

--- a/docs/quickstarts/baremetal.md
+++ b/docs/quickstarts/baremetal.md
@@ -27,7 +27,7 @@ worker nodes.
 
 * Basic understanding of Kubernetes concepts.
 * Terraform v0.12.x, [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox)
-and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) v0.5.0 installed locally.
+and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) v0.6.1 installed locally.
 * Machines with at least 2GB RAM, 30GB disk, PXE-enabled NIC and IPMI.
 * PXE-enabled [network boot](https://coreos.com/matchbox/docs/latest/network-setup.html) environment.
 * Matchbox v0.6+ deployment with API enabled.

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -58,8 +58,8 @@ application to verify the cluster behaves as expected.
 * An SSH key pair for accessing the cluster nodes.
 * Terraform `v0.12.x`
   [installed](https://learn.hashicorp.com/terraform/getting-started/install.html#install-terraform).
-* The `ct` Terraform provider `v0.5.0`
-  [installed](https://github.com/poseidon/terraform-provider-ct/blob/v0.5.0/README.md#install).
+* The `ct` Terraform provider `v0.6.1`
+  [installed](https://github.com/poseidon/terraform-provider-ct/blob/v0.6.1/README.md#install).
 * `kubectl` [installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 >NOTE: The `kubectl` version used to interact with a Kubernetes cluster needs to be compatible with


### PR DESCRIPTION
PR #835 updated the provider from `v0.5.0` to `v0.6.1` but didn't update the docs. Trying to deploy a cluster with `v0.5.0` results in an error.