### PR TITLE
Replace remaining uses of github.com/pkg/errors with fmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/packethost/packngo v0.2.0
 	github.com/pelletier/go-toml v1.6.0 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.20.0
 	github.com/prometheus/client_golang v1.5.0
 	github.com/prometheus/procfs v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,7 +182,9 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2 h1:aZtFdDNWY/yH86JPR2WX/PN63635VsE/f/nXNPAbYxY=
 github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/pkg/backend/s3/s3.go
+++ b/pkg/backend/s3/s3.go
@@ -15,11 +15,11 @@
 package s3
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/backend"
@@ -58,16 +58,17 @@ func (s *s3) Render() (string, error) {
 // Validate validates the s3 backend configuration.
 func (s *s3) Validate() error {
 	if s.Bucket == "" {
-		return errors.Errorf("no bucket specified")
+		return fmt.Errorf("no bucket specified")
 	}
 
 	if s.Key == "" {
-		return errors.Errorf("no key specified")
+		return fmt.Errorf("no key specified")
 	}
 
 	if s.AWSCredsPath == "" && os.Getenv("AWS_SHARED_CREDENTIALS_FILE") == "" {
 		if s.Region == "" && os.Getenv("AWS_DEFAULT_REGION") == "" {
-			return errors.Errorf("no region specified: use Region field in backend configuration or AWS_DEFAULT_REGION environment variable")
+			return fmt.Errorf("no region specified: use Region field in backend configuration or " +
+				"AWS_DEFAULT_REGION environment variable")
 		}
 	}
 

--- a/pkg/components/dex/component.go
+++ b/pkg/components/dex/component.go
@@ -18,12 +18,12 @@ import (
 	"bytes"
 	b64 "encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"text/template"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	internaltemplate "github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -302,29 +302,29 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	connectors, err := marshalToStr(c.Connectors)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal connectors")
+		return nil, fmt.Errorf("marshaling connectors: %w", err)
 	}
 	c.ConnectorsRaw = connectors
 
 	staticClients, err := marshalToStr(c.StaticClients)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal staticClients")
+		return nil, fmt.Errorf("marshaling static clients: %w", err)
 	}
 	c.StaticClientsRaw = staticClients
 
 	configMap, err := internaltemplate.Render(configMapTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "execute template failed")
+		return nil, fmt.Errorf("rendering ConfigMap template: %w", err)
 	}
 
 	ingressBuf, err := internaltemplate.Render(ingressTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "execute template failed")
+		return nil, fmt.Errorf("rendering Ingress template: %w", err)
 	}
 
 	deployment, err := internaltemplate.Render(deploymentTmpl, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "execute template failed")
+		return nil, fmt.Errorf("rendering Deployment template: %w", err)
 	}
 
 	manifests := map[string]string{
@@ -346,7 +346,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	secretManifest, err := createSecretManifest(c.GSuiteJSONConfigPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't create secret from gsuite json file")
+		return nil, fmt.Errorf("creating Secret from G Suite JSON file: %w", err)
 	}
 	manifests["secret.yml"] = secretManifest
 

--- a/pkg/components/gangway/component.go
+++ b/pkg/components/gangway/component.go
@@ -16,11 +16,11 @@ package dex
 
 import (
 	"bytes"
+	"fmt"
 	"text/template"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/k8sutil"
@@ -312,29 +312,29 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 func (c *component) RenderManifests() (map[string]string, error) {
 	tmpl, err := template.New("config-map").Parse(configMapTmpl)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse template failed")
+		return nil, fmt.Errorf("parsing ConfigMap template: %w", err)
 	}
 	var configMapBuf bytes.Buffer
 	if err := tmpl.Execute(&configMapBuf, c); err != nil {
-		return nil, errors.Wrap(err, "execute template failed")
+		return nil, fmt.Errorf("executing ConfigMap template: %w", err)
 	}
 
 	tmpl, err = template.New("ingress").Parse(ingressTmpl)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse template failed")
+		return nil, fmt.Errorf("parsing Ingress template: %w", err)
 	}
 	var ingressBuf bytes.Buffer
 	if err := tmpl.Execute(&ingressBuf, c); err != nil {
-		return nil, errors.Wrap(err, "execute template failed")
+		return nil, fmt.Errorf("executing Ingress template: %w", err)
 	}
 
 	tmpl, err = template.New("secret").Parse(secretTmpl)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse template failed")
+		return nil, fmt.Errorf("parsing Secret template: %w", err)
 	}
 	var secretBuf bytes.Buffer
 	if err := tmpl.Execute(&secretBuf, c); err != nil {
-		return nil, errors.Wrap(err, "execute template failed")
+		return nil, fmt.Errorf("executing Secret template: %w", err)
 	}
 
 	return map[string]string{

--- a/pkg/components/httpbin/component.go
+++ b/pkg/components/httpbin/component.go
@@ -16,11 +16,11 @@ package httpbin
 
 import (
 	"bytes"
+	"fmt"
 	"text/template"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/k8sutil"
@@ -145,11 +145,11 @@ func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContex
 func (c *component) RenderManifests() (map[string]string, error) {
 	tmpl, err := template.New("ingress").Parse(ingressTmpl)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse template failed")
+		return nil, fmt.Errorf("parsing template: %w", err)
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, c); err != nil {
-		return nil, errors.Wrap(err, "execute template failed")
+		return nil, fmt.Errorf("executing template: %w", err)
 	}
 	return map[string]string{
 		"namespace.yml":  namespaceManifest,

--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -87,23 +86,23 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	t, err = util.RenderTolerations(c.ControllerTolerations)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal controller tolerations")
+		return nil, fmt.Errorf("rendering controller tolerations: %w", err)
 	}
 	c.ControllerTolerationsJSON = t
 
 	controllerStr, err := template.Render(deploymentController, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "render template failed")
+		return nil, fmt.Errorf("rendering controller Deployment template: %w", err)
 	}
 
 	speakerStr, err := template.Render(daemonsetSpeaker, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "render template failed")
+		return nil, fmt.Errorf("rendering speaker DaemonSet template: %w", err)
 	}
 
 	configMapStr, err := template.Render(configMap, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "rendering ConfigMap template failed")
+		return nil, fmt.Errorf("rendering ConfigMap template: %w", err)
 	}
 
 	rendered := map[string]string{

--- a/pkg/components/openebs-storage-class/component.go
+++ b/pkg/components/openebs-storage-class/component.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	"github.com/kinvolk/lokomotive/pkg/k8sutil"
@@ -110,12 +109,12 @@ func (c *component) RenderManifests() (map[string]string, error) {
 
 	scTmpl, err := template.New(name).Parse(storageClassTmpl)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse template failed")
+		return nil, fmt.Errorf("parsing storage class template: %w", err)
 	}
 
 	spTmpl, err := template.New(poolName).Parse(storagePoolTmpl)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse template failed")
+		return nil, fmt.Errorf("parsing storage pool template: %w", err)
 	}
 
 	var manifestsMap = make(map[string]string)
@@ -125,14 +124,14 @@ func (c *component) RenderManifests() (map[string]string, error) {
 		var spBuffer bytes.Buffer
 
 		if err := scTmpl.Execute(&scBuffer, sc); err != nil {
-			return nil, errors.Wrap(err, "execute template failed")
+			return nil, fmt.Errorf("executing storage class %q template: %w", sc.Name, err)
 		}
 
 		filename := fmt.Sprintf("%s-%s.yml", name, sc.Name)
 		manifestsMap[filename] = scBuffer.String()
 
 		if err := spTmpl.Execute(&spBuffer, sc); err != nil {
-			return nil, errors.Wrap(err, "execute template failed")
+			return nil, fmt.Errorf("executing storage pool %q template: %w", sc.Name, err)
 		}
 
 		filename = fmt.Sprintf("%s-%s.yml", poolName, sc.Name)

--- a/pkg/components/rook-ceph/component.go
+++ b/pkg/components/rook-ceph/component.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/pkg/errors"
 
 	internaltemplate "github.com/kinvolk/lokomotive/internal/template"
 	"github.com/kinvolk/lokomotive/pkg/components"
@@ -72,7 +71,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	var err error
 	c.TolerationsRaw, err = util.RenderTolerations(c.Tolerations)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to render tolerations")
+		return nil, fmt.Errorf("rendering tolerations: %w", err)
 	}
 
 	ret := make(map[string]string)

--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/pkg/assets"
 	"github.com/kinvolk/lokomotive/pkg/oidc"
@@ -185,7 +184,7 @@ func createTerraformConfigFile(cfg *config, terraformRootDir string) error {
 	t, err := t.Parse(terraformConfigTmpl)
 	if err != nil {
 		// TODO: Use template.Must().
-		return errors.Wrap(err, "failed to parse template")
+		return fmt.Errorf("parsing template: %w", err)
 	}
 
 	path := filepath.Join(terraformRootDir, tmplName)
@@ -198,13 +197,13 @@ func createTerraformConfigFile(cfg *config, terraformRootDir string) error {
 	keyListBytes, err := json.Marshal(cfg.SSHPubKeys)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrap(err, "failed to marshal SSH public keys")
+		return fmt.Errorf("marshaling SSH public keys: %w", err)
 	}
 
 	controllerCLCSnippetsBytes, err := json.Marshal(cfg.ControllerCLCSnippets)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to marshal CLC snippets")
+		return fmt.Errorf("marshaling CLC snippets: %w", err)
 	}
 
 	// Configure oidc flags and set it to KubeAPIServerExtraFlags.
@@ -222,7 +221,7 @@ func createTerraformConfigFile(cfg *config, terraformRootDir string) error {
 	tags, err := json.Marshal(cfg.Tags)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to marshal tags")
+		return fmt.Errorf("marshaling tags: %w", err)
 	}
 
 	for _, workerpool := range cfg.WorkerPools {

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/pkg/assets"
 	"github.com/kinvolk/lokomotive/pkg/oidc"
@@ -147,7 +146,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 	t, err := t.Parse(terraformConfigTmpl)
 	if err != nil {
 		// TODO: Use template.Must().
-		return errors.Wrap(err, "failed to parse template")
+		return fmt.Errorf("parsing template: %w", err)
 	}
 
 	path := filepath.Join(terraformPath, tmplName)
@@ -171,43 +170,43 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 	keyListBytes, err := json.Marshal(cfg.SSHPubKeys)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrap(err, "failed to marshal SSH public keys")
+		return fmt.Errorf("marshaling SSH public keys: %w", err)
 	}
 
 	workerDomains, err := json.Marshal(cfg.WorkerDomains)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to parse %q", cfg.WorkerDomains)
+		return fmt.Errorf("marshaling worker domains: %w", err)
 	}
 
 	workerMacs, err := json.Marshal(cfg.WorkerMacs)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to parse %q", cfg.WorkerMacs)
+		return fmt.Errorf("marshaling worker MAC addresses: %w", err)
 	}
 
 	workerNames, err := json.Marshal(cfg.WorkerNames)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to parse %q", cfg.WorkerNames)
+		return fmt.Errorf("marshaling worker names: %w", err)
 	}
 
 	controllerDomains, err := json.Marshal(cfg.ControllerDomains)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to parse %q", cfg.ControllerDomains)
+		return fmt.Errorf("marshaling controller domains: %w", err)
 	}
 
 	controllerMacs, err := json.Marshal(cfg.ControllerMacs)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to parse %q", cfg.ControllerMacs)
+		return fmt.Errorf("marshaling controller MAC addresses: %w", err)
 	}
 
 	controllerNames, err := json.Marshal(cfg.ControllerNames)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to parse %q", cfg.ControllerNames)
+		return fmt.Errorf("marshaling controller names: %w", err)
 	}
 
 	terraformCfg := struct {

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 
 	"github.com/kinvolk/lokomotive/pkg/assets"
 	"github.com/kinvolk/lokomotive/pkg/dns"
@@ -223,7 +222,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 	t, err := t.Parse(terraformConfigTmpl)
 	if err != nil {
 		// TODO: Use template.Must().
-		return errors.Wrap(err, "failed to parse template")
+		return fmt.Errorf("parsing template: %w", err)
 	}
 
 	path := filepath.Join(terraformPath, tmplName)
@@ -236,13 +235,13 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 	keyListBytes, err := json.Marshal(cfg.SSHPubKeys)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrap(err, "failed to marshal SSH public keys")
+		return fmt.Errorf("marshaling SSH public keys: %w", err)
 	}
 
 	managementCIDRs, err := json.Marshal(cfg.ManagementCIDRs)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to marshal management CIDRs")
+		return fmt.Errorf("marshaling management CIDRs: %w", err)
 	}
 	// Configure oidc flags and set it to KubeAPIServerExtraFlags.
 	if cfg.OIDC != nil {
@@ -264,7 +263,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 	tags, err := json.Marshal(tagsList)
 	if err != nil {
 		// TODO: Render manually instead of marshaling.
-		return errors.Wrapf(err, "failed to marshal tags")
+		return fmt.Errorf("marshaling tags: %w", err)
 	}
 	// Append lokoctl-version tag to all worker pools.
 	for i := range cfg.WorkerPools {


### PR DESCRIPTION
Even though all of them should actually be removed, this commit finishes
the migration to 'fmt.Errorf' for the sake of consistency and
effectively drops the direct dependency on 'github.com/pkg/errors'.

Closes #59

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>