### PR TITLE
rook ceph: Add CSI plugin affinity & toleration attribute

### DIFF
--- a/docs/configuration-reference/components/rook.md
+++ b/docs/configuration-reference/components/rook.md
@@ -67,6 +67,8 @@ Example:
 | `discover_toleration_key`    | Toleration key for the rook discover pods.                                                               |    -    | string                                                                                                         |  false   |
 | `discover_toleration_effect` | Toleration effect for the rook discover pods. Needs to be specified if `discover_toleration_key` is set. |    -    | string                                                                                                         |  false   |
 | `enable_monitoring`          | Enable Monitoring for the Rook sub-systems. Make sure that the Prometheus Operator is installed.         |  false  | bool                                                                                                           |  false   |
+| `csi_plugin_node_selector`   | A map with specific labels to install Rook CSI plugins on a group of nodes.                              |    -    | map(string)                                                                                                    |  false   |
+| `csi_plugin_toleration`      | Tolerations that the Rook CSI plugin installation pods will tolerate.                                    |    -    | list(object({key = string, effect = string, operator = string, value = string, toleration_seconds = string })) |  false   |
 
 
 ## Applying

--- a/pkg/components/rook/manifests.go
+++ b/pkg/components/rook/manifests.go
@@ -34,11 +34,11 @@ csi:
   provisionerNodeAffinity: {{ .RookNodeAffinity }}
   {{- end }}
 
-  {{- if .Tolerations }}
-  pluginTolerations: {{ .TolerationsRaw }}
+  {{- if .CSIPluginTolerations }}
+  pluginTolerations: {{ .CSIPluginTolerationsRaw }}
   {{- end }}
-  {{- if .NodeSelector }}
-  pluginNodeAffinity: {{ .RookNodeAffinity }}
+  {{- if .CSIPluginNodeSelector }}
+  pluginNodeAffinity: {{ .CSIPluginNodeAffinity }}
   {{- end }}
 
 agent:


### PR DESCRIPTION
This commit adds two new attributes: `csi_plugin_node_selector` and
`csi_plugin_toleration` which will enable the plugin pods to install the
necessary plugins on non-ceph nodes.

- [ ] Add docs.