### PR TITLE
ci/aws: increase number of worker nodes to 3

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -34,7 +34,7 @@ EOF
   ]
 
   worker_pool "$CLUSTER_ID-w1" {
-    count         = 2
+    count         = 3
     ssh_pubkeys   = ["$PUB_KEY"]
     disk_size     = 30
     instance_type = "i3.large"


### PR DESCRIPTION
It looks like with 2 i3.large instances, istiod sometimes gets stuck in
Pending state due to insufficient CPU.

Closes #887

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>