### PR TITLE
Makefile: Don't build before linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,9 @@ build-slim:
 test: run-unit-tests
 
 .PHONY: lint
-lint: build-slim build-test
+lint: build-slim build-test lint-bin
+
+lint-bin:
 	@if [ "$$(git config --get diff.noprefix)" = "true" ]; then printf "\n\ngolangci-lint has a bug and can't run with the current git configuration: 'diff.noprefix' is set to 'true'. To override this setting for this repository, run the following command:\n\n'git config diff.noprefix false'\n\nFor more details, see https://github.com/golangci/golangci-lint/issues/948.\n\n\n"; exit 1; fi
 	golangci-lint run --new-from-rev=$$(git merge-base $$(cat .git/resource/base_sha 2>/dev/null || echo "origin/master") HEAD) ./...
 


### PR DESCRIPTION
Building the codebase before running the linter adds over 20 seconds to the run time of `make lint`:

```
time make lint
CGO_ENABLED=0 GO111MODULE=on go build \
        -mod=vendor \
        -ldflags "-X github.com/kinvolk/lokomotive/pkg/version.Version=`git describe --tags --always` -extldflags '-static'" \
        -buildmode=exe \
        -o lokoctl \
        github.com/kinvolk/lokomotive/cmd/lokoctl
go test -run=nonexistent -mod=vendor -tags="aws,packet,aks,e2e,baremetal,disruptivee2e,poste2e" -covermode=atomic -buildmode=exe -v ./... > /dev/null
golangci-lint run --new-from-rev=$(git merge-base $(cat .git/resource/base_sha 2>/dev/null || echo "origin/master") HEAD) ./...
make lint  132.99s user 11.97s system 615% cpu 23.556 total
```

```
time make lint
golangci-lint run --new-from-rev=$(git merge-base $(cat .git/resource/base_sha 2>/dev/null || echo "origin/master") HEAD) ./...
make lint  3.41s user 0.54s system 368% cpu 1.071 total
```

`make lint` is used frequently while developing and therefore should be fast. The linter shouts about syntax errors in source files anyway, so running an explicit build is redundant.