### PR TITLE
cli/cmd: fix re-installing controlplane components in custom namespaces

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -208,6 +208,7 @@ func (c controlplaneUpdater) upgradeComponent(component, namespace string) {
 		install.ReleaseName = component
 		install.Namespace = namespace
 		install.Atomic = true
+		install.CreateNamespace = true
 
 		if _, err := install.Run(helmChart, values); err != nil {
 			fmt.Println("Failed!")


### PR DESCRIPTION
Since 474abab61cfc7bf33aeb91ea8682f5f7228d986d, we support also
installing controlplane components in namespaces other than kube-system.

On fresh installation, those namespaces are being created by bootkube.

However, in scenario when user upgrades from the previous release, we
also need to ensure that custom namespace exists, so this commit does
that by instructing Helm to use CreateNamespace feature.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>