### PR TITLE
Add encryption to in-cluster pod traffic

### DIFF
--- a/assets/charts/control-plane/calico-host-protection/templates/host-protection.yaml
+++ b/assets/charts/control-plane/calico-host-protection/templates/host-protection.yaml
@@ -1,15 +1,3 @@
-# General
-# =======
----
-# Disable default failsafe inbound rules
-apiVersion: crd.projectcalico.org/v1
-kind: FelixConfiguration
-metadata:
-  name: default
-spec:
-  failsafeInboundHostPorts: []
-  bpfLogLevel: Info
-
 # Firewall policy
 # ===============
 ---

--- a/assets/charts/control-plane/calico/templates/config.yaml
+++ b/assets/charts/control-plane/calico/templates/config.yaml
@@ -13,7 +13,7 @@ data:
   # - Otherwise, if VXLAN or BPF mode is enabled, set to your network MTU - 50
   # - Otherwise, if IPIP is enabled, set to your network MTU - 20
   # - Otherwise, if not using any encapsulation, set to your network MTU.
-  veth_mtu: "{{ .Values.calico.networkMTU }}"
+  veth_mtu: "{{ sub .Values.calico.networkMTU 20 }}" # IP in IP overhead.
   # The CNI network configuration to install on each node. The special
   # values in this config will be automatically populated.
   cni_network_config: |-

--- a/assets/charts/control-plane/calico/templates/config.yaml
+++ b/assets/charts/control-plane/calico/templates/config.yaml
@@ -13,7 +13,11 @@ data:
   # - Otherwise, if VXLAN or BPF mode is enabled, set to your network MTU - 50
   # - Otherwise, if IPIP is enabled, set to your network MTU - 20
   # - Otherwise, if not using any encapsulation, set to your network MTU.
+  {{- if .Values.calico.encryptPodTraffic }}
+  veth_mtu: "{{ sub .Values.calico.networkMTU 60 }}" # Wireguard overhead.
+  {{- else }}
   veth_mtu: "{{ sub .Values.calico.networkMTU 20 }}" # IP in IP overhead.
+  {{- end}}
   # The CNI network configuration to install on each node. The special
   # values in this config will be automatically populated.
   cni_network_config: |-

--- a/assets/charts/control-plane/calico/templates/felixconfig.yaml
+++ b/assets/charts/control-plane/calico/templates/felixconfig.yaml
@@ -7,3 +7,4 @@ spec:
   failsafeInboundHostPorts: {{ .Values.calico.failsafeInboundHostPorts }}
   {{- end }}
   bpfLogLevel: Info
+  wireguardEnabled: {{ .Values.calico.encryptPodTraffic }}

--- a/assets/charts/control-plane/calico/templates/felixconfig.yaml
+++ b/assets/charts/control-plane/calico/templates/felixconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: crd.projectcalico.org/v1
+kind: FelixConfiguration
+metadata:
+  name: default
+spec:
+  {{- if hasKey .Values.calico "failsafeInboundHostPorts"  }}
+  failsafeInboundHostPorts: {{ .Values.calico.failsafeInboundHostPorts }}
+  {{- end }}
+  bpfLogLevel: Info

--- a/assets/charts/control-plane/calico/values.yaml
+++ b/assets/charts/control-plane/calico/values.yaml
@@ -13,3 +13,5 @@ calico:
   podCIDR: 10.2.0.0/16
   networkEncapsulation: "ipipMode: Always"
   blockedMetadataCIDRs: []
+  # Lokomotive specific change.
+  # failsafeInboundHostPorts:

--- a/assets/charts/control-plane/calico/values.yaml
+++ b/assets/charts/control-plane/calico/values.yaml
@@ -15,3 +15,4 @@ calico:
   blockedMetadataCIDRs: []
   # Lokomotive specific change.
   # failsafeInboundHostPorts:
+  encryptPodTraffic: false

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -30,4 +30,5 @@ module "bootkube" {
 
   bootstrap_tokens     = var.enable_tls_bootstrap ? concat([local.controller_bootstrap_token], var.worker_bootstrap_tokens) : []
   enable_tls_bootstrap = var.enable_tls_bootstrap
+  encrypt_pod_traffic  = var.encrypt_pod_traffic
 }

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/variables.tf
@@ -184,3 +184,9 @@ variable "kube_apiserver_extra_flags" {
   type        = list(string)
   default     = []
 }
+
+variable "encrypt_pod_traffic" {
+  description = "Enable in-cluster pod traffic encryption."
+  type        = bool
+  default     = false
+}

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/variables.tf
@@ -111,9 +111,8 @@ variable "asset_dir" {
 }
 
 variable "network_mtu" {
-  description = "CNI interface MTU. Use 8981 if using instances types with Jumbo frames."
+  description = "Physical Network MTU. Use 9001 if using instances types with Jumbo frames."
   type        = number
-  default     = 1480
 }
 
 variable "host_cidr" {

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -23,4 +23,5 @@ module "bootkube" {
 
   bootstrap_tokens     = var.enable_tls_bootstrap ? [local.controller_bootstrap_token, local.worker_bootstrap_token] : []
   enable_tls_bootstrap = var.enable_tls_bootstrap
+  encrypt_pod_traffic  = var.encrypt_pod_traffic
 }

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -83,9 +83,8 @@ variable "asset_dir" {
 }
 
 variable "network_mtu" {
-  description = "CNI interface MTU"
+  description = "Physical Network MTU."
   type        = number
-  default     = 1480
 }
 
 variable "network_ip_autodetection_method" {

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -183,3 +183,9 @@ variable "kube_apiserver_extra_flags" {
   type        = list(string)
   default     = []
 }
+
+variable "encrypt_pod_traffic" {
+  description = "Enable in-cluster pod traffic encryption."
+  type        = bool
+  default     = false
+}

--- a/assets/terraform-modules/bootkube/conditional.tf
+++ b/assets/terraform-modules/bootkube/conditional.tf
@@ -22,6 +22,7 @@ resource "local_file" "calico" {
         port     = protoport.port
       }
     ] : null
+    encrypt_pod_traffic = var.encrypt_pod_traffic
   })
   filename = "${var.asset_dir}/charts/kube-system/calico.yaml"
 }

--- a/assets/terraform-modules/bootkube/conditional.tf
+++ b/assets/terraform-modules/bootkube/conditional.tf
@@ -15,6 +15,13 @@ resource "local_file" "calico" {
     pod_cidr                        = var.pod_cidr
     enable_reporting                = var.enable_reporting
     blocked_metadata_cidrs          = var.blocked_metadata_cidrs
+    failsafe_inbound_host_ports = var.failsafe_inbound_host_ports != null ? [
+      for protoport in var.failsafe_inbound_host_ports :
+      {
+        protocol = protoport.protocol
+        port     = protoport.port
+      }
+    ] : null
   })
   filename = "${var.asset_dir}/charts/kube-system/calico.yaml"
 }

--- a/assets/terraform-modules/bootkube/resources/charts/calico.yaml
+++ b/assets/terraform-modules/bootkube/resources/charts/calico.yaml
@@ -16,3 +16,13 @@ calico:
   - ${cidr}
   %{~ endfor ~}
   %{~ endif ~}
+  %{~ if failsafe_inbound_host_ports != null && failsafe_inbound_host_ports != [] ~}
+  failsafeInboundHostPorts:
+  %{~ for protoport in failsafe_inbound_host_ports ~}
+  - protocol: ${protoport.protocol}
+    port: ${protoport.port}
+  %{~ endfor ~}
+  %{~ endif ~}
+  %{~ if failsafe_inbound_host_ports == [] ~}
+  failsafeInboundHostPorts: []
+  %{~ endif ~}

--- a/assets/terraform-modules/bootkube/resources/charts/calico.yaml
+++ b/assets/terraform-modules/bootkube/resources/charts/calico.yaml
@@ -26,3 +26,4 @@ calico:
   %{~ if failsafe_inbound_host_ports == [] ~}
   failsafeInboundHostPorts: []
   %{~ endif ~}
+  encryptPodTraffic: ${encrypt_pod_traffic}

--- a/assets/terraform-modules/bootkube/variables.tf
+++ b/assets/terraform-modules/bootkube/variables.tf
@@ -179,3 +179,9 @@ variable "failsafe_inbound_host_ports" {
   type        = list(any)
   default     = null
 }
+
+variable "encrypt_pod_traffic" {
+  description = "Enable in-cluster pod traffic encryption."
+  type        = bool
+  default     = false
+}

--- a/assets/terraform-modules/bootkube/variables.tf
+++ b/assets/terraform-modules/bootkube/variables.tf
@@ -173,3 +173,9 @@ variable "enable_tls_bootstrap" {
   description = "Enable TLS Bootstrap for Kubelet."
   type        = bool
 }
+
+variable "failsafe_inbound_host_ports" {
+  description = "UDP/TCP/SCTP protocol/port pairs to allow incoming traffic on regardless of the security policy."
+  type        = list(any)
+  default     = null
+}

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -12,6 +12,7 @@ module "bootkube" {
   cluster_domain_suffix = var.cluster_domain_suffix
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
+  encrypt_pod_traffic   = var.encrypt_pod_traffic
 
   // temporary
   external_apiserver_port = 443

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -130,3 +130,9 @@ variable "certs_validity_period_hours" {
   type        = number
   default     = 8760
 }
+
+variable "encrypt_pod_traffic" {
+  description = "Enable in-cluster pod traffic encryption."
+  type        = bool
+  default     = false
+}

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -17,6 +17,7 @@ module "bootkube" {
   cluster_domain_suffix = var.cluster_domain_suffix
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
+  encrypt_pod_traffic   = var.encrypt_pod_traffic
 
   certs_validity_period_hours = var.certs_validity_period_hours
 }

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -112,3 +112,9 @@ variable "certs_validity_period_hours" {
   type        = number
   default     = 8760
 }
+
+variable "encrypt_pod_traffic" {
+  description = "Enable in-cluster pod traffic encryption."
+  type        = bool
+  default     = false
+}

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -47,4 +47,5 @@ module "bootkube" {
 
   # We install calico-host-protection chart on Packet which ships GNPs, so we can disable failsafe ports in Calico.
   failsafe_inbound_host_ports = []
+  encrypt_pod_traffic         = var.encrypt_pod_traffic
 }

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -44,4 +44,7 @@ module "bootkube" {
 
   bootstrap_tokens     = var.enable_tls_bootstrap ? concat([local.controller_bootstrap_token], var.worker_bootstrap_tokens) : []
   enable_tls_bootstrap = var.enable_tls_bootstrap
+
+  # We install calico-host-protection chart on Packet which ships GNPs, so we can disable failsafe ports in Calico.
+  failsafe_inbound_host_ports = []
 }

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/variables.tf
@@ -86,9 +86,8 @@ variable "asset_dir" {
 }
 
 variable "network_mtu" {
-  description = "CNI interface MTU"
+  description = "Physical Network MTU."
   type        = number
-  default     = 1480
 }
 
 variable "network_ip_autodetection_method" {

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/variables.tf
@@ -201,3 +201,9 @@ variable "kube_apiserver_extra_flags" {
   type        = list(string)
   default     = []
 }
+
+variable "encrypt_pod_traffic" {
+  description = "Enable in-cluster pod traffic encryption."
+  type        = bool
+  default     = false
+}

--- a/docs/configuration-reference/platforms/aws.md
+++ b/docs/configuration-reference/platforms/aws.md
@@ -107,6 +107,8 @@ cluster "aws" {
 
   enable_tls_bootstrap = true
 
+  encrypt_pod_traffic = true
+
   disk_size = var.disk_size
 
   disk_type = var.disk_type
@@ -219,6 +221,7 @@ worker_pool "my-worker-pool" {
 | `region`                      | AWS region to use for deploying the cluster.                                                                                                                                               | "eu-central-1"  |    string    |  false   |
 | `enable_aggregation`          | Enable the Kubernetes Aggregation Layer.                                                                                                                                                   |      true       |     bool     |  false   |
 | `enable_tls_bootstrap`        | Enable TLS bootstraping for Kubelet.                                                                                                                                                       |      true       |     bool     |  false   |
+| `encrypt_pod_traffic`         | Enable in-cluster pod traffic encryption. If true `network_mtu` is reduced by 60 to make room for the encryption header.                                                                   |      false      |     bool     |  false   |
 | `disk_size`                   | Size of the EBS volume in GB.                                                                                                                                                              |       40        |    number    |  false   |
 | `disk_type`                   | Type of the EBS volume (e.g. standard, gp2, io1).                                                                                                                                          |      "gp2"      |    string    |  false   |
 | `disk_iops`                   | IOPS of the EBS volume (e.g 100).                                                                                                                                                          |        0        |    number    |  false   |

--- a/docs/configuration-reference/platforms/aws.md
+++ b/docs/configuration-reference/platforms/aws.md
@@ -113,7 +113,7 @@ cluster "aws" {
 
   disk_iops = var.disk_iops
 
-  network_mtu = 1480
+  network_mtu = 1500
 
   host_cidr = ""
 
@@ -222,7 +222,7 @@ worker_pool "my-worker-pool" {
 | `disk_size`                   | Size of the EBS volume in GB.                                                                                                                                                              |       40        |    number    |  false   |
 | `disk_type`                   | Type of the EBS volume (e.g. standard, gp2, io1).                                                                                                                                          |      "gp2"      |    string    |  false   |
 | `disk_iops`                   | IOPS of the EBS volume (e.g 100).                                                                                                                                                          |        0        |    number    |  false   |
-| `network_mtu`                 | CNI interface MTU. Use 8981 if using instances types with Jumbo frames.                                                                                                                    |      1480       |    number    |  false   |
+| `network_mtu`                 | Physical Network MTU. When using instance types with Jumbo frames, use 9001.                                                                                                               |      1500       |    number    |  false   |
 | `host_cidr`                   | CIDR IPv4 range to assign to EC2 nodes.                                                                                                                                                    |  "10.0.0.0/16"  |    string    |  false   |
 | `pod_cidr`                    | CIDR IPv4 range to assign Kubernetes pods.                                                                                                                                                 |  "10.2.0.0/16"  |    string    |  false   |
 | `service_cidr`                | CIDR IPv4 range to assign Kubernetes services.                                                                                                                                             |  "10.3.0.0/16"  |    string    |  false   |

--- a/docs/configuration-reference/platforms/baremetal.md
+++ b/docs/configuration-reference/platforms/baremetal.md
@@ -96,6 +96,8 @@ cluster "bare-metal" {
 
   enable_tls_bootstrap = true
 
+  encrypt_pod_traffic = true
+
   oidc {
     issuer_url     = var.oidc_issuer_url
     client_id      = var.oidc_client_id
@@ -153,6 +155,7 @@ os_version = var.custom_default_os_version
 | `os_version`                | Flatcar Container Linux version to install. Version such as "2303.3.1" or "current".                                                                                         |    "current"     |    string    |  false   |
 | `os_channel`                | Flatcar Container Linux channel to install from ("flatcar-stable", "flatcar-beta", "flatcar-alpha", "flatcar-edge").                                                         | "flatcar-stable" |    string    |  false   |
 | `enable_tls_bootstrap`      | Enable TLS bootstraping for Kubelet.                                                                                                                                         |       true       |     bool     |  false   |
+| `encrypt_pod_traffic`       | Enable in-cluster pod traffic encryption. If true `network_mtu` is reduced by 60 to make room for the encryption header.                                                     |      false       |     bool     |  false   |
 | `oidc`                      | OIDC configuration block.                                                                                                                                                    |        -         |    object    |  false   |
 | `oidc.issuer_url`           | URL of the provider which allows the API server to discover public signing keys. Only URLs which use the https:// scheme are accepted.                                       |        -         |    string    |  false   |
 | `oidc.client_id`            | A client id that all tokens must be issued for.                                                                                                                              |    "gangway"     |    string    |  false   |

--- a/docs/configuration-reference/platforms/baremetal.md
+++ b/docs/configuration-reference/platforms/baremetal.md
@@ -76,7 +76,7 @@ cluster "bare-metal" {
     "testlabel" = ""
   }
 
-  network_mtu = 1480
+  network_mtu = 1500
 
   controller_domains = var.controller_domains
 
@@ -145,7 +145,7 @@ os_version = var.custom_default_os_version
 | `matchbox_client_key_path`  | Path to the server TLS key file.                                                                                                                                             |        -         |    string    |   true   |
 | `matchbox_endpoint`         | Matchbox API endpoint.                                                                                                                                                       |        -         |    string    |   true   |
 | `matchbox_http_endpoint`    | Matchbox HTTP read-only endpoint. Example: "http://matchbox.example.com:8080"                                                                                                |        -         |    string    |   true   |
-| `network_mtu`               | CNI interface MTU.                                                                                                                                                           |       1480       |    number    |  false   |
+| `network_mtu`               | Physical Network MTU.                                                                                                                                                        |       1500       |    number    |  false   |
 | `worker_names`              | Ordered list of worker names. Example: ["node2", "node3"]                                                                                                                    |        -         | list(string) |   true   |
 | `worker_macs`               | Ordered list of worker identifying MAC addresses. Example ["52:54:00:b2:2f:86", "52:54:00:c3:61:77"]                                                                         |        -         | list(string) |   true   |
 | `worker_domains`            | Ordered list of worker FQDNs. Example ["node2.example.com", "node3.example.com"]                                                                                             |        -         | list(string) |   true   |

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -111,6 +111,8 @@ cluster "packet" {
 
   enable_tls_bootstrap = true
 
+  encrypt_pod_traffic = true
+
   enable_reporting = false
 
   network_ip_autodetection_method = "first-found"
@@ -221,6 +223,7 @@ node_type = var.custom_default_worker_type
 | `node_private_cidr`                   | Private IPv4 CIDR of the nodes used to allow inter-node traffic. Example "10.0.0.0/8"                                                                                                                                                                                             |        -        |    string    |   true   |
 | `enable_aggregation`                  | Enable the Kubernetes Aggregation Layer.                                                                                                                                                                                                                                          |      true       |     bool     |  false   |
 | `enable_tls_bootstrap`                | Enable TLS bootstraping for Kubelet.                                                                                                                                                                                                                                              |      true       |     bool     |  false   |
+| `encrypt_pod_traffic`                 | Enable in-cluster pod traffic encryption. If true `network_mtu` is reduced by 60 to make room for the encryption header.                                                                                                                                                          |      false      |     bool     |  false   |
 | `network_mtu`                         | Physical Network MTU.                                                                                                                                                                                                                                                             |      1500       |    number    |  false   |
 | `pod_cidr`                            | CIDR IPv4 range to assign Kubernetes pods.                                                                                                                                                                                                                                        |  "10.2.0.0/16"  |    string    |  false   |
 | `service_cidr`                        | CIDR IPv4 range to assign Kubernetes services.                                                                                                                                                                                                                                    |  "10.3.0.0/16"  |    string    |  false   |

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -100,7 +100,7 @@ cluster "packet" {
 
   cluster_domain_suffix = "cluster.local"
 
-  network_mtu = 1480
+  network_mtu = 1500
 
   tags {
     key1 = "value1"
@@ -221,7 +221,7 @@ node_type = var.custom_default_worker_type
 | `node_private_cidr`                   | Private IPv4 CIDR of the nodes used to allow inter-node traffic. Example "10.0.0.0/8"                                                                                                                                                                                             |        -        |    string    |   true   |
 | `enable_aggregation`                  | Enable the Kubernetes Aggregation Layer.                                                                                                                                                                                                                                          |      true       |     bool     |  false   |
 | `enable_tls_bootstrap`                | Enable TLS bootstraping for Kubelet.                                                                                                                                                                                                                                              |      true       |     bool     |  false   |
-| `network_mtu`                         | CNI interface MTU                                                                                                                                                                                                                                                                 |      1480       |    number    |  false   |
+| `network_mtu`                         | Physical Network MTU.                                                                                                                                                                                                                                                             |      1500       |    number    |  false   |
 | `pod_cidr`                            | CIDR IPv4 range to assign Kubernetes pods.                                                                                                                                                                                                                                        |  "10.2.0.0/16"  |    string    |  false   |
 | `service_cidr`                        | CIDR IPv4 range to assign Kubernetes services.                                                                                                                                                                                                                                    |  "10.3.0.0/16"  |    string    |  false   |
 | `cluster_domain_suffix`               | Cluster's DNS domain.                                                                                                                                                                                                                                                             | "cluster.local" |    string    |  false   |

--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -83,6 +83,7 @@ type config struct {
 	DisableSelfHostedKubelet bool              `hcl:"disable_self_hosted_kubelet,optional"`
 	OIDC                     *oidc.Config      `hcl:"oidc,block"`
 	EnableTLSBootstrap       bool              `hcl:"enable_tls_bootstrap,optional"`
+	EncryptPodTraffic        bool              `hcl:"encrypt_pod_traffic,optional"`
 	KubeAPIServerExtraFlags  []string
 }
 

--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -108,6 +108,7 @@ func NewConfig() *config {
 		Region:             "eu-central-1",
 		EnableAggregation:  true,
 		EnableTLSBootstrap: true,
+		NetworkMTU:         platform.NetworkMTU,
 	}
 }
 

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -97,6 +97,11 @@ module "aws-{{.Config.ClusterName}}" {
   {{- end }}
 
   enable_tls_bootstrap    = {{ .Config.EnableTLSBootstrap }}
+
+  {{- if .Config.EncryptPodTraffic }}
+  encrypt_pod_traffic = {{.Config.EncryptPodTraffic}}
+  {{- end }}
+
   worker_bootstrap_tokens = [
     {{- range $index, $pool := .Config.WorkerPools }}
     module.worker-pool-{{ $index }}.worker_bootstrap_token,

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -89,6 +89,7 @@ func NewConfig() *config {
 		OSChannel:          "flatcar-stable",
 		OSVersion:          "current",
 		EnableTLSBootstrap: true,
+		NetworkMTU:         platform.NetworkMTU,
 	}
 }
 

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -55,6 +55,7 @@ type config struct {
 	Labels                   map[string]string `hcl:"labels,optional"`
 	OIDC                     *oidc.Config      `hcl:"oidc,block"`
 	EnableTLSBootstrap       bool              `hcl:"enable_tls_bootstrap,optional"`
+	EncryptPodTraffic        bool              `hcl:"encrypt_pod_traffic,optional"`
 	KubeAPIServerExtraFlags  []string
 }
 
@@ -234,6 +235,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		KubeAPIServerExtraFlags  []string
 		Labels                   map[string]string
 		EnableTLSBootstrap       bool
+		EncryptPodTraffic        bool
 	}{
 		CachedInstall:            cfg.CachedInstall,
 		ClusterName:              cfg.ClusterName,
@@ -257,6 +259,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		KubeAPIServerExtraFlags:  cfg.KubeAPIServerExtraFlags,
 		Labels:                   cfg.Labels,
 		EnableTLSBootstrap:       cfg.EnableTLSBootstrap,
+		EncryptPodTraffic:        cfg.EncryptPodTraffic,
 	}
 
 	if err := t.Execute(f, terraformCfg); err != nil {

--- a/pkg/platform/baremetal/template.go
+++ b/pkg/platform/baremetal/template.go
@@ -30,6 +30,10 @@ module "bare-metal-{{.ClusterName}}" {
   # Enable TLS Bootstrap
   enable_tls_bootstrap = {{ .EnableTLSBootstrap }}
 
+  {{- if .EncryptPodTraffic }}
+  encrypt_pod_traffic = {{ .EncryptPodTraffic }}
+  {{- end }}
+
   # configuration
   cached_install     = "{{.CachedInstall}}"
   k8s_domain_name    = "{{.K8sDomainName}}"

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -121,6 +121,7 @@ func NewConfig() *config {
 	return &config{
 		EnableAggregation:  true,
 		EnableTLSBootstrap: true,
+		NetworkMTU:         platform.NetworkMTU,
 	}
 }
 

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -94,6 +94,7 @@ type config struct {
 	DisableSelfHostedKubelet bool              `hcl:"disable_self_hosted_kubelet,optional"`
 	OIDC                     *oidc.Config      `hcl:"oidc,block"`
 	EnableTLSBootstrap       bool              `hcl:"enable_tls_bootstrap,optional"`
+	EncryptPodTraffic        bool              `hcl:"encrypt_pod_traffic,optional"`
 	WorkerPools              []workerPool      `hcl:"worker_pool,block"`
 	// Not exposed to the user
 	KubeAPIServerExtraFlags []string

--- a/pkg/platform/packet/packet_test.go
+++ b/pkg/platform/packet/packet_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package packet
 
 import (

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -112,6 +112,11 @@ EOF
   {{- end }}
 
   enable_tls_bootstrap    = {{ .Config.EnableTLSBootstrap }}
+
+  {{- if .Config.EncryptPodTraffic }}
+  encrypt_pod_traffic = {{.Config.EncryptPodTraffic}}
+  {{- end }}
+
   worker_bootstrap_tokens = [
     {{- range $index, $pool := .Config.WorkerPools }}
     module.worker-{{$pool.Name}}.worker_bootstrap_token,

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -27,6 +27,9 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/version"
 )
 
+// NetworkMTU is the default host network MTU.
+const NetworkMTU = 1500
+
 // CommonControlPlaneCharts returns a list of control plane Helm charts to be deployed for all
 // platforms.
 func CommonControlPlaneCharts() []helm.LokomotiveChart {


### PR DESCRIPTION
Calico v3.15+ support wireguard and if enabled it encrypts in-cluster
pod traffic across nodes.

Signed-off-by: knrt10 <kautilya@kinvolk.io>

### Release Notes

- delete `default FelixConfiguration` while upgrading from 0.4.1
- `network_mtu` changed from CNI network MTU to Physical network MTU.
- `bpfLogLevel` will be briefly set from `Info` to `Off`.
- Following ports will be opened on all hosts for the upgrade time between `calico` chart upgrade and `calico-host-protection` chart:
  
```
  - 22/tcp
  - 68/udp
  - 179/tcp
  - 2379/tcp
  - 2380/tcp
  - 5473/tcp
  - 6443/tcp
  - 6666/tcp
  - 6667/tcp
```
