### PR TITLE
docs: fix etcd version upgrade sed expression

### DIFF
--- a/docs/how-to-guides/upgrade-etcd.md
+++ b/docs/how-to-guides/upgrade-etcd.md
@@ -54,7 +54,7 @@ Run the following commands:
 ```bash
 export etcd_version=<latest etcd version e.g. v3.4.10>
 
-sudo sed -i "s,ETCD_IMAGE_TAG=.*,ETCD_IMAGE_TAG=${etcd_version}," \
+sudo sed -i "s,ETCD_IMAGE_TAG=.*,ETCD_IMAGE_TAG=${etcd_version}\"," \
         /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf
 sudo systemctl daemon-reload
 sudo systemctl restart etcd-member


### PR DESCRIPTION
When upgrading the etcd version of a node, you need to update the local
etcd cluster configuration. The previous sed expression missed appending
an ending double quote to the `ETCD_IMAGE_TAG` environment variable.
This prevented the correct version from being installed, hence not
updating at all.

Closes #920