### PR TITLE
feat: add severity labels to MetalLB alerts

### DIFF
--- a/pkg/components/metallb/manifests.go
+++ b/pkg/components/metallb/manifests.go
@@ -948,24 +948,32 @@ spec:
     - alert: MetalLBNoBGPSession
       expr: metallb_bgp_session_up != 1
       for: 2m
+      labels:
+        severity: critical
       annotations:
         description: '{{ $labels.instance }}: MetalLB has not established a BGP session for more than 2 minutes.'
         summary: '{{ $labels.instance }}: MetalLB has not established BGP session.'
     - alert: MetalLBConfigStale
       expr: metallb_k8s_client_config_stale_bool != 0
       for: 2m
+      labels:
+        severity: critical
       annotations:
         description: '{{ $labels.instance }}: MetalLB instance has stale configuration.'
         summary: '{{ $labels.instance }}: MetalLB stale configuration.'
     - alert: MetalLBControllerPodsAvailability
       expr: kube_deployment_status_replicas_unavailable{deployment="controller",namespace="metallb-system"} != 0
       for: 1m
+      labels:
+        severity: critical
       annotations:
         description: '{{ $labels.instance }}: MetalLB Controller pod was not available in the last minute.'
         summary: '{{ $labels.instance }}: MetalLB Controller deployment pods.'
     - alert: MetalLBSpeakerPodsAvailability
       expr: kube_daemonset_status_number_unavailable{daemonset="speaker",namespace="metallb-system"} != 0
       for: 1m
+      labels:
+        severity: critical
       annotations:
         description: '{{ $labels.instance }}: MetalLB Speaker pod(s) were not available in the last minute.'
         summary: '{{ $labels.instance }}: MetalLB Speaker daemonset pods.'


### PR DESCRIPTION
Add the severity label "critical" to the MetalLB alerts, using the same
approach as the alerts configured by the prometheus-operator.

When any of these alerts are triggered, this could impact any
load balancer/ingress, therefore labeling them as critical.