### PR TITLE
component/metallb: Fix controller tolerations

### DIFF
--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -73,7 +73,7 @@ func (c *component) RenderManifests() (map[string]string, error) {
 	c.ControllerNodeSelectors["beta.kubernetes.io/os"] = "linux"
 	c.ControllerNodeSelectors["node.kubernetes.io/master"] = ""
 
-	c.ControllerTolerations = append(c.SpeakerTolerations, util.Toleration{
+	c.ControllerTolerations = append(c.ControllerTolerations, util.Toleration{
 		Effect: "NoSchedule",
 		Key:    "node-role.kubernetes.io/master",
 	})


### PR DESCRIPTION
This fixes a bug which causes MetalLB speaker tolerations to be applied to controller pods, too.

Tests should be added as part of https://github.com/kinvolk/lokomotive/pull/927.