### PR TITLE
pkg/assets: cleanup exported API

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -85,7 +85,7 @@ func Generate(fileName string, packageName string, variableName string, dirs map
 // The assets are read either from data embedded in the binary or from the filesystem, depending on
 // whether the LOKOCTL_USE_FS_ASSETS environment variable is set.
 func Extract(src, dst string) error {
-	walk := CopyingWalker(dst, 0700)
+	walk := copyingWalker(dst, 0700)
 	if err := Assets.WalkFiles(src, walk); err != nil {
 		return fmt.Errorf("failed to walk assets: %v", err)
 	}

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -49,13 +49,12 @@ type AssetsIface interface {
 	WalkFiles(path string, cb WalkFunc) error
 }
 
-var Assets AssetsIface
-
-func init() {
-	Assets = newEmbeddedAssets()
+func get() AssetsIface {
 	if value, found := os.LookupEnv("LOKOCTL_USE_FS_ASSETS"); found {
-		Assets = newFsAssets(value)
+		return newFsAssets(value)
 	}
+
+	return newEmbeddedAssets()
 }
 
 // Generate function wraps vfsgen.Generate function.
@@ -86,7 +85,7 @@ func Generate(fileName string, packageName string, variableName string, dirs map
 // whether the LOKOCTL_USE_FS_ASSETS environment variable is set.
 func Extract(src, dst string) error {
 	walk := copyingWalker(dst, 0700)
-	if err := Assets.WalkFiles(src, walk); err != nil {
+	if err := get().WalkFiles(src, walk); err != nil {
 		return fmt.Errorf("failed to walk assets: %v", err)
 	}
 

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -85,7 +85,7 @@ func Generate(fileName string, packageName string, variableName string, dirs map
 // The assets are read either from data embedded in the binary or from the filesystem, depending on
 // whether the LOKOCTL_USE_FS_ASSETS environment variable is set.
 func Extract(src, dst string) error {
-	walk := CopyingWalker(dst, 0755)
+	walk := CopyingWalker(dst, 0700)
 	if err := Assets.WalkFiles(src, walk); err != nil {
 		return fmt.Errorf("failed to walk assets: %v", err)
 	}

--- a/pkg/assets/embedded.go
+++ b/pkg/assets/embedded.go
@@ -29,15 +29,13 @@ type embeddedAssets struct {
 	fs http.FileSystem
 }
 
-var _ AssetsIface = &embeddedAssets{}
-
 func newEmbeddedAssets() *embeddedAssets {
 	return &embeddedAssets{
 		fs: vfsgenAssets,
 	}
 }
 
-func (a *embeddedAssets) WalkFiles(location string, cb WalkFunc) error {
+func (a *embeddedAssets) WalkFiles(location string, cb walkFunc) error {
 	return vfsutil.WalkFiles(a.fs, location, func(filePath string, fileInfo os.FileInfo, r io.ReadSeeker, err error) error {
 		if err != nil {
 			return cb(filePath, fileInfo, r, err)

--- a/pkg/assets/fs.go
+++ b/pkg/assets/fs.go
@@ -26,8 +26,6 @@ type fsAssets struct {
 	assetsDir string
 }
 
-var _ AssetsIface = &fsAssets{}
-
 func newFsAssets(dir string) *fsAssets {
 	if dir == "" {
 		execDir, err := osext.ExecutableFolder()
@@ -41,7 +39,7 @@ func newFsAssets(dir string) *fsAssets {
 	}
 }
 
-func (a *fsAssets) WalkFiles(location string, cb WalkFunc) error {
+func (a *fsAssets) WalkFiles(location string, cb walkFunc) error {
 	relativeLocation := strings.TrimLeft(location, string(os.PathSeparator))
 	assetsLocation := filepath.Join(a.assetsDir, relativeLocation)
 	return filepath.Walk(assetsLocation, func(path string, info os.FileInfo, err error) error {

--- a/pkg/assets/walkers.go
+++ b/pkg/assets/walkers.go
@@ -17,7 +17,6 @@ package assets
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -36,39 +35,6 @@ func copyingWalker(path string, newDirPerms os.FileMode) WalkFunc {
 		}
 
 		return writeFile(fileName, r)
-	}
-}
-
-// DumpingWalker returns a WalkFunc which sets the contents of the given file in a map.
-func DumpingWalker(contentsMap map[string]string, allowedExts ...string) WalkFunc {
-	var extsMap map[string]struct{}
-
-	if len(allowedExts) > 0 {
-		extsMap = make(map[string]struct{}, len(allowedExts))
-		for _, ext := range allowedExts {
-			extsMap[ext] = struct{}{}
-		}
-	}
-
-	return func(fileName string, fileInfo os.FileInfo, r io.ReadSeeker, err error) error {
-		if err != nil {
-			return fmt.Errorf("error while walking at %q: %w", fileName, err)
-		}
-
-		if extsMap != nil {
-			if _, ok := extsMap[filepath.Ext(fileName)]; !ok {
-				return nil
-			}
-		}
-
-		contents, err := ioutil.ReadAll(r)
-		if err != nil {
-			return fmt.Errorf("failed to read %q: %w", fileName, err)
-		}
-
-		contentsMap[fileName] = string(contents)
-
-		return nil
 	}
 }
 

--- a/pkg/assets/walkers.go
+++ b/pkg/assets/walkers.go
@@ -22,7 +22,7 @@ import (
 )
 
 // copyingWalker returns a WalkFunc which writes the given file to disk.
-func copyingWalker(path string, newDirPerms os.FileMode) WalkFunc {
+func copyingWalker(path string, newDirPerms os.FileMode) walkFunc {
 	return func(fileName string, fileInfo os.FileInfo, r io.ReadSeeker, err error) error {
 		if err != nil {
 			return fmt.Errorf("error while walking at %q: %w", fileName, err)

--- a/pkg/assets/walkers.go
+++ b/pkg/assets/walkers.go
@@ -22,8 +22,8 @@ import (
 	"path/filepath"
 )
 
-// CopyingWalker returns a WalkFunc which writes the given file to disk.
-func CopyingWalker(path string, newDirPerms os.FileMode) WalkFunc {
+// copyingWalker returns a WalkFunc which writes the given file to disk.
+func copyingWalker(path string, newDirPerms os.FileMode) WalkFunc {
 	return func(fileName string, fileInfo os.FileInfo, r io.ReadSeeker, err error) error {
 		if err != nil {
 			return fmt.Errorf("error while walking at %q: %w", fileName, err)

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -46,9 +46,7 @@ func ChartFromAssets(location string) (*chart.Chart, error) {
 	// isn't trivial since we call os.RemoveAll() in a defer statement.
 	defer os.RemoveAll(tmpDir) //nolint: errcheck
 
-	// Rendered files could contain secrets - allow r/w access to owner only.
-	walk := assets.CopyingWalker(tmpDir, 0700)
-	if err := assets.Assets.WalkFiles(location, walk); err != nil {
+	if err := assets.Extract(location, tmpDir); err != nil {
 		return nil, fmt.Errorf("traversing assets: %w", err)
 	}
 


### PR DESCRIPTION
~**Includes commits from #935**~

This PR finishes cleaning up API of `pkg/assets` package, so end result is, that only exported function we have is `Extract()`.

See commit messages for more details.

Closes #796