### PR TITLE
Fix output of `convertNodeSelector` in rook

### DIFF
--- a/pkg/components/rook/component.go
+++ b/pkg/components/rook/component.go
@@ -16,6 +16,7 @@ package rook
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -116,8 +117,18 @@ func (c *component) Metadata() components.Metadata {
 func convertNodeSelector(m map[string]string) string {
 	var ret string
 
-	for k, v := range m {
-		ret += fmt.Sprintf("%s=%s; ", k, v)
+	// Covert map to slice and sort them
+	// by keys.
+	keys := []string{}
+
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		ret += fmt.Sprintf("%s=%s; ", k, m[k])
 	}
 
 	return ret

--- a/pkg/components/rook/component_test.go
+++ b/pkg/components/rook/component_test.go
@@ -1,0 +1,35 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rook //nolint:testpackage
+
+import (
+	"testing"
+)
+
+func TestConvertNodeSelector(t *testing.T) {
+	m := map[string]string{
+		"key1": "val1",
+		"key3": "val3",
+		"key4": "val4",
+		"key2": "val2",
+	}
+
+	expectedOutput := "key1=val1; key2=val2; key3=val3; key4=val4; "
+	actualOutput := convertNodeSelector(m)
+
+	if expectedOutput != actualOutput {
+		t.Fatalf("expected: %s, got: %s", expectedOutput, actualOutput)
+	}
+}


### PR DESCRIPTION
Earlier it was looping through map so output was not consistent.

Closes: #942
Signed-off-by: knrt10 <kautilya@kinvolk.io>