### PR TITLE
Makefile: complain if assets dir has empty directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ all: build build-test test lint codespell
 
 .PHONY: update-assets
 update-assets:
+	@find assets/ -type d -empty | grep . >/dev/null && echo "Found empty directories in assets/ directory. Remove them and run 'make update-assets' again." || true
+	@find assets/ -type d -empty | grep . && exit 1 || true
 	GO111MODULE=on go generate -mod=$(MOD) ./...
 
 .PHONY: build-slim


### PR DESCRIPTION
As running locally 'make update-assets' will include them, but as git do
not include empty directories, after fresh clone it will be removed, so
the assets won't be consistent.

This find will ensure, that if there are empty directories found,
update-assets will fail with clear message to the developer.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>