### PR TITLE
Remove space before nolint comment to make it consistent across the project

### DIFF
--- a/cli/cmd/component-apply.go
+++ b/cli/cmd/component-apply.go
@@ -43,7 +43,7 @@ When run with no arguments, all components listed in the configuration are appli
 
 var debug bool
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	componentCmd.AddCommand(componentApplyCmd)
 	pf := componentApplyCmd.PersistentFlags()

--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -42,7 +42,7 @@ When run with no arguments, all components listed in the configuration are delet
 
 var deleteNamespace bool
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	componentCmd.AddCommand(componentDeleteCmd)
 	pf := componentDeleteCmd.PersistentFlags()

--- a/cli/cmd/health.go
+++ b/cli/cmd/health.go
@@ -32,7 +32,7 @@ var healthCmd = &cobra.Command{
 	Run:   runHealth,
 }
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	RootCmd.AddCommand(healthCmd)
 	pf := healthCmd.PersistentFlags()

--- a/pkg/components/aws-ebs-csi-driver/component_test.go
+++ b/pkg/components/aws-ebs-csi-driver/component_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:testpackage
+//nolint:testpackage
 package awsebscsidriver
 
 import (

--- a/pkg/components/istio-operator/component.go
+++ b/pkg/components/istio-operator/component.go
@@ -31,7 +31,7 @@ const (
 	namespace = "istio-operator"
 )
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	components.Register(name, newComponent())
 }

--- a/pkg/components/linkerd/component.go
+++ b/pkg/components/linkerd/component.go
@@ -34,7 +34,7 @@ const (
 	certCommonName = "identity.linkerd.cluster.local"
 )
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	components.Register(name, newComponent())
 }

--- a/pkg/components/linkerd/component_test.go
+++ b/pkg/components/linkerd/component_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:testpackage
+//nolint:testpackage
 package linkerd
 
 import "testing"

--- a/pkg/components/metallb/component_test.go
+++ b/pkg/components/metallb/component_test.go
@@ -136,7 +136,7 @@ func getDeployController(t *testing.T, m map[string]string) *appsv1.Deployment {
 	return deploy
 }
 
-// nolint:funlen
+//nolint:funlen
 func TestConversion(t *testing.T) {
 	configHCL := `
 component "metallb" {

--- a/pkg/components/prometheus-operator/component_test.go
+++ b/pkg/components/prometheus-operator/component_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/components/util"
 )
 
-// nolint:funlen
+//nolint:funlen
 func TestRenderManifest(t *testing.T) {
 	tests := []struct {
 		desc    string

--- a/pkg/components/util/helm_test.go
+++ b/pkg/components/util/helm_test.go
@@ -108,7 +108,7 @@ metadata:
 		t.Fatalf("Chart should be created, got: %v", err)
 	}
 
-	if len(chart.Manifests) != 1 { //nolint:gomnd
+	if len(chart.Manifests) != 1 {
 		t.Fatalf("Manifest file with the namespace should still be added, as it may contain other objects")
 	}
 
@@ -194,7 +194,7 @@ metadata:
 		t.Fatalf("Chart should be created, got: %v", err)
 	}
 
-	if len(chart.Manifests) != 1 { //nolint:gomnd
+	if len(chart.Manifests) != 1 {
 		t.Fatalf("Manifest file with the CRDs should still be added, as it may contain other objects")
 	}
 
@@ -202,7 +202,7 @@ metadata:
 		t.Fatalf("CRD object should be removed from the manifests file")
 	}
 
-	if len(chart.Files) != 1 { //nolint:gomnd
+	if len(chart.Files) != 1 {
 		t.Fatalf("CRD object should be added to Files field")
 	}
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -77,7 +77,7 @@ type Platform interface {
 // PlatformWithPostApplyHook runs code after Terraform finishes applying. This allows
 // running sanity checks on the newly created cluster. Implementing this
 // interface is optional for platforms.
-type PlatformWithPostApplyHook interface { // nolint:golint
+type PlatformWithPostApplyHook interface { //nolint:golint
 	PostApplyHook(kubeconfig []byte) error
 }
 

--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -285,7 +285,7 @@ func (ex *Executor) execute(verbose bool, args ...string) error {
 }
 
 func showError(path string, noOfLines int) {
-	// nolint: gosec
+	//nolint: gosec
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		fmt.Printf("error reading file: %v", err)
@@ -297,7 +297,7 @@ func showError(path string, noOfLines int) {
 
 	// Deletion by one is done here to adjust the difference between the user provided number which
 	// starts counting from 1 and array indices which start counting from 0.
-	// nolint: gomnd
+	//nolint: gomnd
 	offset := len(lines) - noOfLines - 1
 
 	if offset > 0 {

--- a/test/components/aws-ebs-csi-driver/aws-ebs-csi-driver_test.go
+++ b/test/components/aws-ebs-csi-driver/aws-ebs-csi-driver_test.go
@@ -15,7 +15,7 @@
 // +build aws aws_edge
 // +build e2e
 
-// nolint:testpackage
+//nolint:testpackage
 package awsebscsidriver
 
 import (

--- a/test/components/linkerd/linkerd_test.go
+++ b/test/components/linkerd/linkerd_test.go
@@ -64,7 +64,7 @@ func TestLinkerdDeployment(t *testing.T) {
 }
 
 const (
-	// nolint: lll
+	//nolint: lll
 	podConfig = `
 apiVersion: v1
 kind: Pod
@@ -121,7 +121,7 @@ spec:
 	timeout       = 9 * time.Minute
 )
 
-// nolint: funlen
+//nolint: funlen
 func TestLinkerdCheck(t *testing.T) {
 	t.Parallel()
 

--- a/test/components/prometheus-operator/prometheus_operator_test.go
+++ b/test/components/prometheus-operator/prometheus_operator_test.go
@@ -79,7 +79,7 @@ func TestPrometheusOperatorDeployment(t *testing.T) {
 	testutil.WaitForDaemonSet(t, client, namespace, "prometheus-operator-prometheus-node-exporter", retryInterval, timeout)
 }
 
-// nolint:funlen
+//nolint:funlen
 func TestGrafanaLoadsEnvVars(t *testing.T) {
 	kubeconfig := testutil.KubeconfigPath(t)
 

--- a/test/monitoring/components_alerts_test.go
+++ b/test/monitoring/components_alerts_test.go
@@ -43,7 +43,6 @@ type alertTestCase struct {
 	Alerts        []string
 }
 
-//nolint:funlen
 func testComponentAlerts(t *testing.T, v1api v1.API) {
 	alertTestCases := []alertTestCase{
 		{

--- a/test/monitoring/grafana_password_test.go
+++ b/test/monitoring/grafana_password_test.go
@@ -15,7 +15,7 @@
 // +build aws aws_edge packet aks
 // +build poste2e
 
-package monitoring // nolint:testpackage
+package monitoring //nolint:testpackage
 
 import (
 	"context"

--- a/test/system/clc_snippets_test.go
+++ b/test/system/clc_snippets_test.go
@@ -15,7 +15,7 @@
 // +build aws aws_edge packet
 // +build e2e
 
-package system // nolint:testpackage
+package system //nolint:testpackage
 
 import (
 	"context"

--- a/test/system/ssh_keys_test.go
+++ b/test/system/ssh_keys_test.go
@@ -15,7 +15,7 @@
 // +build aws aws_edge baremetal packet
 // +build e2e
 
-package system // nolint:testpackage
+package system //nolint:testpackage
 
 import (
 	"context"


### PR DESCRIPTION
This commit replaces `// nolint` with `//nolint`, to make it consistent
across the project.