### PR TITLE
pkg/components: make Register() take function as argument, not interface

### DIFF
--- a/pkg/components/aws-ebs-csi-driver/component.go
+++ b/pkg/components/aws-ebs-csi-driver/component.go
@@ -34,14 +34,14 @@ enableDefaultStorageClass: {{ .EnableDefaultStorageClass }}
 
 //nolint:gochecknoinits
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
 	EnableDefaultStorageClass bool `hcl:"enable_default_storage_class,optional"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		EnableDefaultStorageClass: true,
 	}

--- a/pkg/components/cert-manager/component.go
+++ b/pkg/components/cert-manager/component.go
@@ -29,7 +29,7 @@ import (
 const name = "cert-manager"
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -39,7 +39,7 @@ type component struct {
 	ServiceMonitor bool   `hcl:"service_monitor,optional"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		Namespace:      "cert-manager",
 		Webhooks:       true,

--- a/pkg/components/cluster-autoscaler/component.go
+++ b/pkg/components/cluster-autoscaler/component.go
@@ -75,7 +75,7 @@ serviceMonitor:
 `
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -114,7 +114,7 @@ type packetConfiguration struct {
 	AuthToken     string
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	c := &component{
 		Provider:               "packet",
 		Namespace:              "kube-system",

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -24,13 +24,14 @@ import (
 )
 
 // components is the map of registered components
-var components map[string]Component
+var components map[string]func() Component
 
 func init() {
-	components = make(map[string]Component)
+	components = make(map[string]func() Component)
 }
 
-func Register(name string, obj Component) {
+// Register registers new component function into global components registry.
+func Register(name string, obj func() Component) {
 	if _, exists := components[name]; exists {
 		panic(fmt.Sprintf("component with name %q registered already", name))
 	}
@@ -50,7 +51,8 @@ func Get(name string) (Component, error) {
 	if !exists {
 		return nil, fmt.Errorf("no component with name %q found", name)
 	}
-	return component, nil
+
+	return component(), nil
 }
 
 // Chart is a convenience function which returns a pointer to a chart.Chart representing the

--- a/pkg/components/contour/component.go
+++ b/pkg/components/contour/component.go
@@ -33,7 +33,7 @@ const (
 )
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 // This annotation is added to Envoy service.
@@ -46,7 +46,7 @@ type component struct {
 	TolerationsRaw   string
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		ServiceType: serviceTypeLoadBalancer,
 	}

--- a/pkg/components/dex/component.go
+++ b/pkg/components/dex/component.go
@@ -29,8 +29,9 @@ import (
 
 const name = "dex"
 
-func init() { //nolint:gochecknoinits
-	components.Register(name, newComponent())
+//nolint:gochecknoinits
+func init() {
+	components.Register(name, newComponent)
 }
 
 type org struct {
@@ -77,7 +78,7 @@ type component struct {
 	StaticClientsRaw string
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		CertManagerClusterIssuer: "letsencrypt-production",
 	}

--- a/pkg/components/external-dns/component.go
+++ b/pkg/components/external-dns/component.go
@@ -62,7 +62,7 @@ metrics:
 `
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 // AwsConfig provides configuration for AWS Route53 DNS.
@@ -84,7 +84,7 @@ type component struct {
 	OwnerID        string    `hcl:"owner_id"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		Namespace: "external-dns",
 		Sources:   []string{"ingress"},

--- a/pkg/components/external-dns/component_test.go
+++ b/pkg/components/external-dns/component_test.go
@@ -44,7 +44,8 @@ func TestEmptyBody(t *testing.T) {
 	}
 }
 func TestDefaultValues(t *testing.T) {
-	c := newComponent()
+	c := newComponent().(*component)
+
 	if c.Namespace != "external-dns" {
 		t.Fatal("Default namespace for installation should be external-dns.")
 	}

--- a/pkg/components/flatcar-linux-update-operator/component.go
+++ b/pkg/components/flatcar-linux-update-operator/component.go
@@ -28,7 +28,7 @@ import (
 const name = "flatcar-linux-update-operator"
 
 func init() {
-	components.Register(name, &component{})
+	components.Register(name, func() components.Component { return &component{} })
 }
 
 type component struct{}

--- a/pkg/components/gangway/component.go
+++ b/pkg/components/gangway/component.go
@@ -29,7 +29,7 @@ import (
 const name = "gangway"
 
 func init() { //nolint:gochecknoinits
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -45,7 +45,7 @@ type component struct {
 	CertManagerClusterIssuer string `hcl:"certmanager_cluster_issuer,optional"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		CertManagerClusterIssuer: "letsencrypt-production",
 	}

--- a/pkg/components/httpbin/component.go
+++ b/pkg/components/httpbin/component.go
@@ -29,7 +29,7 @@ import (
 const name = "httpbin"
 
 func init() { //nolint:gochecknoinits
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -37,7 +37,7 @@ type component struct {
 	CertManagerClusterIssuer string `hcl:"certmanager_cluster_issuer,optional"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		CertManagerClusterIssuer: "letsencrypt-production",
 	}

--- a/pkg/components/istio-operator/component.go
+++ b/pkg/components/istio-operator/component.go
@@ -33,7 +33,7 @@ const (
 
 //nolint:gochecknoinits
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -41,7 +41,7 @@ type component struct {
 	EnableMonitoring bool   `hcl:"enable_monitoring,optional"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		Profile:          "minimal",
 		EnableMonitoring: false,

--- a/pkg/components/linkerd/component.go
+++ b/pkg/components/linkerd/component.go
@@ -36,7 +36,7 @@ const (
 
 //nolint:gochecknoinits
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -53,7 +53,7 @@ type cert struct {
 	Expiry string
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		ControllerReplicas: 1,
 		EnableMonitoring:   false,

--- a/pkg/components/metallb/component.go
+++ b/pkg/components/metallb/component.go
@@ -29,7 +29,7 @@ import (
 const name = "metallb"
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -44,7 +44,7 @@ type component struct {
 	SpeakerTolerationsJSON    string
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{}
 }
 

--- a/pkg/components/metrics-server/component.go
+++ b/pkg/components/metrics-server/component.go
@@ -49,14 +49,14 @@ args:
 `
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
 	Namespace string `hcl:"namespace,optional"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		Namespace: "kube-system",
 	}

--- a/pkg/components/openebs-operator/component.go
+++ b/pkg/components/openebs-operator/component.go
@@ -29,7 +29,7 @@ import (
 const name = "openebs-operator"
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -84,7 +84,7 @@ webhook:
 {{- end }}
 `
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{}
 }
 

--- a/pkg/components/openebs-storage-class/component.go
+++ b/pkg/components/openebs-storage-class/component.go
@@ -32,7 +32,7 @@ const (
 )
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type Storageclass struct {
@@ -58,7 +58,7 @@ func defaultStorageClass() *Storageclass {
 	}
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		Storageclasses: []*Storageclass{},
 	}

--- a/pkg/components/prometheus-operator/component.go
+++ b/pkg/components/prometheus-operator/component.go
@@ -30,7 +30,7 @@ import (
 const name = "prometheus-operator"
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 // Monitor holds information about which Kubernetes components should be monitored with the default Prometheus instance.
@@ -88,7 +88,7 @@ type component struct {
 	CoreDNS *CoreDNS `hcl:"coredns,block"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	defaultAlertManagerConfig := `
   config:
     global:

--- a/pkg/components/rook-ceph/component.go
+++ b/pkg/components/rook-ceph/component.go
@@ -29,7 +29,7 @@ import (
 const name = "rook-ceph"
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -49,7 +49,7 @@ type StorageClass struct {
 	Default bool `hcl:"default,optional"`
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		Namespace:    "rook",
 		MonitorCount: 1,

--- a/pkg/components/rook/component.go
+++ b/pkg/components/rook/component.go
@@ -30,7 +30,7 @@ import (
 const name = "rook"
 
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 type component struct {
@@ -51,7 +51,7 @@ type component struct {
 	CSIPluginTolerationsRaw  string
 }
 
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		Namespace: "rook",
 	}

--- a/pkg/components/velero/component.go
+++ b/pkg/components/velero/component.go
@@ -34,7 +34,7 @@ const name = "velero"
 
 // init registers velero component to components list, so it shows up as available to install
 func init() {
-	components.Register(name, newComponent())
+	components.Register(name, newComponent)
 }
 
 // component represents component configuration data
@@ -65,7 +65,7 @@ type provider interface {
 }
 
 // newComponent creates new velero component struct with default values initialized
-func newComponent() *component {
+func newComponent() components.Component {
 	return &component{
 		Namespace: "velero",
 		Metrics: &Metrics{


### PR DESCRIPTION
So components.Get() can be used in tests to obtain a component struct,
as components currently do not expose any function directly to do it.

Without this change, using 'components.Get()' mutliple times and
calling 'LoadConfig' happens on the global struct copy, which causes
conflicts and issues.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

Closes #992.