### PR TITLE
components/metallb: Add missing autodiscovery labels

### DIFF
--- a/pkg/components/metallb/component_test.go
+++ b/pkg/components/metallb/component_test.go
@@ -265,6 +265,10 @@ component "metallb" {
     my-asn: metallb.lokomotive.io/my-asn
     peer-asn: metallb.lokomotive.io/peer-asn
     peer-address: metallb.lokomotive.io/peer-address
+    peer-port: metallb.lokomotive.io/peer-port
+    src-address: metallb.lokomotive.io/src-address
+    hold-time: metallb.lokomotive.io/hold-time
+    router-id: metallb.lokomotive.io/router-id
 address-pools:
 - name: default
   protocol: bgp

--- a/pkg/components/metallb/manifests.go
+++ b/pkg/components/metallb/manifests.go
@@ -516,6 +516,10 @@ data:
         my-asn: metallb.lokomotive.io/my-asn
         peer-asn: metallb.lokomotive.io/peer-asn
         peer-address: metallb.lokomotive.io/peer-address
+        peer-port: metallb.lokomotive.io/peer-port
+        src-address: metallb.lokomotive.io/src-address
+        hold-time: metallb.lokomotive.io/hold-time
+        router-id: metallb.lokomotive.io/router-id
     address-pools:
     {{- range $k, $v := .AddressPools }}
     - name: {{ $k }}


### PR DESCRIPTION
In order to allow users to control all supported BGP parameters by
specifying labels in worker pool config, we need to specify mappings
for them.

Fixes #987.

To test this change, deploy a cluster using a config similar to the following:

```hcl
cluster "packet" {
  asset_dir        = "./assets"
  cluster_name     = "my-cluster"
  controller_count = 1
  controller_type  = "t1.small.x86"
  dns {
    provider = "route53"
    zone     = "example.com"
  }
  facility    = "ams1"
  project_id = "fake"
  ssh_pubkeys       = ["ssh-rsa ..."]
  management_cidrs  = ["0.0.0.0/0"]
  node_private_cidr = "10.1.1.0/25"

  worker_pool "pool-1" {
    count     = 2
    node_type = "t1.small.x86"
    # Example: configure hold time and peer port by setting autodiscovery labels
    labels    = "metallb.lokomotive.io/hold-time=3s,metallb.lokomotive.io/peer-port=1179"
  }
}

component "metallb" {
  address_pools = {
    default = ["147.1.2.3/32"]
  }
}

```