### PR TITLE
kubelet e2e: Enable the disruptive test

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -39,6 +39,7 @@ EOF
     disk_size     = 30
     instance_type = "i3.large"
     spot_price    = "0.08"
+    labels        = "testing.io=yes,roleofnode=testing"
     tags = {
       "deployment" = "ci"
     }

--- a/test/components/kubernetes/kubelet_disruptive_test.go
+++ b/test/components/kubernetes/kubelet_disruptive_test.go
@@ -30,10 +30,6 @@ import (
 )
 
 func TestSelfHostedKubeletLabels(t *testing.T) {
-	t.Skip("This test will always fail, as Flatcar currently ships version of runc, which has a race " +
-		"condition bug, which makes self-hosted kubelet to hang when the pod is removed. " +
-		"It should be re-enabled once the fix reaches Flatcar stable channel.")
-
 	client := testutil.CreateKubeClient(t)
 
 	// List all the nodes and then delete a node that is not controller.


### PR DESCRIPTION
The test was disabled because the runc issue rendered the nodes
unusable,now that it is fixed in flatcar stable it makes sense to enable
it.

Fixes #1002