### PR TITLE
bootkube: feed output using local rather than local_file content

### DIFF
--- a/assets/terraform-modules/bootkube/assets.tf
+++ b/assets/terraform-modules/bootkube/assets.tf
@@ -85,12 +85,8 @@ resource "local_file" "kubernetes" {
   })
 }
 
-# Populate bootstrap-secrets chart values file named bootstrap-secrets.yaml.
-resource "local_file" "bootstrap-secrets" {
-  count = var.enable_tls_bootstrap == true ? 1 : 0
-
-  filename = "${var.asset_dir}/charts/kube-system/bootstrap-secrets.yaml"
-  content = templatefile("${path.module}/resources/charts/bootstrap-secrets.yaml", {
+locals {
+  bootstrap_secrets = templatefile("${path.module}/resources/charts/bootstrap-secrets.yaml", {
     bootstrap_tokens = [
       for token in var.bootstrap_tokens :
       {
@@ -99,6 +95,14 @@ resource "local_file" "bootstrap-secrets" {
       }
     ]
   })
+}
+
+# Populate bootstrap-secrets chart values file named bootstrap-secrets.yaml.
+resource "local_file" "bootstrap-secrets" {
+  count = var.enable_tls_bootstrap == true ? 1 : 0
+
+  filename = "${var.asset_dir}/charts/kube-system/bootstrap-secrets.yaml"
+  content  = local.bootstrap_secrets
 }
 
 locals {

--- a/assets/terraform-modules/bootkube/outputs.tf
+++ b/assets/terraform-modules/bootkube/outputs.tf
@@ -92,5 +92,5 @@ output "lokomotive_values" {
 }
 
 output "bootstrap-secrets_values" {
-  value = var.enable_tls_bootstrap ? local_file.bootstrap-secrets[0].content : ""
+  value = var.enable_tls_bootstrap ? local.bootstrap_secrets : ""
 }


### PR DESCRIPTION
Currently, if one has TLS bootstrap enabled and remove it's assets
directory, assuming that they use remote Terraform backend, Terraform
won't be able to evalue this output, as after refreshing,
local_file.bootstrap-secrets will be gone, as the file has been removed.

This commit moves content rendering to local variable, so module output
does not depend on local file.

Closes #1016

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>