### PR TITLE
docs/rook-ceph-storage: Use correct apply command

### DIFF
--- a/docs/how-to-guides/rook-ceph-storage.md
+++ b/docs/how-to-guides/rook-ceph-storage.md
@@ -277,7 +277,7 @@ component "rook-ceph" {
 Execute the following command to apply the changes:
 
 ```bash
-lokoctl component apply rook
+lokoctl component apply rook-ceph
 ```
 
 Verify the StorageClass is default:


### PR DESCRIPTION
The doc tells the user to update the `rook-ceph` component config and then re-apply the `rook` component, which doesn't make sense.