### PR TITLE
labels taints format change

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -115,7 +115,7 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
           KUBELET_IMAGE_TAG=v1.18.8
-          NODE_LABELS="node.kubernetes.io/node,${node_labels}"
+          NODE_LABELS="${join(",", [for k, v in node_labels : "${k}=${v}"])}"
           NODE_TAINTS="${taints}"
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -116,7 +116,7 @@ storage:
           KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
           KUBELET_IMAGE_TAG=v1.18.8
           NODE_LABELS="${join(",", [for k, v in node_labels : "${k}=${v}"])}"
-          NODE_TAINTS="${taints}"
+          NODE_TAINTS="${join(",", [for k, v in taints : "${k}=${v}"])}"
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -46,9 +46,9 @@ variable "labels" {
 }
 
 variable "taints" {
-  type        = string
-  default     = ""
-  description = "Comma separated list of taints. eg. 'clusterType=staging:NoSchedule,nodeType=storage:NoSchedule'"
+  type        = map(string)
+  default     = {}
+  description = "Map of custom taints for worker nodes."
 }
 
 variable "os_name" {

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -40,9 +40,9 @@ variable "instance_type" {
 }
 
 variable "labels" {
-  type        = string
-  default     = ""
-  description = "Custom labels to assign to worker nodes. Provide comma separated key=value pairs as labels. e.g. 'foo=oof,bar=,baz=zab'"
+  type        = map(string)
+  description = "Map of custom labels for worker nodes."
+  default     = {}
 }
 
 variable "taints" {

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -93,7 +93,7 @@ data "ct_config" "worker-ignition" {
     ssh_keys               = jsonencode(var.ssh_keys)
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     cluster_domain_suffix  = var.cluster_domain_suffix
-    node_labels            = var.labels
+    node_labels            = merge({ "node.kubernetes.io/node" = "" }, var.labels)
     taints                 = var.taints
     enable_tls_bootstrap   = var.enable_tls_bootstrap
   })

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -82,16 +82,7 @@ resource "aws_launch_configuration" "worker" {
 
 # Worker Ignition config
 data "ct_config" "worker-ignition" {
-  content      = data.template_file.worker-config.rendered
-  pretty_print = false
-  snippets     = var.clc_snippets
-}
-
-# Worker Container Linux config
-data "template_file" "worker-config" {
-  template = file("${path.module}/cl/worker.yaml.tmpl")
-
-  vars = {
+  content = templatefile("${path.module}/cl/worker.yaml.tmpl", {
     kubeconfig = var.enable_tls_bootstrap ? indent(10, templatefile("${path.module}/cl/bootstrap-kubeconfig.yaml.tmpl", {
       token_id     = random_string.bootstrap_token_id[0].result
       token_secret = random_string.bootstrap_token_secret[0].result
@@ -105,5 +96,7 @@ data "template_file" "worker-config" {
     node_labels            = var.labels
     taints                 = var.taints
     enable_tls_bootstrap   = var.enable_tls_bootstrap
-  }
+  })
+  pretty_print = false
+  snippets     = var.clc_snippets
 }

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -291,7 +291,7 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
           KUBELET_IMAGE_TAG=v1.18.8-${os_arch}
-          NODE_LABELS="node.kubernetes.io/node,${node_labels}"
+          NODE_LABELS="${join(",", [for k, v in node_labels : "${k}=${v}"])}"
           BGP_NODE_LABELS="${bgp_node_labels}"
           NODE_TAINTS="${taints}"
     - path: /etc/sysctl.d/max-user-watches.conf

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -293,7 +293,7 @@ storage:
           KUBELET_IMAGE_TAG=v1.18.8-${os_arch}
           NODE_LABELS="${join(",", [for k, v in node_labels : "${k}=${v}"])}"
           BGP_NODE_LABELS="${bgp_node_labels}"
-          NODE_TAINTS="${taints}"
+          NODE_TAINTS="${join(",", [for k, v in taints : "${k}=${v}"])}"
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -43,9 +43,9 @@ variable "labels" {
 }
 
 variable "taints" {
-  type        = string
-  default     = ""
-  description = "Comma separated list of taints. eg. 'clusterType=staging:NoSchedule,nodeType=storage:NoSchedule'"
+  type        = map(string)
+  default     = {}
+  description = "Map of custom taints for worker nodes."
 }
 
 variable "ipxe_script_url" {

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -37,9 +37,9 @@ variable "clc_snippets" {
 # TODO: migrate to `templatefile` when Terraform `0.12` is out and use `{% for ~}`
 # to avoid specifying `--node-labels` again when the var is empty.
 variable "labels" {
-  type        = string
-  default     = ""
-  description = "Custom labels to assign to worker nodes. Provide comma separated key=value pairs as labels. e.g. 'foo=oof,bar=,baz=zab'"
+  type        = map(string)
+  description = "Map of custom labels for worker nodes."
+  default     = {}
 }
 
 variable "taints" {

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -70,7 +70,7 @@ data "ct_config" "ignitions" {
       ssh_keys              = jsonencode(var.ssh_keys)
       k8s_dns_service_ip    = cidrhost(var.service_cidr, 10)
       cluster_domain_suffix = var.cluster_domain_suffix
-      node_labels           = var.labels
+      node_labels           = merge({ "node.kubernetes.io/node" = "" }, var.labels)
       bgp_node_labels       = var.disable_bgp ? "" : format("%s,%s", local.my_asn, local.peer_asn)
       taints                = var.taints
       setup_raid            = var.setup_raid

--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -39,7 +39,10 @@ EOF
     disk_size     = 30
     instance_type = "i3.large"
     spot_price    = "0.08"
-    labels        = "testing.io=yes,roleofnode=testing"
+    labels        = {
+      "testing.io" = "yes",
+      "roleofnode" = "testing",
+    }
     tags = {
       "deployment" = "ci"
     }
@@ -66,8 +69,13 @@ EOF
     disk_size     = 30
     instance_type = "t2.small"
     spot_price    = "0.01"
-    labels        = "testing.io=yes,roleofnode=testing"
-    taints        = "nodeType=storage:NoSchedule"
+    labels        = {
+      "testing.io" = "yes",
+      "roleofnode" = "testing",
+    }
+    taints        = {
+      "nodeType" = "storage:NoSchedule"
+    }
 
     # TODO: remove this once https://github.com/kinvolk/lokomotive/issues/839 is fixed.
     lb_http_port  = 8080

--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -35,7 +35,10 @@ EOF
   worker_pool "pool-1" {
     count     = 2
     node_type = "c2.medium.x86"
-    labels    = "testing.io=yes,roleofnode=testing"
+    labels        = {
+      "testing.io" = "yes",
+      "roleofnode" = "testing",
+    }
     clc_snippets = [
       <<EOF
 storage:

--- a/docs/configuration-reference/platforms/aws.md
+++ b/docs/configuration-reference/platforms/aws.md
@@ -145,7 +145,9 @@ cluster "aws" {
 
     os_version = "current"
 
-    labels = "foo=bar,baz=zab"
+    labels = {
+      "testlabel" = ""
+    }
 
     taints = "nodeType=storage:NoSchedule"
 
@@ -238,7 +240,7 @@ worker_pool "my-worker-pool" {
 | `worker_pool.ssh_pubkeys`     | List of SSH public keys for user `core`. Each element must be specified in a valid OpenSSH public key format, as defined in RFC 4253 Section 6.6, e.g. "ssh-rsa AAAAB3N...".               |        -        | list(string) |   true   |
 | `worker_pool.os_channel`      | Flatcar Container Linux channel to install from (stable, beta, alpha, edge).                                                                                                               |    "stable"     |    string    |  false   |
 | `worker_pool.os_version`      | Flatcar Container Linux version to install. Version such as "2303.3.1" or "current".                                                                                                       |    "current"    |    string    |  false   |
-| `worker_pool.labels`          | Custom labels to assign to worker nodes such as `foo=bar,baz=zab`.                                                                                                                         |        -        |    string    |  false   |
+| `worker_pool.labels`          | Map of extra Kubernetes Node labels for worker nodes.                                                                                                                                      |        -        | map(string)  |  false   |
 | `worker_pool.taints`          | Taints to assign to worker nodes such as `nodeType=storage:NoSchedule`.                                                                                                                    |        -        |    string    |  false   |
 | `worker_pool.disk_size`       | Size of the EBS volume in GB.                                                                                                                                                              |       40        |    number    |  false   |
 | `worker_pool.disk_type`       | Type of the EBS volume (e.g. standard, gp2, io1).                                                                                                                                          |      "gp2"      |    string    |  false   |

--- a/docs/configuration-reference/platforms/aws.md
+++ b/docs/configuration-reference/platforms/aws.md
@@ -149,7 +149,9 @@ cluster "aws" {
       "testlabel" = ""
     }
 
-    taints = "nodeType=storage:NoSchedule"
+    taints = {
+      "nodeType" = "storage:NoSchedule"
+    }
 
     disk_size = var.worker_disk_size
 
@@ -241,7 +243,7 @@ worker_pool "my-worker-pool" {
 | `worker_pool.os_channel`      | Flatcar Container Linux channel to install from (stable, beta, alpha, edge).                                                                                                               |    "stable"     |    string    |  false   |
 | `worker_pool.os_version`      | Flatcar Container Linux version to install. Version such as "2303.3.1" or "current".                                                                                                       |    "current"    |    string    |  false   |
 | `worker_pool.labels`          | Map of extra Kubernetes Node labels for worker nodes.                                                                                                                                      |        -        | map(string)  |  false   |
-| `worker_pool.taints`          | Taints to assign to worker nodes such as `nodeType=storage:NoSchedule`.                                                                                                                    |        -        |    string    |  false   |
+| `worker_pool.taints`          | Map of Taints to assign to worker nodes.                                                                                                                                                   |        -        | map(string)  |  false   |
 | `worker_pool.disk_size`       | Size of the EBS volume in GB.                                                                                                                                                              |       40        |    number    |  false   |
 | `worker_pool.disk_type`       | Type of the EBS volume (e.g. standard, gp2, io1).                                                                                                                                          |      "gp2"      |    string    |  false   |
 | `worker_pool.disk_iops`       | IOPS of the EBS volume (e.g 100).                                                                                                                                                          |        0        |    number    |  false   |

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -155,7 +155,9 @@ cluster "packet" {
 
     os_version = "current"
 
-    labels = "foo=bar,baz=zab"
+    labels = {
+      "testlabel" = ""
+    }
 
     taints = "nodeType=storage:NoSchedule"
 
@@ -242,7 +244,7 @@ node_type = var.custom_default_worker_type
 | `worker_pool.os_channel`              | Flatcar Container Linux channel to install from (stable, beta, alpha, edge).                                                                                                                                                                                                      |    "stable"     |    string    |  false   |
 | `worker_pool.os_version`              | Flatcar Container Linux version to install. Version such as "2303.3.1" or "current".                                                                                                                                                                                              |    "current"    |    string    |  false   |
 | `worker_pool.node_type`               | Packet instance type for worker nodes.                                                                                                                                                                                                                                            | "c3.small.x86"  |    string    |  false   |
-| `worker_pool.labels`                  | Custom labels to assign to worker nodes such as `foo=bar,baz=zab`.                                                                                                                                                                                                                |        -        |    string    |  false   |
+| `worker_pool.labels`                  | Map of extra Kubernetes Node labels for worker nodes.                                                                                                                                                                                                                             |        -        | map(string)  |  false   |
 | `worker_pool.taints`                  | Taints to assign to worker nodes such as `nodeType=storage:NoSchedule`.                                                                                                                                                                                                           |        -        |    string    |  false   |
 | `worker_pool.reservation_ids`         | Block with Packet hardware reservation IDs for worker nodes. Each key must have the format `worker-${index}` and the value is the reservation UUID. Can't be combined with `reservation_ids_default`. Example: `reservation_ids = { worker-0 = "<reservation_id>" }`.             |        -        | map(string)  |  false   |
 | `worker_pool.reservation_ids_default` | Default reservation ID for workers. The value`next-available` will choose any reservation that matches the pool's device type and facility. Can't be combined with `reservation_ids`.                                                                                             |        -        |    string    |  false   |

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -159,7 +159,9 @@ cluster "packet" {
       "testlabel" = ""
     }
 
-    taints = "nodeType=storage:NoSchedule"
+    taints = {
+      "nodeType" = "storage:NoSchedule"
+    }
 
     setup_raid = false
 
@@ -245,7 +247,7 @@ node_type = var.custom_default_worker_type
 | `worker_pool.os_version`              | Flatcar Container Linux version to install. Version such as "2303.3.1" or "current".                                                                                                                                                                                              |    "current"    |    string    |  false   |
 | `worker_pool.node_type`               | Packet instance type for worker nodes.                                                                                                                                                                                                                                            | "c3.small.x86"  |    string    |  false   |
 | `worker_pool.labels`                  | Map of extra Kubernetes Node labels for worker nodes.                                                                                                                                                                                                                             |        -        | map(string)  |  false   |
-| `worker_pool.taints`                  | Taints to assign to worker nodes such as `nodeType=storage:NoSchedule`.                                                                                                                                                                                                           |        -        |    string    |  false   |
+| `worker_pool.taints`                  | Map of Taints to assign to worker nodes.                                                                                                                                                                                                                                          |        -        | map(string)  |  false   |
 | `worker_pool.reservation_ids`         | Block with Packet hardware reservation IDs for worker nodes. Each key must have the format `worker-${index}` and the value is the reservation UUID. Can't be combined with `reservation_ids_default`. Example: `reservation_ids = { worker-0 = "<reservation_id>" }`.             |        -        | map(string)  |  false   |
 | `worker_pool.reservation_ids_default` | Default reservation ID for workers. The value`next-available` will choose any reservation that matches the pool's device type and facility. Can't be combined with `reservation_ids`.                                                                                             |        -        |    string    |  false   |
 | `worker_pool.setup_raid`              | Attempt to create a RAID 0 from extra disks to be used for persistent container storage. Can't be used with `setup_raid_hdd` nor `setup_raid_sdd`.                                                                                                                                |      false      |     bool     |  false   |

--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -39,7 +39,7 @@ type workerPool struct {
 	OSChannel    string            `hcl:"os_channel,optional"`
 	OSVersion    string            `hcl:"os_version,optional"`
 	Labels       map[string]string `hcl:"labels,optional"`
-	Taints       string            `hcl:"taints,optional"`
+	Taints       map[string]string `hcl:"taints,optional"`
 	DiskSize     int               `hcl:"disk_size,optional"`
 	DiskType     string            `hcl:"disk_type,optional"`
 	DiskIOPS     int               `hcl:"disk_iops,optional"`

--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -38,7 +38,7 @@ type workerPool struct {
 	InstanceType string            `hcl:"instance_type,optional"`
 	OSChannel    string            `hcl:"os_channel,optional"`
 	OSVersion    string            `hcl:"os_version,optional"`
-	Labels       string            `hcl:"labels,optional"`
+	Labels       map[string]string `hcl:"labels,optional"`
 	Taints       string            `hcl:"taints,optional"`
 	DiskSize     int               `hcl:"disk_size,optional"`
 	DiskType     string            `hcl:"disk_type,optional"`

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -163,7 +163,11 @@ module "worker-pool-{{ $index }}" {
   {{- end }}
 
   {{- if $pool.Taints }}
-  taints = "{{ $pool.Taints }}"
+  taints = {
+  {{- range $k, $v := $pool.Taints }}
+    "{{ $k }}" = "{{ $v }}",
+  {{- end }}
+  }
   {{- end}}
 
   {{- if $pool.DiskSize }}

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -155,8 +155,12 @@ module "worker-pool-{{ $index }}" {
   {{- end }}
 
   {{- if $pool.Labels }}
-  labels = "{{ $pool.Labels }}"
-  {{- end}}
+  labels = {
+  {{- range $k, $v := $pool.Labels }}
+    "{{ $k }}" = "{{ $v }}",
+  {{- end }}
+  }
+  {{- end }}
 
   {{- if $pool.Taints }}
   taints = "{{ $pool.Taints }}"

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -51,7 +51,7 @@ type workerPool struct {
 	OSChannel             string            `hcl:"os_channel,optional"`
 	OSVersion             string            `hcl:"os_version,optional"`
 	NodeType              string            `hcl:"node_type,optional"`
-	Labels                string            `hcl:"labels,optional"`
+	Labels                map[string]string `hcl:"labels,optional"`
 	Taints                string            `hcl:"taints,optional"`
 	ReservationIDs        map[string]string `hcl:"reservation_ids,optional"`
 	ReservationIDsDefault string            `hcl:"reservation_ids_default,optional"`

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -52,7 +52,7 @@ type workerPool struct {
 	OSVersion             string            `hcl:"os_version,optional"`
 	NodeType              string            `hcl:"node_type,optional"`
 	Labels                map[string]string `hcl:"labels,optional"`
-	Taints                string            `hcl:"taints,optional"`
+	Taints                map[string]string `hcl:"taints,optional"`
 	ReservationIDs        map[string]string `hcl:"reservation_ids,optional"`
 	ReservationIDsDefault string            `hcl:"reservation_ids_default,optional"`
 	SetupRaid             bool              `hcl:"setup_raid,optional"`

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -193,7 +193,11 @@ EOF
   }
   {{- end }}
   {{- if $pool.Taints }}
-  taints = "{{ $pool.Taints }}"
+  taints = {
+  {{- range $k, $v := $pool.Taints }}
+    "{{ $k }}" = "{{ $v }}",
+  {{- end }}
+  }
   {{- end }}
   {{- if $.Config.ServiceCIDR }}
   service_cidr = "{{$.Config.ServiceCIDR}}"

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -186,7 +186,11 @@ EOF
   enable_tls_bootstrap = {{ $.Config.EnableTLSBootstrap }}
 
   {{- if $pool.Labels }}
-  labels = "{{ $pool.Labels }}"
+  labels = {
+  {{- range $k, $v := $pool.Labels }}
+    "{{ $k }}" = "{{ $v }}",
+  {{- end }}
+  }
   {{- end }}
   {{- if $pool.Taints }}
   taints = "{{ $pool.Taints }}"


### PR DESCRIPTION
Commits for more information.

closes: #489 #833

### Release Notes

- labels and nodes format changed from `string` to `map(string)` for aws and packet platform.
```
# Before
labels = "testing=true"

taints = "nodeType=storage:NoSchedule"

# After
labels = {
  "testing" = "true"
}

taints = {
  "nodeType" = "storage:NoSchedule"
 }
```