### PR TITLE
docs/KEYS: switch to personal GPG key

### DIFF
--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -7,13 +7,13 @@ This is the current set of trusted keys:
 
 | Short fingerprint               | Full fingerprint                                      | Owner         |
 | ------------------------------- | ----------------------------------------------------- | ------------- |
-| [0x72EBB080][key-iaguis]        | `BECE 2BD4 B68D 2071 255A 7A4E 3689 AD7F 72EB B080`   | @iaguis       |
+| [0x61BAD4F7][key-iaguis]        | `B7DD BE70 0140 8D7D 7FD0 79D2 7E26 3682 61BA D4F7`   | @iaguis       |
 | [0xF79374C3][key-invidian]      | `9725 A27E 0A93 A153 B798 F292 8DBC FB00 F793 74C3`   | @invidian     |
 | [0xF82B446B][key-ipochi]        | `967F A608 7E62 DF09 E22A 3A40 2851 51CE F82B 446B`   | @ipochi       |
 | [0xDF48CA1E][key-surajssd]      | `17E6 829F 7335 E994 2613 AABE 83E9 8295 DF48 CA1E`   | @surajssd     |
 
 
-[key-iaguis]: https://pgp.mit.edu/pks/lookup?search=0xBECE2BD4B68D2071255A7A4E3689AD7F72EBB080&op=index&exact=on
+[key-iaguis]: https://pgp.mit.edu/pks/lookup?search=0xB7DDBE7001408D7D7FD079D27E26368261BAD4F7&op=index&exact=on
 [key-invidian]: https://pgp.mit.edu/pks/lookup?search=0x9725A27E0A93A153B798F2928DBCFB00F79374C3&op=index&exact=on
 [key-ipochi]: https://pgp.mit.edu/pks/lookup?search=0x967FA6087E62DF09E22A3A40285151CEF82B446B&op=index&exact=on
 [key-surajssd]: https://pgp.mit.edu/pks/lookup?search=0x17E6829F7335E9942613AABE83E98295DF48CA1E&op=index&exact=on


### PR DESCRIPTION
I lost access to the previous private key
(0xBECE2BD4B68D2071255A7A4E3689AD7F72EBB080) so I've added a
iago@kinvolk.io identity to my personal key
(0xB7DDBE7001408D7D7FD079D27E26368261BAD4F7) and I'll be using that key
from now on.

Additionally, I've added the new key to keys.openpgp.org
(https://keys.openpgp.org/search?q=iago%40kinvolk.io) which verifies the
email address associated with the key.