### PR TITLE
Update to bootkube with --wait Helm option

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -194,7 +194,7 @@ storage:
             -v /opt/bootkube/assets:/assets:ro \
             -v /etc/kubernetes:/etc/kubernetes:rw \
             --network=host \
-            quay.io/kinvolk/bootkube:v0.14.0-helm-ec64535-amd64 \
+            quay.io/kinvolk/bootkube:v0.14.0-helm2-amd64 \
             /bootkube start --asset-dir=/assets
     - path: /etc/tmpfiles.d/etcd-wrapper.conf
       filesystem: root

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -156,7 +156,7 @@ storage:
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            docker://quay.io/kinvolk/bootkube:v0.14.0-helm-ec64535-amd64 \
+            docker://quay.io/kinvolk/bootkube:v0.14.0-helm2-amd64 \
             --insecure-options=image \
             --net=host \
             --dns=host \

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -205,7 +205,7 @@ storage:
             -v /opt/bootkube/assets:/assets:ro \
             -v /etc/kubernetes:/etc/kubernetes:rw \
             --network=host \
-            quay.io/kinvolk/bootkube:v0.14.0-helm-ec64535-amd64 \
+            quay.io/kinvolk/bootkube:v0.14.0-helm2-amd64 \
             /bootkube start --asset-dir=/assets
     - path: /etc/kubernetes/configure-kubelet-cgroup-driver
       filesystem: root

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -157,7 +157,7 @@ storage:
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            docker://quay.io/kinvolk/bootkube:v0.14.0-helm-ec64535-amd64 \
+            docker://quay.io/kinvolk/bootkube:v0.14.0-helm2-amd64 \
             --insecure-options=image \
             --net=host \
             --dns=host \

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -167,7 +167,7 @@ storage:
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            docker://quay.io/kinvolk/bootkube:v0.14.0-helm-ec64535-amd64 \
+            docker://quay.io/kinvolk/bootkube:v0.14.0-helm2-amd64 \
             --insecure-options=image \
             --net=host \
             --dns=host \

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -245,7 +245,7 @@ storage:
             -v /opt/bootkube/assets:/assets:ro \
             -v /etc/kubernetes:/etc/kubernetes:rw \
             --network=host \
-            quay.io/kinvolk/bootkube:v0.14.0-helm-ec64535-${os_arch} \
+            quay.io/kinvolk/bootkube:v0.14.0-helm2-${os_arch} \
             /bootkube start --asset-dir=/assets
     - path: /etc/tmpfiles.d/etcd-wrapper.conf
       filesystem: root


### PR DESCRIPTION
So smooth out pivoting from bootstrap kube-apiserver to self-hosted one.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>