### PR TITLE
Add check for multiple release in Namespace

### DIFF
--- a/cli/cmd/component-delete.go
+++ b/cli/cmd/component-delete.go
@@ -82,6 +82,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 
 	if !confirm && !askForConfirmation(confirmationMessage) {
 		contextLogger.Info("Components deletion cancelled.")
+
 		return
 	}
 

--- a/pkg/components/util/install.go
+++ b/pkg/components/util/install.go
@@ -184,7 +184,7 @@ func UninstallComponent(c components.Component, kubeconfig []byte, deleteNSBool 
 
 	cfg, err := HelmActionConfig(ns, kubeconfig)
 	if err != nil {
-		return fmt.Errorf("failed preparing helm client: %w", err)
+		return fmt.Errorf("preparing Helm client: %w", err)
 	}
 
 	history := action.NewHistory(cfg)

--- a/pkg/components/util/install.go
+++ b/pkg/components/util/install.go
@@ -205,7 +205,16 @@ func UninstallComponent(c components.Component, kubeconfig []byte, deleteNSBool 
 		}
 	}
 
+	releasesList, err := action.NewList(cfg).Run()
+	if err != nil {
+		return fmt.Errorf("listing Helm releases: %w", err)
+	}
+
 	if deleteNSBool {
+		if len(releasesList) > 0 {
+			return fmt.Errorf("namespace %q may have other components installed, cannot remove namespace", ns)
+		}
+
 		if err := deleteNS(ns, kubeconfig); err != nil {
 			return err
 		}

--- a/test/components/component_delete_multiple_release_test.go
+++ b/test/components/component_delete_multiple_release_test.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build aws aws_edge packet
+// +build disruptivee2e
+
+package components_test
+
+import (
+	"testing"
+
+	"github.com/kinvolk/lokomotive/pkg/components"
+	_ "github.com/kinvolk/lokomotive/pkg/components/headlamp"
+	"github.com/kinvolk/lokomotive/pkg/components/util"
+	testutil "github.com/kinvolk/lokomotive/test/components/util"
+)
+
+func TestDeleteNamespaceMultipleRelease(t *testing.T) {
+	n := "headlamp"
+
+	c, err := components.Get(n)
+	if err != nil {
+		t.Fatalf("failed getting component: %v", err)
+	}
+
+	k := testutil.Kubeconfig(t)
+
+	if err := util.UninstallComponent(c, k, true); err == nil {
+		t.Fatalf("Deleting component should fail.")
+	}
+}


### PR DESCRIPTION
User should know that before deleting a component that other helm
release  exists in a namespace.

closes: #1077
Signed-off-by: knrt10 <kautilya@kinvolk.io>