### PR TITLE
gangway: add a serviceaccount

### DIFF
--- a/assets/charts/components/gangway/templates/deployment.yaml
+++ b/assets/charts/components/gangway/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
         runAsGroup: 65534
+      serviceAccountName: gangway
       initContainers:
       - name: download-theme
         image: alpine/git:1.0.7

--- a/assets/charts/components/gangway/templates/serviceaccount.yaml
+++ b/assets/charts/components/gangway/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: gangway
+  name: gangway

--- a/test/components/gangway/gangway_test.go
+++ b/test/components/gangway/gangway_test.go
@@ -18,7 +18,10 @@
 package gangway
 
 import (
+	"context"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testutil "github.com/kinvolk/lokomotive/test/components/util"
 )
@@ -34,4 +37,25 @@ func TestGangwayDeployment(t *testing.T) {
 
 		testutil.WaitForDeployment(t, client, namespace, deployment, testutil.RetryInterval, testutil.Timeout)
 	})
+}
+
+func TestGangwayServiceAccount(t *testing.T) {
+	namespace := "gangway"
+	deployment := "gangway"
+	expectedServiceAccountName := "gangway"
+
+	client := testutil.CreateKubeClient(t)
+
+	testutil.WaitForDeployment(t, client, namespace, deployment, testutil.RetryInterval, testutil.Timeout)
+
+	deploy, err := client.AppsV1().Deployments(namespace).Get(context.TODO(), deployment, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't find gangway deployment")
+	}
+
+	if deploy.Spec.Template.Spec.ServiceAccountName != expectedServiceAccountName {
+		t.Fatalf("Expected serviceAccountName %q, got: %q",
+			deploy.Spec.Template.Spec.ServiceAccountName,
+			deploy.Spec.Template.Spec.ServiceAccountName)
+	}
 }


### PR DESCRIPTION
Gangway relies on a service account (any service account) to be mounted
on the pod file system to figure out the cluster CA.

We've disabled automounting of the default service account with the
our admission wehbook and this was breaking Gangway.

This creates a dummy service account so the Gangway pod has access to
the cluster CA file.

Fixes #1103 

TODO:

- [x] Test