### PR TITLE
prometheus-operator: disable powersupply collector

### DIFF
--- a/assets/charts/components/prometheus-operator/values.yaml
+++ b/assets/charts/components/prometheus-operator/values.yaml
@@ -1125,6 +1125,9 @@ prometheus-node-exporter:
   extraArgs:
     - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
     - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+    # Disables powersupply collector as the support for power class supply is disabled by default in Flatcar
+    # Issue tracked in #[215](flatcar-linux/Flatcar#215)
+    - --no-collector.powersupplyclass
 
 ## Manages Prometheus and Alertmanager components
 ##


### PR DESCRIPTION
Fixes: #1109

This commit disables the powersupply collector in `node_exporter`.

By default support for power class supply is disabled in Flatcar:
```
$ zcat /proc/config.gz | grep POWER_SUPPLY
# CONFIG_POWER_SUPPLY is not set
```

Hence node_exporter pod throws the following error:
```
level=error ts=2020-10-16T20:43:19.526Z caller=collector.go:161 msg="collector failed"
name=powersupplyclass duration_seconds=0.000774391 err="could not get
power_supply class info: error obtaining power_supply class info: failed to list power
supplies at \"/host/sys/class/power_supply\": open /host/sys/class/power_supply: no such
file or directory"
```

This issue is tracked in #[215](https://github.com/flatcar-linux/Flatcar/issues/215) to know the reasons behind the default behaviour and whether it makes sense to enable the power class supply support.

If the decision to enable the said support is made then the changes made in
this commit will need to be reverted.

Signed-off-by: Imran Pochi <imran@kinvolk.io>