### PR TITLE
Add seccompProfile field in pod's security context

### DIFF
--- a/assets/charts/control-plane/pod-checkpointer/templates/daemonset.yaml
+++ b/assets/charts/control-plane/pod-checkpointer/templates/daemonset.yaml
@@ -22,7 +22,6 @@ spec:
         k8s-app: pod-checkpointer
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
       nodeSelector:
@@ -74,3 +73,6 @@ spec:
       - name: var-run
         hostPath:
           path: /var/run
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault

--- a/assets/charts/control-plane/pod-checkpointer/templates/psp.yaml
+++ b/assets/charts/control-plane/pod-checkpointer/templates/psp.yaml
@@ -5,8 +5,8 @@ metadata:
   # If the pod must be defaulted or mutated, the first PodSecurityPolicy (ordered by name) to allow the pod is selected.
   name: pod-checkpointer-restricted
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
 spec:
   privileged: false
   allowPrivilegeEscalation: true

--- a/assets/terraform-modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/assets/terraform-modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: bootstrap-kube-apiserver
   namespace: kube-system
-  annotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   hostNetwork: true
   containers:
@@ -63,3 +61,6 @@ spec:
   - name: ssl-certs-host
     hostPath:
       path: ${trusted_certs_dir}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/assets/terraform-modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/assets/terraform-modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: bootstrap-kube-controller-manager
   namespace: kube-system
-  annotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   containers:
   - name: kube-controller-manager
@@ -37,3 +35,6 @@ spec:
   - name: ssl-host
     hostPath:
       path: ${trusted_certs_dir}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/assets/terraform-modules/bootkube/resources/bootstrap-manifests/bootstrap-scheduler.yaml
+++ b/assets/terraform-modules/bootkube/resources/bootstrap-manifests/bootstrap-scheduler.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: bootstrap-kube-scheduler
   namespace: kube-system
-  annotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   containers:
   - name: kube-scheduler
@@ -22,3 +20,6 @@ spec:
   - name: secrets
     hostPath:
       path: /etc/kubernetes/bootstrap-secrets
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault


### PR DESCRIPTION
This change has been implemented for the following control-plane
components:

- Pod checkpointer.
- Kube apiserver.
- Kube controller manager.
- Kube scheduler.

Fixes #1107