### PR TITLE
test/linkerd: Fix TestLinkerdDeployment

### DIFF
--- a/test/components/linkerd/linkerd_test.go
+++ b/test/components/linkerd/linkerd_test.go
@@ -82,10 +82,10 @@ spec:
     volumeMounts:
     - name: download-dir
       mountPath: /data
-  - image: fedora
+  - image: nginx
     name: download-linkerd
     command:
-    - bash
+    - /bin/sh
     args:
     - -c
     - 'curl -L https://run.linkerd.io/install | sh && cp -L /root/.linkerd2/bin/linkerd /data/linkerd'


### PR DESCRIPTION
linkerd changed the script, due to which it was failing to install
linkerd on fedora. Changed base image to nginx and script accordingly.

Signed-off-by: knrt10 <kautilya@kinvolk.io>