### PR TITLE
Update velero to 1.5.2

### DIFF
--- a/assets/charts/components/velero/Chart.yaml
+++ b/assets/charts/components/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.4.2
+appVersion: 1.5.2
 description: A Helm chart for velero
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
@@ -18,4 +18,4 @@ name: velero
 sources:
 - https://github.com/vmware-tanzu/velero
 tillerVersion: '>=2.10.0'
-version: 2.12.15
+version: 2.13.6

--- a/assets/charts/components/velero/README.md
+++ b/assets/charts/components/velero/README.md
@@ -6,13 +6,13 @@ Velero has two main components: a CLI, and a server-side Kubernetes deployment.
 
 ## Installing the Velero CLI
 
-See the different options for installing the [Velero CLI](https://velero.io/docs/v1.4/basic-install/#install-the-cli).
+See the different options for installing the [Velero CLI](https://velero.io/docs/v1.5/basic-install/#install-the-cli).
 
 ## Installing the Velero server
 
 ### Velero version
 
-This helm chart installs Velero version v1.4.2 https://github.com/vmware-tanzu/velero/tree/v1.4.2. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
+This helm chart installs Velero version v1.5.1 https://github.com/vmware-tanzu/velero/tree/v1.5.1. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
 
 ### Provider credentials
 
@@ -22,7 +22,7 @@ When installing using the Helm chart, the provider's credential information will
 
 The default configuration values for this chart are listed in values.yaml.
 
-See Velero's full [official documentation](https://velero.io/docs/v1.4/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.4/supported-providers/) for specific configuration information and examples.
+See Velero's full [official documentation](https://velero.io/docs/v1.5/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.5/supported-providers/) for specific configuration information and examples.
 
 
 #### Using Helm 3
@@ -45,7 +45,7 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> \
 --set configuration.volumeSnapshotLocation.name=<VOLUME SNAPSHOT LOCATION NAME> \
 --set configuration.volumeSnapshotLocation.config.region=<REGION> \
 --set image.repository=velero/velero \
---set image.tag=v1.4.2 \
+--set image.tag=v1.5.1 \
 --set image.pullPolicy=IfNotPresent \
 --set initContainers[0].name=velero-plugin-for-aws \
 --set initContainers[0].image=velero/velero-plugin-for-aws:v1.1.0 \
@@ -97,7 +97,7 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> \
 --set configuration.volumeSnapshotLocation.name=<VOLUME SNAPSHOT LOCATION NAME> \
 --set configuration.volumeSnapshotLocation.config.region=<REGION> \
 --set image.repository=velero/velero \
---set image.tag=v1.4.2 \
+--set image.tag=v1.5.1 \
 --set image.pullPolicy=IfNotPresent \
 --set initContainers[0].name=velero-plugin-for-aws \
 --set initContainers[0].image=velero/velero-plugin-for-aws:v1.1.0 \
@@ -123,10 +123,14 @@ helm upgrade vmware-tanzu/velero <RELEASE NAME> --reuse-values --set configurati
 
 ## Upgrading
 
+### Upgrading to v1.5
+
+The [instructions found here](https://velero.io/docs/v1.5/upgrade-to-1.5/) will assist you in upgrading from version v1.4.x to v1.5.
+
+
 ### Upgrading to v1.4
 
 The [instructions found here](https://velero.io/docs/v1.4/upgrade-to-1.4/) will assist you in upgrading from version v1.3.x to v1.4.
-
 
 ### Upgrading to v1.3.1
 

--- a/assets/charts/components/velero/ci/test-values.yaml
+++ b/assets/charts/components/velero/ci/test-values.yaml
@@ -14,6 +14,16 @@ configuration:
       bucket: velero
       region: us-west-1
 
+schedules:
+  mybackup:
+    labels:
+      myenv: foo
+    schedule: "0 0 * * *"
+    template:
+      ttl: "240h"
+      includedNamespaces:
+      - foo
+
 # Set a service account so that the CRD clean up job has proper permissions to delete CRDs
 serviceAccount:
   server:

--- a/assets/charts/components/velero/crds/backups.yaml
+++ b/assets/charts/components/velero/crds/backups.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: backups.velero.io
 spec:
   group: velero.io
@@ -27,18 +26,24 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
           description: BackupSpec defines the specification for a Velero backup.
           properties:
+            defaultVolumesToRestic:
+              description: DefaultVolumesToRestic specifies whether restic
+                should be used to take a backup of all pod volumes by default.
+              type: boolean
             excludedNamespaces:
               description: ExcludedNamespaces contains a list of namespaces that are
                 not included in the backup.
@@ -302,6 +307,15 @@ spec:
                     are ANDed.
                   type: object
               type: object
+            orderedResources:
+              additionalProperties:
+                type: string
+              description: OrderedResources specifies the backup order of resources of
+                specific Kind. The map key is the Kind name and value is a list of resource
+                names separeted by commas. Each resource name has format "namespace/resourcename".
+                For cluster resources, simply use "resourcename".
+              nullable: true
+              type: object
             snapshotVolumes:
               description: SnapshotVolumes specifies whether to take cloud snapshots
                 of any PV's referenced in the set of objects included in the Backup.
@@ -414,9 +428,4 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+

--- a/assets/charts/components/velero/crds/backupstoragelocations.yaml
+++ b/assets/charts/components/velero/crds/backupstoragelocations.yaml
@@ -7,18 +7,33 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: backupstoragelocations.velero.io
 spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.phase
+      description: Backup Storage Location status such as Available/Unavailable
+      name: Phase
+      type: string
+    - JSONPath: .status.lastValidationTime
+      description: LastValidationTime is the last time the backup store location was validated
+      name: Last Validated
+      type: date
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
   group: velero.io
   names:
     kind: BackupStorageLocation
     listKind: BackupStorageLocationList
     plural: backupstoragelocations
+    shortNames:
+      - bsl
     singular: backupstoragelocation
   preserveUnknownFields: false
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: BackupStorageLocation is a location where Velero stores backup
@@ -27,17 +42,19 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: BackupStorageLocationSpec defines the specification for a Velero
+          description: BackupStorageLocationSpec defines the desired state of a Velero
             BackupStorageLocation.
           properties:
             accessMode:
@@ -79,13 +96,18 @@ spec:
             provider:
               description: Provider is the provider of the backup storage.
               type: string
+            validationFrequency:
+              description: ValidationFrequency defines how frequently to validate
+                the corresponding object storage. A value of 0 disables validation.
+              nullable: true
+              type: string
           required:
           - objectStorage
           - provider
           type: object
         status:
-          description: BackupStorageLocationStatus describes the current status of
-            a Velero BackupStorageLocation.
+          description: BackupStorageLocationStatus defines the observed state of
+            BackupStorageLocation
           properties:
             accessMode:
               description: "AccessMode is an unused field. \n Deprecated: there is
@@ -108,6 +130,12 @@ spec:
               format: date-time
               nullable: true
               type: string
+            lastValidationTime:
+              description: LastValidationTime is the last time the backup store location
+                was validated the cluster.
+              format: date-time
+              nullable: true
+              type: string
             phase:
               description: Phase is the current state of the BackupStorageLocation.
               enum:
@@ -121,9 +149,4 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+

--- a/assets/charts/components/velero/crds/deletebackuprequests.yaml
+++ b/assets/charts/components/velero/crds/deletebackuprequests.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: deletebackuprequests.velero.io
 spec:
   group: velero.io
@@ -26,12 +25,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -68,9 +69,4 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+

--- a/assets/charts/components/velero/crds/downloadrequests.yaml
+++ b/assets/charts/components/velero/crds/downloadrequests.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: downloadrequests.velero.io
 spec:
   group: velero.io
@@ -27,12 +26,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -89,9 +90,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/assets/charts/components/velero/crds/podvolumebackups.yaml
+++ b/assets/charts/components/velero/crds/podvolumebackups.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: podvolumebackups.velero.io
 spec:
   group: velero.io
@@ -25,12 +24,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -65,20 +66,25 @@ spec:
                     in the future.'
                   type: string
                 kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  description: 'Kind of the referent. More info:
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                   type: string
                 name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  description: 'Name of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                   type: string
                 namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  description: 'Namespace of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                   type: string
                 resourceVersion:
                   description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    made, if any. More info:
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  description: 'UID of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
             repoIdentifier:
@@ -157,9 +163,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/assets/charts/components/velero/crds/podvolumerestores.yaml
+++ b/assets/charts/components/velero/crds/podvolumerestores.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: podvolumerestores.velero.io
 spec:
   group: velero.io
@@ -25,12 +24,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -62,20 +63,25 @@ spec:
                     in the future.'
                   type: string
                 kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  description: 'Kind of the referent. More info:
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                   type: string
                 name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  description: 'Name of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                   type: string
                 namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  description: 'Namespace of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                   type: string
                 resourceVersion:
                   description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    made, if any. More info:
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  description: 'UID of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
             repoIdentifier:
@@ -140,9 +146,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/assets/charts/components/velero/crds/resticrepositories.yaml
+++ b/assets/charts/components/velero/crds/resticrepositories.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: resticrepositories.velero.io
 spec:
   group: velero.io
@@ -25,12 +24,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -84,9 +85,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/assets/charts/components/velero/crds/restores.yaml
+++ b/assets/charts/components/velero/crds/restores.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: restores.velero.io
 spec:
   group: velero.io
@@ -27,12 +26,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -57,6 +58,1214 @@ spec:
                 type: string
               nullable: true
               type: array
+            hooks:
+              description: Hooks represent custom behaviors that should be executed
+                during or post restore.
+              properties:
+                resources:
+                  items:
+                    description: RestoreResourceHookSpec defines one or more RestoreResrouceHooks
+                      that should be executed based on the rules defined for namespaces, resources,
+                      and label selector.
+                    properties:
+                      excludedNamespaces:
+                        description: ExcludedNamespaces specifies the namespaces to which
+                          this hook spec does not apply.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedResources:
+                        description: ExcludedResources specifies the resources to which
+                          this hook spec does not apply.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedNamespaces:
+                        description: IncludedNamespaces specifies the namespaces to which
+                          this hook spec applies. If empty, it applies to all namespaces.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedResources:
+                        description: IncludedResources specifies the resources to which
+                          this hook spec applies. If empty, it applies to all resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      labelSelector:
+                        description: LabelSelector, if specified, filters the resources
+                          to which this hook spec applies.
+                        nullable: true
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to
+                                    a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is
+                                    In or NotIn, the values array must be non-empty. If the operator is
+                                    Exists or DoesNotExist, the values array must be empty. This array is
+                                    replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                              in the matchLabels map is equivalent to an element of matchExpressions,
+                              whose key field is "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      name:
+                        description: Name is the name of this hook.
+                        type: string
+                      postHooks:
+                        description: PostHooks is a list of RestoreResourceHooks to execute during and
+                          after restoring a resource.
+                        items:
+                          description: RestoreResourceHook defines a restore hook for a resource.
+                          properties:
+                            exec:
+                              description: Exec defines an exec restore hook.
+                              properties:
+                                command:
+                                  description: Command is the command and arguments to execute from within
+                                    a container after a pod has been restored.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                container:
+                                  description: Container is the container in the pod where the command should
+                                    be executed. If not specified, the pod's first container is used.
+                                  type: string
+                                execTimeout:
+                                  description: ExecTimeout defines the maximum amount of time Velero should
+                                    wait for the hook to complete before considering the execution a failure.
+                                  type: string
+                                onError:
+                                  description: OnError specifies how Velero should behave if it encounters
+                                    an error executing this hook.
+                                  enum:
+                                    - Continue
+                                    - Fail
+                                  type: string
+                                waitTimeout:
+                                  description: WaitTimeout defines the maximum amount of time Velero should
+                                    wait for the container to be Ready before attempting to run the command.
+                                  type: string
+                              required:
+                                - command
+                              type: object
+                            init:
+                              description: Init defines an init restore hook.
+                              properties:
+                                initContainers:
+                                  description: InitContainers is list of init containers to be added
+                                    to a pod during its restore.
+                                  items:
+                                    description: A single application container that you want to run within a pod.
+                                    properties:
+                                      args:
+                                        description: 'Arguments to the entrypoint. The docker image''s CMD is
+                                          used if this is not provided. Variable references $(VAR_NAME) are expanded
+                                          using the container''s environment. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. The $(VAR_NAME)
+                                          syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                                          references will never be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        description: 'Entrypoint array. Not executed within a shell.
+                                          The docker image''s ENTRYPOINT is used if this is not provided.
+                                          Variable references $(VAR_NAME) are expanded using the container''s
+                                          environment. If a variable cannot be resolved, the reference in the
+                                          input string will be unchanged. The $(VAR_NAME) syntax can be
+                                          escaped with a double $$, ie: $$(VAR_NAME). Escaped references will
+                                          never be expanded, regardless of whether the variable exists or not.
+                                          Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        description: List of environment variables to set in the
+                                          container. Cannot be updated.
+                                        items:
+                                          description: EnvVar represents an environment variable
+                                            present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment variable.
+                                                Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: 'Variable references $(VAR_NAME) are expanded
+                                                using the previous defined environment variables in the
+                                                container and any service environment variables. If a variable
+                                                cannot be resolved, the reference in the input string will be
+                                                unchanged. The $(VAR_NAME) syntax can be escaped with a
+                                                double $$, ie: $$(VAR_NAME). Escaped references will never be
+                                                expanded, regardless of whether the variable exists or not.
+                                                Defaults to "".'
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment variable's value.
+                                                Cannot be used if value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent. More info:
+                                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap or its
+                                                        key must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  description: 'Selects a field of the pod: supports metadata.name,
+                                                    metadata.namespace, metadata.labels, metadata.annotations,
+                                                    spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                                    status.podIP, status.podIPs.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource of the container: only
+                                                    resources limits and requests (limits.cpu, limits.memory,
+                                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                                    and requests.ephemeral-storage) are currently supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name: required for volumes,
+                                                        optional for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: Specifies the output format of the exposed
+                                                        resources, defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource to select'
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret to select from.
+                                                        Must be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent. More info:
+                                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the Secret or its key
+                                                        must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        description: List of sources to populate environment variables in
+                                          the container. The keys defined within a source must be a C_IDENTIFIER.
+                                          All invalid keys will be reported as an event when the container
+                                          is starting. When a key exists in multiple sources, the value
+                                          associated with the last source will take precedence. Values
+                                          defined by an Env with a duplicate key will take precedence. Cannot
+                                          be updated.
+                                        items:
+                                          description: EnvFromSource represents the source of a set of ConfigMaps
+                                          properties:
+                                            configMapRef:
+                                              description: The ConfigMap to select from
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent. More info:
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap must be defined
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              description: An optional identifier to prepend to each
+                                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                                              type: string
+                                            secretRef:
+                                              description: The Secret to select from
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent. More info:
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret must be defined
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        description: 'Docker image name. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images
+                                          This field is optional to allow higher level config management
+                                          to default or override container images in workload controllers
+                                          like Deployments and StatefulSets.'
+                                        type: string
+                                      imagePullPolicy:
+                                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                          Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                        type: string
+                                      lifecycle:
+                                        description: Actions that the management system should take in response
+                                          to container lifecycle events. Cannot be updated.
+                                        properties:
+                                          postStart:
+                                            description: 'PostStart is called immediately after a container is
+                                              created. If the handler fails, the container is terminated and
+                                              restarted according to its restart policy. Other management of
+                                              the container blocks until the hook completes. More info:
+                                              https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            properties:
+                                              exec:
+                                                description: One and only one of the following should be specified.
+                                                  Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: Command is the command line to execute inside
+                                                      the container, the working directory for the command
+                                                      is root ('/') in the container's filesystem. The command
+                                                      is simply exec'd, it is not run inside a shell, so traditional
+                                                      shell instructions ('|', etc) won't work. To use a shell,
+                                                      you need to explicitly call out to that shell. Exit status
+                                                      of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to
+                                                      the pod IP. You probably want to set "Host" in
+                                                      httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request.
+                                                      HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to
+                                                        be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Name or number of the port to access on
+                                                      the container. Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              tcpSocket:
+                                                description: 'TCPSocket specifies an action involving
+                                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                                  a realistic TCP lifecycle hook'
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to,
+                                                      defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Number or name of the port to access on
+                                                      the container. Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            description: 'PreStop is called immediately before a container
+                                              is terminated due to an API request or management event such
+                                              as liveness/startup probe failure, preemption, resource
+                                              contention, etc. The handler is not called if the container
+                                              crashes or exits. The reason for termination is passed to
+                                              the handler. The Pod''s termination grace period countdown
+                                              begins before the PreStop hooked is executed. Regardless
+                                              of the outcome of the handler, the container will eventually
+                                              terminate within the Pod''s termination grace period. Other
+                                              management of the container blocks until the hook completes
+                                              or until the termination grace period is reached. More info:
+                                              https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            properties:
+                                              exec:
+                                                description: One and only one of the following should be
+                                                  specified. Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: Command is the command line to execute
+                                                      inside the container, the working directory for
+                                                      the command  is root ('/') in the container's
+                                                      filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell
+                                                      instructions ('|', etc) won't work. To use a shell,
+                                                      you need to explicitly call out to that shell. Exit
+                                                      status of 0 is treated as live/healthy and non-zero
+                                                      is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to
+                                                      the pod IP. You probably want to set "Host"
+                                                      in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request.
+                                                      HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header
+                                                        to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Name or number of the port to access on
+                                                      the container. Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              tcpSocket:
+                                                description: 'TCPSocket specifies an action involving
+                                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                                  a realistic TCP lifecycle hook'
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to,
+                                                      defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Number or name of the port to access on
+                                                      the container. Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                        type: object
+                                      livenessProbe:
+                                        description: 'Periodic probe of container liveness. Container
+                                          will be restarted if the probe fails. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should be
+                                              specified. Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute inside
+                                                  the container, the working directory for the command  is
+                                                  root ('/') in the container's filesystem. The command is
+                                                  simply exec'd, it is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't work. To use a shell,
+                                                  you need to explicitly call out to that shell. Exit status
+                                                  of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be
+                                              considered failed after having succeeded. Defaults to 3.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults
+                                                  to the pod IP. You probably want to set "Host"
+                                                  in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request.
+                                                  HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom
+                                                    header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Name or number of the port to access on the
+                                                  container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after the container has
+                                              started before liveness probes are initiated. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to perform the probe.
+                                              Default to 10 seconds. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe
+                                              to be considered successful after having failed.
+                                              Defaults to 1. Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving a
+                                              TCP port. TCP hooks not yet supported TODO: implement
+                                              a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to,
+                                                 defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Number or name of the port to access on the
+                                                  container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after which the probe times out.
+                                              Defaults to 1 second. Minimum value is 1. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      name:
+                                        description: Name of the container specified as a DNS_LABEL. Each
+                                          container in a pod must have a unique name (DNS_LABEL).
+                                          Cannot be updated.
+                                        type: string
+                                      ports:
+                                        description: List of ports to expose from the container. Exposing
+                                          a port here gives the system additional information about the
+                                          network connections a container uses, but is primarily informational.
+                                          Not specifying a port here DOES NOT prevent that port from being
+                                          exposed. Any port which is listening on the default "0.0.0.0" address
+                                          inside a container will be accessible from the network.
+                                          Cannot be updated.
+                                        items:
+                                          description: ContainerPort represents a network port in a
+                                            single container.
+                                          properties:
+                                            containerPort:
+                                              description: Number of port to expose on the pod's IP
+                                                address. This must be a valid port number, 0 < x < 65536.
+                                              format: int32
+                                              type: integer
+                                            hostIP:
+                                              description: What host IP to bind the external port to.
+                                              type: string
+                                            hostPort:
+                                              description: Number of port to expose on the host.
+                                                If specified, this must be a valid port number,
+                                                0 < x < 65536. If HostNetwork is specified, this must
+                                                match ContainerPort. Most containers do not need this.
+                                              format: int32
+                                              type: integer
+                                            name:
+                                              description: If specified, this must be an IANA_SVC_NAME
+                                                and unique within the pod. Each named port in a pod
+                                                must have a unique name. Name for the port that can
+                                                be referred to by services.
+                                              type: string
+                                            protocol:
+                                              description: Protocol for port. Must be UDP, TCP,
+                                                or SCTP. Defaults to "TCP".
+                                              type: string
+                                          required:
+                                            - containerPort
+                                            - protocol
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                        x-kubernetes-list-type: map
+                                      readinessProbe:
+                                        description: 'Periodic probe of container service readiness. Container
+                                          will be removed from service endpoints if the probe fails. Cannot be
+                                          updated. More info:
+                                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should be specified.
+                                              Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute inside
+                                                  the container, the working directory for the command
+                                                  is root ('/') in the container's filesystem. The command
+                                                  is simply exec'd, it is not run inside a shell, so
+                                                  traditional shell instructions ('|', etc) won't work.
+                                                  To use a shell, you need to explicitly call out to that
+                                                  shell. Exit status of 0 is treated as live/healthy and
+                                                  non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe
+                                              to be considered failed after having succeeded. Defaults to 3.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                  You probably want to set "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request.
+                                                  HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header
+                                                    to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Name or number of the port to access on
+                                                  the container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after the container has
+                                              started before liveness probes are initiated. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to perform the probe.
+                                              Default to 10 seconds. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe
+                                              to be considered successful after having failed.
+                                              Defaults to 1. Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving
+                                              a TCP port. TCP hooks not yet supported TODO: implement
+                                              a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to,
+                                                  defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Number or name of the port to access on
+                                                  the container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after which the probe
+                                              times out. Defaults to 1 second. Minimum value is 1.
+                                              More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      resources:
+                                        description: 'Compute Resources required by this container.
+                                          Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum amount of compute
+                                              resources allowed. More info:
+                                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum amount of compute
+                                              resources required. If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly specified, otherwise
+                                              to an implementation-defined value. More info:
+                                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        description: 'Security options the pod should run with. More
+                                          info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            description: 'AllowPrivilegeEscalation controls whether
+                                              a process can gain more privileges than its parent process.
+                                              This bool directly controls if the no_new_privs flag will
+                                              be set on the container process. AllowPrivilegeEscalation
+                                              is true always when the container is: 1) run as Privileged 2)
+                                              has CAP_SYS_ADMIN'
+                                            type: boolean
+                                          capabilities:
+                                            description: The capabilities to add/drop when
+                                              running containers. Defaults to the default
+                                              set of capabilities granted by the container runtime.
+                                            properties:
+                                              add:
+                                                description: Added capabilities
+                                                items:
+                                                  description: Capability represent POSIX
+                                                    capabilities type
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                description: Removed capabilities
+                                                items:
+                                                  description: Capability represent POSIX capabilities
+                                                    type
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            description: Run container in privileged mode. Processes
+                                              in privileged containers are essentially equivalent
+                                              to root on the host. Defaults to false.
+                                            type: boolean
+                                          procMount:
+                                            description: procMount denotes the type of proc mount to
+                                              use for the containers. The default is DefaultProcMount
+                                              which uses the container runtime defaults for readonly
+                                              paths and masked paths. This requires the ProcMountType
+                                              feature flag to be enabled.
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            description: Whether this container has a read-only root filesystem.
+                                              Default is false.
+                                            type: boolean
+                                          runAsGroup:
+                                            description: The GID to run the entrypoint of the container
+                                              process. Uses runtime default if unset. May also be set
+                                              in PodSecurityContext.  If set in both SecurityContext
+                                              and PodSecurityContext, the value specified in
+                                              SecurityContext takes precedence.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container must run as
+                                              a non-root user. If true, the Kubelet will validate
+                                              the image at runtime to ensure that it does not run
+                                              as UID 0 (root) and fail to start the container if
+                                              it does. If unset or false, no such validation will
+                                              be performed. May also be set in PodSecurityContext.
+                                              If set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext takes precedence.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint of the container
+                                              process. Defaults to user specified in image metadata if
+                                              unspecified. May also be set in PodSecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext, the
+                                              value specified in SecurityContext takes precedence.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be applied to
+                                              the container. If unspecified, the container runtime
+                                              will allocate a random SELinux context for each
+                                              container.  May also be set in PodSecurityContext.
+                                              If set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext takes precedence.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level label that
+                                                  applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role label that
+                                                  applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type label that
+                                                  applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user label that
+                                                  applies to the container.
+                                                type: string
+                                            type: object
+                                          windowsOptions:
+                                            description: The Windows specific settings applied to
+                                              all containers. If unspecified, the options from
+                                              the PodSecurityContext will be used. If set in both
+                                              SecurityContext and PodSecurityContext, the value
+                                              specified in SecurityContext takes precedence.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: GMSACredentialSpec is where the GMSA
+                                                  admission webhook
+                                                  (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                  inlines the contents of the GMSA credential spec
+                                                  named by the GMSACredentialSpecName field.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName is the name
+                                                  of the GMSA credential spec to use.
+                                                type: string
+                                              runAsUserName:
+                                                description: The UserName in Windows to run
+                                                  the entrypoint of the container process.
+                                                  Defaults to the user specified in image
+                                                  metadata if unspecified. May also be set
+                                                  in PodSecurityContext. If set in both SecurityContext
+                                                  and PodSecurityContext, the value specified in
+                                                  SecurityContext takes precedence.
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        description: 'StartupProbe indicates that the Pod
+                                          has successfully initialized. If specified, no other
+                                          probes are executed until this completes successfully.
+                                          If this probe fails, the Pod will be restarted, just
+                                          as if the livenessProbe failed. This can be used to
+                                          provide different probe parameters at the beginning
+                                          of a Pod''s lifecycle, when it might take a long time
+                                          to load data or warm a cache, than during steady-state
+                                          operation. This cannot be updated. This is a beta feature
+                                          enabled by the StartupProbe feature flag. More info:
+                                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should
+                                              be specified. Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute
+                                                  inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it is not run inside a
+                                                  shell, so traditional shell instructions ('|', etc)
+                                                  won't work. To use a shell, you need to explicitly
+                                                  call out to that shell. Exit status of 0 is treated
+                                                  as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe
+                                              to be considered failed after having succeeded.
+                                              Defaults to 3. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to
+                                                  the pod IP. You probably want to set "Host" in
+                                                  httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request.
+                                                  HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header
+                                                    to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Name or number of the port to access on the
+                                                  container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after the container has
+                                              started before liveness probes are initiated. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to perform the probe.
+                                              Default to 10 seconds. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe
+                                              to be considered successful after having failed.
+                                              Defaults to 1. Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving
+                                              a TCP port. TCP hooks not yet supported TODO: implement
+                                              a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to,
+                                                  defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Number or name of the port to access on
+                                                  the container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after which the probe times
+                                             out. Defaults to 1 second. Minimum value is 1. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        description: Whether this container should allocate a buffer
+                                          for stdin in the container runtime. If this is not set,
+                                          reads from stdin in the container will always result in EOF.
+                                          Default is false.
+                                        type: boolean
+                                      stdinOnce:
+                                        description: Whether the container runtime should close
+                                          the stdin channel after it has been opened by a single
+                                          attach. When stdin is true the stdin stream will remain
+                                          open across multiple attach sessions. If stdinOnce is
+                                          set to true, stdin is opened on container start, is empty
+                                          until the first client attaches to stdin, and then remains
+                                          open and accepts data until the client disconnects, at
+                                          which time stdin is closed and remains closed until the
+                                          container is restarted. If this flag is false, a container
+                                          processes that reads from stdin will never receive an EOF.
+                                          Default is false
+                                        type: boolean
+                                      terminationMessagePath:
+                                        description: 'Optional: Path at which the file to which
+                                          the container''s termination message will be written
+                                          is mounted into the container''s filesystem. Message
+                                          written is intended to be brief final status, such as
+                                          an assertion failure message. Will be truncated by
+                                          the node if greater than 4096 bytes. The total message
+                                           length across all containers will be limited to 12kb.
+                                            Defaults to /dev/termination-log. Cannot be updated.'
+                                        type: string
+                                      terminationMessagePolicy:
+                                        description: Indicate how the termination message
+                                          should be populated. File will use the contents
+                                          of terminationMessagePath to populate the container
+                                          status message on both success and failure.
+                                          FallbackToLogsOnError will use the last chunk
+                                          of container log output if the termination message
+                                          file is empty and the container exited with an error.
+                                          The log output is limited to 2048 bytes or 80 lines,
+                                          whichever is smaller. Defaults to File. Cannot be updated.
+                                        type: string
+                                      tty:
+                                        description: Whether this container should allocate
+                                          a TTY for itself, also requires 'stdin' to be true.
+                                          Default is false.
+                                        type: boolean
+                                      volumeDevices:
+                                        description: volumeDevices is the list of block devices
+                                          to be used by the container.
+                                        items:
+                                          description: volumeDevice describes a mapping of a raw
+                                            block device within a container.
+                                          properties:
+                                            devicePath:
+                                              description: devicePath is the path inside
+                                                of the container that the device will be mapped to.
+                                              type: string
+                                            name:
+                                              description: name must match the name of a
+                                                persistentVolumeClaim
+                                                in the pod
+                                              type: string
+                                          required:
+                                            - devicePath
+                                            - name
+                                          type: object
+                                        type: array
+                                      volumeMounts:
+                                        description: Pod volumes to mount into the container's
+                                          filesystem. Cannot be updated.
+                                        items:
+                                          description: VolumeMount describes a mounting of a Volume
+                                            within a container.
+                                          properties:
+                                            mountPath:
+                                              description: Path within the container at which the
+                                                volume should be mounted.  Must not contain ':'.
+                                              type: string
+                                            mountPropagation:
+                                              description: mountPropagation determines how mounts
+                                                are propagated from the host to container and the
+                                                other way around. When not set, MountPropagationNone
+                                                is used. This field is beta in 1.10.
+                                              type: string
+                                            name:
+                                              description: This must match the Name of a Volume.
+                                              type: string
+                                            readOnly:
+                                              description: Mounted read-only if true, read-write
+                                                otherwise (false or unspecified). Defaults to false.
+                                              type: boolean
+                                            subPath:
+                                              description: Path within the volume from which the
+                                                container's volume should be mounted. Defaults to ""
+                                                (volume's root).
+                                              type: string
+                                            subPathExpr:
+                                              description: Expanded path within the volume
+                                                from which the container's volume should be
+                                                mounted. Behaves similarly to SubPath but
+                                                environment variable references $(VAR_NAME)
+                                                are expanded using the container's environment.
+                                                Defaults to "" (volume's root). SubPathExpr and
+                                                SubPath are mutually exclusive.
+                                              type: string
+                                          required:
+                                            - mountPath
+                                            - name
+                                          type: object
+                                        type: array
+                                      workingDir:
+                                        description: Container's working directory.
+                                          If not specified, the container runtime's
+                                          default will be used, which might be configured
+                                          in the container image. Cannot be updated.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                timeout:
+                                  description: Timeout defines the maximum amount
+                                    of time Velero should wait for the initContainers
+                                    to complete.
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                      - name
+                    type: object
+                  type: array
+              type: object
             includeClusterResources:
               description: IncludeClusterResources specifies whether cluster-scoped
                 resources should be included for consideration in the restore. If
@@ -109,8 +1318,8 @@ spec:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
@@ -141,11 +1350,18 @@ spec:
                 restore from the most recent successful backup created from this schedule.
               type: string
           required:
-          - backupName
+            - backupName
           type: object
         status:
           description: RestoreStatus captures the current status of a Velero restore
           properties:
+            completionTimestamp:
+              description: CompletionTimestamp records the time the restore operation
+                was completed. Completion time is recorded even on failed restore.
+                The server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
             errors:
               description: Errors is a count of all error messages that were generated
                 during execution of the restore. The actual errors are stored in object
@@ -158,12 +1374,18 @@ spec:
             phase:
               description: Phase is the current state of the Restore
               enum:
-              - New
-              - FailedValidation
-              - InProgress
-              - Completed
-              - PartiallyFailed
-              - Failed
+                - New
+                - FailedValidation
+                - InProgress
+                - Completed
+                - PartiallyFailed
+                - Failed
+              type: string
+            startTimestamp:
+              description: StartTimestamp records the time the restore operation
+                was started. The server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
               type: string
             validationErrors:
               description: ValidationErrors is a slice of all validation errors (if
@@ -181,12 +1403,7 @@ spec:
       type: object
   version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    - name: v1
+      served: true
+      storage: true
+

--- a/assets/charts/components/velero/crds/schedules.yaml
+++ b/assets/charts/components/velero/crds/schedules.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,post-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: schedules.velero.io
 spec:
   group: velero.io
@@ -27,12 +26,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -47,6 +48,10 @@ spec:
               description: Template is the definition of the Backup to be run on the
                 provided schedule
               properties:
+                defaultVolumesToRestic:
+                  description: DefaultVolumesToRestic specifies whether restic should
+                    be used to take a backup of all pod volumes by default.
+                  type: boolean
                 excludedNamespaces:
                   description: ExcludedNamespaces contains a list of namespaces that
                     are not included in the backup.
@@ -317,6 +322,15 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                orderedResources:
+                  additionalProperties:
+                    type: string
+                  description: OrderedResources specifies the backup order of resources of
+                    specific Kind. The map key is the Kind name and value is a list of
+                    resource names separeted by commas. Each resource name has format
+                    "namespace/resourcename".  For cluster resources, simply use "resourcename".
+                  nullable: true
+                  type: object
                 snapshotVolumes:
                   description: SnapshotVolumes specifies whether to take cloud snapshots
                     of any PV's referenced in the set of objects included in the Backup.
@@ -370,9 +384,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/assets/charts/components/velero/crds/serverstatusrequests.yaml
+++ b/assets/charts/components/velero/crds/serverstatusrequests.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: serverstatusrequests.velero.io
 spec:
   group: velero.io
@@ -16,9 +15,13 @@ spec:
     kind: ServerStatusRequest
     listKind: ServerStatusRequestList
     plural: serverstatusrequests
+    shortNames:
+      - ssr
     singular: serverstatusrequest
   preserveUnknownFields: false
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: ServerStatusRequest is a request to access current status information
@@ -27,12 +30,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -80,9 +85,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/assets/charts/components/velero/crds/volumesnapshotlocations.yaml
+++ b/assets/charts/components/velero/crds/volumesnapshotlocations.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: volumesnapshotlocations.velero.io
 spec:
   group: velero.io
@@ -27,12 +26,14 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -69,9 +70,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/assets/charts/components/velero/templates/cleanup-crd.yaml
+++ b/assets/charts/components/velero/templates/cleanup-crd.yaml
@@ -1,6 +1,6 @@
+{{- if and .Values.installCRDs .Values.cleanUpCRDs  }}
 # This job is meant primarily for cleaning up on CI systems.
 # Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
-{{- if and .Values.installCRDs .Values.cleanUpCRDs  }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/assets/charts/components/velero/templates/deployment.yaml
+++ b/assets/charts/components/velero/templates/deployment.yaml
@@ -36,6 +36,12 @@ spec:
       {{- end }}
     {{- end }}
     spec:
+    {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       restartPolicy: Always
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       {{- if .Values.priorityClassName }}
@@ -79,6 +85,9 @@ spec:
             {{- end }}
             {{- with .logFormat }}
             - --log-format={{ . }}
+            {{- end }}
+            {{- if .defaultVolumesToRestic }}
+            - --default-volumes-to-restic
             {{- end }}
           {{- end }}
           {{- with .Values.resources }}
@@ -124,8 +133,8 @@ spec:
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
           {{- range $key, $value := . }}
-            - name: {{ default "none" $key | quote }}
-              value: {{ default "none" $value | quote }}
+            - name: {{ default "none" $key }}
+              value: {{ default "none" $value }}
           {{- end }}
           {{- end }}
           {{- with .Values.credentials.extraEnvVars }}

--- a/assets/charts/components/velero/templates/restic-daemonset.yaml
+++ b/assets/charts/components/velero/templates/restic-daemonset.yaml
@@ -29,6 +29,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       securityContext:
         runAsUser: 0
@@ -87,12 +93,6 @@ spec:
             {{- toYaml .Values.restic.extraVolumeMounts | nindent 12 }}
             {{- end }}
           env:
-            {{- with .Values.configuration.extraEnvVars }}
-            {{- range $key, $value := . }}
-            - name: {{ default "none" $key | quote }}
-              value: {{ default "none" $value | quote }}
-            {{- end }}
-            {{- end }}
             - name: VELERO_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -120,8 +120,8 @@ spec:
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
           {{- range $key, $value := . }}
-            - name: {{ default "none" $key | quote }}
-              value: {{ default "none" $value | quote }}
+            - name: {{ default "none" $key }}
+              value: {{ default "none" $value }}
           {{- end }}
           {{- end }}
           {{- with .Values.credentials.extraEnvVars }}

--- a/assets/charts/components/velero/templates/schedule.yaml
+++ b/assets/charts/components/velero/templates/schedule.yaml
@@ -3,6 +3,9 @@ apiVersion: velero.io/v1
 kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/assets/charts/components/velero/templates/serviceaccount-server.yaml
+++ b/assets/charts/components/velero/templates/serviceaccount-server.yaml
@@ -4,7 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ include "velero.serverServiceAccount" . }}
 {{- if .Values.serviceAccount.server.annotations }}
-  annotations: {{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
+  annotations:
+{{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/assets/charts/components/velero/values.yaml
+++ b/assets/charts/components/velero/values.yaml
@@ -6,18 +6,21 @@
 # enabling restic). Required.
 image:
   repository: velero/velero
-  tag: v1.4.2
+  tag: v1.5.2
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38. If used, it will
   # take precedence over the image.tag.
   # digest:
   pullPolicy: IfNotPresent
+  # One or more secrets to be used when pulling images
+  imagePullSecrets: []
+  # - registrySecretName
 
 # Annotations to add to the Velero deployment's pod template. Optional.
 #
 # If using kube2iam or kiam, use the following annotation with your AWS_ACCOUNT_ID
 # and VELERO_ROLE_NAME filled in:
-#  iam.amazonaws.com/role: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<VELERO_ROLE_NAME>
 podAnnotations: {}
+  #  iam.amazonaws.com/role: "arn:aws:iam::<AWS_ACCOUNT_ID>:role/<VELERO_ROLE_NAME>"
 
 # Additional pod labels for Velero deployment's template. Optional
 # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -40,6 +43,9 @@ initContainers: []
 # see more informations at: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 securityContext: {}
   # fsGroup: 1337
+
+# Pod priority class name to use for the Velero deployment. Optional.
+priorityClassName: ""
 
 # Tolerations to use for the Velero deployment. Optional.
 tolerations: []
@@ -83,7 +89,7 @@ configuration:
   provider:
 
   # Parameters for the `default` BackupStorageLocation. See
-  # https://velero.io/docs/v1.4/api-types/backupstoragelocation/
+  # https://velero.io/docs/v1.5/api-types/backupstoragelocation/
   backupStorageLocation:
     # name is the name of the backup storage location where backups should be stored. If a name is not provided,
     # a backup storage location will be created with the name "default". Optional.
@@ -114,7 +120,7 @@ configuration:
     #  serviceAccount:
 
   # Parameters for the `default` VolumeSnapshotLocation. See
-  # https://velero.io/docs/v1.4/api-types/volumesnapshotlocation/
+  # https://velero.io/docs/v1.5/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
     # name is the name of the volume snapshot location where snapshots are being taken. Required.
     name:
@@ -157,6 +163,9 @@ configuration:
 
   # Set log-format for Velero pod. Default: text. Other option: json.
   logFormat:
+
+  # Set true for backup all pod volumes without having to apply annotation on the pod when used restic Default: false. Other option: false.
+  defaultVolumesToRestic:
 
 ##
 ## End of backup/snapshot location settings.
@@ -210,7 +219,7 @@ restic:
   podVolumePath: /var/lib/kubelet/pods
   privileged: false
   # Pod priority class name to use for the Restic daemonset. Optional.
-  priorityClassName: {}
+  priorityClassName: ""
   # Resource requests/limits to specify for the Restic daemonset deployment. Optional.
   resources: {}
   # Tolerations to use for the Restic daemonset. Optional.
@@ -232,13 +241,13 @@ restic:
 # Eg:
 # schedules:
 #   mybackup:
-#      labels:
-#        myenv: foo
+#     labels:
+#       myenv: foo
 #     schedule: "0 0 * * *"
 #     template:
 #       ttl: "240h"
 #       includedNamespaces:
-#        - foo
+#       - foo
 schedules: {}
 
 # Velero ConfigMaps.

--- a/pkg/components/velero/openebs/template.go
+++ b/pkg/components/velero/openebs/template.go
@@ -57,7 +57,7 @@ credentials:
 {{ .CredentialsIndented }}
   {{- end }}
 initContainers:
-- image: openebs/velero-plugin:2.0.0
+- image: openebs/velero-plugin:2.2.0
   imagePullPolicy: IfNotPresent
   name: velero-plugin-for-openebs
   resources: {}


### PR DESCRIPTION
Release notes: Since this PR also updates the CRD, they need to be manually updated first.

Step before installing the new component:
```
kubectl apply -f https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero/crds
```