### PR TITLE
Enable e2e tests for Prometheus Operator on Packet FLUO pipeline

### DIFF
--- a/ci/packet_fluo/packet_fluo-cluster.lokocfg.envsubst
+++ b/ci/packet_fluo/packet_fluo-cluster.lokocfg.envsubst
@@ -96,7 +96,12 @@ component "rook-ceph" {
   }
 }
 
-
-component "prometheus-operator" {}
+component "prometheus-operator" {
+  grafana {
+    secret_env = {
+      "LOKOMOTIVE_VERY_SECRET_PASSWORD" = "VERY_VERY_SECRET"
+    }
+  }
+}
 
 component "flatcar-linux-update-operator" {}

--- a/test/components/prometheus-operator/prometheus_operator_test.go
+++ b/test/components/prometheus-operator/prometheus_operator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build aws aws_edge packet aks
+// +build aws aws_edge packet aks packet_fluo
 // +build e2e
 
 package prometheusoperator


### PR DESCRIPTION
It should've been added in #1084.

Closes #397

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>