### PR TITLE
test/ingress/packet_test: retry when ingress has no status set yet

### DIFF
--- a/test/ingress/packet_test/match_host_test.go
+++ b/test/ingress/packet_test/match_host_test.go
@@ -65,7 +65,7 @@ func TestIngressHost(t *testing.T) {
 			}
 
 			if err := wait.PollImmediate(
-				testutil.RetryInterval, testutil.Timeout, checkIngressHost(client, tc),
+				testutil.RetryInterval, testutil.Timeout, checkIngressHost(t, client, tc),
 			); err != nil {
 				t.Fatalf("%v", err)
 			}
@@ -73,7 +73,7 @@ func TestIngressHost(t *testing.T) {
 	}
 }
 
-func checkIngressHost(client kubernetes.Interface, tc componentTestCase) wait.ConditionFunc {
+func checkIngressHost(t *testing.T, client kubernetes.Interface, tc componentTestCase) wait.ConditionFunc {
 	return func() (done bool, err error) {
 		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout*time.Second)
 		defer cancel()
@@ -84,7 +84,9 @@ func checkIngressHost(client kubernetes.Interface, tc componentTestCase) wait.Co
 		}
 
 		if len(ing.Status.LoadBalancer.Ingress) == 0 {
-			return false, fmt.Errorf("got empty Status.LoadBalancer.Ingress")
+			t.Log("Status.LoadBalancer.Ingress is not populated yet")
+
+			return false, nil
 		}
 
 		if len(ing.Spec.Rules) == 0 {


### PR DESCRIPTION
As Ingress object will be created first, then Ingress controller will set
it's status, there might be a window where we can receive Ingress object
without all values set which we require.

Instead of failing the test, we should simply retry in this case, as
status should be eventually set.

Also pass testing.T to checkIngressHost() so we can use t.Log there.

Closes #1157

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>