### PR TITLE
contour: apply node affinity and tolerations also to certgen job

### DIFF
--- a/assets/charts/components/contour/templates/02-job-certgen.yaml
+++ b/assets/charts/components/contour/templates/02-job-certgen.yaml
@@ -45,6 +45,24 @@ spec:
       labels:
         app: "contour-certgen"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: contour
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+
+        {{- with .Values.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: contour
         # This version is set to latest because Job specs are immutable;


### PR DESCRIPTION
They are already applied for both contour and envoy, so they should also
be applied for job.

Closes #926

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>