### PR TITLE
Print bootkube journal if it fails

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
@@ -102,7 +102,7 @@ resource "null_resource" "bootkube-start" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/assets /opt/bootkube",
-      "sudo systemctl start bootkube",
+      "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }
 }

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -141,7 +141,7 @@ resource "null_resource" "bootkube-start" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/assets /opt/bootkube",
-      "sudo systemctl start bootkube",
+      "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }
 }

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
@@ -103,7 +103,7 @@ resource "null_resource" "bootkube-start" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/assets /opt/bootkube",
-      "sudo systemctl start bootkube",
+      "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }
 }


### PR DESCRIPTION
In previous attempt in e852117992a4a5ae13104a57ebb07dac71f9ed0f, I
missed the fact that Terraform remote-exec only prints stderr to the
user and stdout is ignored. This means, if we redirect journalctl output
to stderr, then it should be printed which will improve debugging
experience.

Refs #440

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>