### PR TITLE
pkg/components/cluster-autoscaler: fix duplicate device error

### DIFF
--- a/pkg/components/cluster-autoscaler/component.go
+++ b/pkg/components/cluster-autoscaler/component.go
@@ -169,14 +169,15 @@ func getClusterWorkers(clusterName, facility string, devices []packngo.Device) [
 func findDuplicatedDevices(devices []packngo.Device) []packngo.Device {
 	duplicatedDevices := []packngo.Device{}
 
-	deviceMap := map[string]struct{}{}
+	deviceMap := map[string]string{}
 
 	for _, d := range devices {
-		if _, ok := deviceMap[d.Hostname]; ok {
+		id, ok := deviceMap[d.Hostname]
+		if ok && d.ID != id {
 			duplicatedDevices = append(duplicatedDevices, d)
 		}
 
-		deviceMap[d.Hostname] = struct{}{}
+		deviceMap[d.Hostname] = d.ID
 	}
 
 	return duplicatedDevices


### PR DESCRIPTION
Packet API seems to have a bug, that when you use Project API key
for querying devices, it returns duplicated entries. However IDs
of the devices should be the same, so it should be safe to relax
the check on those, as if there would actually be 2 different devices
with the same name, they should have different IDs.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>