### PR TITLE
packet: ensure Calico CDRs gets created before use

### DIFF
--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/calico-host-protection.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/calico-host-protection.tf
@@ -1,3 +1,20 @@
+// TODO: Currently, bootkube installs all charts in parallel, which causes
+// calico-host-protection chart installation to fail ocasionally, as it
+// gets installed before the Calico chart itself.
+//
+// To workaround this issue, we make an extra copy of the Calico CRDs into
+// the bootkube manifests directory, as those will be applied
+// before all Helm charts. This ensures that the CRDs are created before
+// the calico-host-protection chart is installed.
+//
+// See https://github.com/kinvolk/lokomotive/issues/1175 for more details.
+resource "local_file" "calico_crds" {
+  for_each = fileset("${var.asset_dir}/charts/kube-system/calico/crds", "*.yaml")
+
+  content  = file("${var.asset_dir}/charts/kube-system/calico/crds/${each.value}")
+  filename = "${var.asset_dir}/manifests-calico-cdrs/${each.value}"
+}
+
 resource "local_file" "calico_host_protection" {
   content = templatefile("${path.module}/calico-host-protection.yaml.tmpl", {
     host_endpoints = [

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
@@ -70,6 +70,7 @@ resource "null_resource" "copy-assets-dir" {
     module.bootkube,
     null_resource.copy-controller-secrets,
     local_file.calico_host_protection,
+    local_file.calico_crds,
   ]
 
   connection {
@@ -102,7 +103,10 @@ resource "null_resource" "bootkube-start" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/assets /opt/bootkube",
+      "sudo mv $HOME/assets /opt/bootkube/",
+      # This is needed, as the bootkube-start script will move all files matching
+      # /opt/bootkube/asssets/manifests-*/*.yaml into /opt/bootkube/assets/manifests.
+      "sudo mkdir /opt/bootkube/assets/manifests",
       "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }


### PR DESCRIPTION
Currently, bootkube installs all charts in parallel, which causes
calico-host-protection chart installation to fail ocasionally, as it
gets installed before Calico chart itself.

This commit adds a workaround for this, by making an extra copy of
Calico CRDs into bootkube manifests directory, as those will be applied
before Helm charts. This ensures, that the CRDs are created before
calico-host-protection is installed, however it is rather hacky and
should not be considered as final solution for the issue, but a
temporary workaround to ensure cluster bootstrapping remains reliable.

More details in issue #1175.

Closes #1175

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>