### PR TITLE
calico-host-protection: allow running controller on controller nodes

### DIFF
--- a/assets/charts/control-plane/calico-host-protection/templates/host-endpoint-controller.yaml
+++ b/assets/charts/control-plane/calico-host-protection/templates/host-endpoint-controller.yaml
@@ -26,6 +26,10 @@ spec:
         app: calico-hostendpoint-controller
     spec:
       serviceAccountName: calico-hostendpoint-controller
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       containers:
       - image: quay.io/kinvolk/calico-hostendpoint-controller:v0.0.4
         name: calico-hostendpoint-controller


### PR DESCRIPTION
As calico-host-protection is now being installed using bootkube, it
requires bootkube to wait for worker nodes to join the cluster to finish
running, which extends running time of bootkube unnecesserily.

I believe all workloads installed using bootkube should be schedulable
on a controller nodes, so make it more robust

Closes #1179

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>