### PR TITLE
Implement automatic certificate rotation

### DIFF
--- a/assets/charts/control-plane/kube-apiserver/templates/kube-apiserver-ds.yaml
+++ b/assets/charts/control-plane/kube-apiserver/templates/kube-apiserver-ds.yaml
@@ -24,6 +24,8 @@ spec:
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        # Automatically rolls update when secret changes.
+        checksum/secret: {{ include (print $.Template.BasePath "/kube-apiserver-secret.yaml") . | sha256sum }}
     spec:
 {{- template "containers" . }}
 {{- end }}

--- a/assets/charts/control-plane/kube-apiserver/templates/kube-apiserver.yaml
+++ b/assets/charts/control-plane/kube-apiserver/templates/kube-apiserver.yaml
@@ -25,6 +25,8 @@ spec:
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        # Automatically rolls update when secret changes.
+        checksum/secret: {{ include (print $.Template.BasePath "/kube-apiserver-secret.yaml") . | sha256sum }}
     spec:
 {{- template "containers" . }}
 {{- end }}

--- a/assets/charts/control-plane/kubelet/templates/kubelet-ds.yaml
+++ b/assets/charts/control-plane/kubelet/templates/kubelet-ds.yaml
@@ -17,7 +17,23 @@ spec:
         tier: node
         k8s-app: kubelet
     spec:
-      automountServiceAccountToken: false
+      initContainers:
+      - name: ca-syncer
+        image: {{ .Values.image }}
+        command:
+        - bash
+        - -c
+        - |
+          sed -i "s/^    certificate-authority-data:.*$/    certificate-authority-data: {{ .Values.kubernetesCACert }}/g" /var/lib/kubelet/kubeconfig /etc/kubernetes/kubeconfig
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+          readOnly: false
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+          readOnly: false
       containers:
       - name: kubelet
         image: {{ .Values.image }}

--- a/assets/charts/control-plane/kubelet/values.yaml
+++ b/assets/charts/control-plane/kubelet/values.yaml
@@ -3,3 +3,4 @@ clusterDNS: 10.0.0.10
 clusterDomain: cluster.local
 enableTLSBootstrap: true
 cloudProvider:
+kubernetesCACert: ""

--- a/assets/charts/control-plane/kubernetes/templates/_helpers.tpl
+++ b/assets/charts/control-plane/kubernetes/templates/_helpers.tpl
@@ -55,6 +55,7 @@
         - --pod-eviction-timeout=1m
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+        - --cluster-signing-duration=45m
         livenessProbe:
           httpGet:
             scheme: HTTPS

--- a/assets/charts/control-plane/kubernetes/templates/kube-controller-manager-ds.yaml
+++ b/assets/charts/control-plane/kubernetes/templates/kube-controller-manager-ds.yaml
@@ -23,6 +23,8 @@ spec:
         k8s-app: kube-controller-manager
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        # Automatically rolls update when secret changes.
+        checksum/secret: {{ include (print $.Template.BasePath "/kube-controller-manager-secret.yaml") . | sha256sum }}
     spec:
 {{- template "controller-manager-containers" . }}
 {{- end }}

--- a/assets/charts/control-plane/kubernetes/templates/kube-controller-manager.yaml
+++ b/assets/charts/control-plane/kubernetes/templates/kube-controller-manager.yaml
@@ -24,6 +24,8 @@ spec:
         k8s-app: kube-controller-manager
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        # Automatically rolls update when secret changes.
+        checksum/secret: {{ include (print $.Template.BasePath "/kube-controller-manager-secret.yaml") . | sha256sum }}
     spec:
 {{- template "controller-manager-containers" . }}
 {{- end }}

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
@@ -70,11 +70,15 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
       "sudo chown -R etcd:etcd /etc/ssl/etcd",
       "sudo chmod -R 500 /etc/ssl/etcd",
+      "sudo systemctl restart etcd",
     ]
   }
 
   triggers = {
-    controller_id = aws_instance.controllers[count.index].id
+    controller_id    = aws_instance.controllers[count.index].id
+    etcd_ca_cert     = module.bootkube.etcd_ca_cert
+    etcd_server_cert = module.bootkube.etcd_server_cert
+    etcd_peer_cert   = module.bootkube.etcd_peer_cert
   }
 }
 

--- a/assets/terraform-modules/bootkube/assets.tf
+++ b/assets/terraform-modules/bootkube/assets.tf
@@ -109,6 +109,7 @@ locals {
     cluster_domain_suffix  = var.cluster_domain_suffix
     enable_tls_bootstrap   = var.enable_tls_bootstrap
     cloud_provider         = var.cloud_provider
+    kubernetes_ca_cert     = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
   })
 
   kubeconfig_kubelet_content = templatefile("${path.module}/resources/kubeconfig-kubelet", {

--- a/assets/terraform-modules/bootkube/resources/charts/kubelet.yaml
+++ b/assets/terraform-modules/bootkube/resources/charts/kubelet.yaml
@@ -3,3 +3,4 @@ clusterDNS: ${cluster_dns_service_ip}
 clusterDomain: ${cluster_domain_suffix}
 enableTLSBootstrap: ${enable_tls_bootstrap}
 cloudProvider: ${cloud_provider}
+kubernetesCACert: ${kubernetes_ca_cert}

--- a/cli/cmd/cluster/certificate-rotator.go
+++ b/cli/cmd/cluster/certificate-rotator.go
@@ -1,0 +1,158 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
+	"github.com/kinvolk/lokomotive/pkg/platform"
+)
+
+type certificateRotatorConfig struct {
+	clientSet            *kubernetes.Clientset
+	newCACert            string
+	logger               *log.Entry
+	daemonSetsToRestart  []platform.Workload
+	deploymentsToRestart []platform.Workload
+}
+
+type certificateRotator struct {
+	config certificateRotatorConfig
+}
+
+const (
+	// Time to wait between updating DaemonSet/Deployment and start looking if
+	// workload has converged. This should account for kube-controller-manager election time,
+	// reconciliation period and time spent in reconciliation loop (based on number of workloads
+	// in the cluster). 10 seconds might not be enough.
+	kubeControllerManagerReconciliationPeriod = 10 * time.Second
+)
+
+func newCertificateRotator(config certificateRotatorConfig) (*certificateRotator, error) {
+	if config.clientSet == nil {
+		return nil, fmt.Errorf("clientSet can't be nil")
+	}
+
+	if config.newCACert == "" {
+		return nil, fmt.Errorf("new CA certificate can't be empty")
+	}
+
+	return &certificateRotator{
+		config: config,
+	}, nil
+}
+
+func (cr *certificateRotator) restartDaemonSetAndWaitToConverge(ns, name string) error {
+	dsc := cr.config.clientSet.AppsV1().DaemonSets(ns)
+
+	generation, err := k8sutil.RolloutRestartDaemonSet(dsc, name)
+	if err != nil {
+		return fmt.Errorf("restarting: %w", err)
+	}
+
+	// TODO: make sure this is the right value.
+	time.Sleep(kubeControllerManagerReconciliationPeriod)
+
+	options := k8sutil.WaitOptions{
+		Generation: generation,
+	}
+
+	if err := k8sutil.WaitForDaemonSet(dsc, name, options); err != nil {
+		return fmt.Errorf("waiting for DaemonSet to converge: %w", err)
+	}
+
+	return nil
+}
+
+func (cr *certificateRotator) restartDeploymentAndWaitToConverge(ns, name string) error {
+	deployClient := cr.config.clientSet.AppsV1().Deployments(ns)
+
+	generation, err := k8sutil.RolloutRestartDeployment(deployClient, name)
+	if err != nil {
+		return fmt.Errorf("restarting: %w", err)
+	}
+
+	// TODO: make sure this is the right value.
+	time.Sleep(kubeControllerManagerReconciliationPeriod)
+
+	options := k8sutil.WaitOptions{
+		Generation: generation,
+	}
+
+	if err := k8sutil.WaitForDeployment(deployClient, name, options); err != nil {
+		return fmt.Errorf("waiting for Deployment to converge: %w", err)
+	}
+
+	return nil
+}
+
+func (cr *certificateRotator) rotate() error {
+	cr.config.logger.Printf("Waiting for all service account tokens on the cluster to be updated...")
+
+	if err := cr.waitForUpdatedServiceAccountTokens(); err != nil {
+		return fmt.Errorf("waiting for all service account tokens to be updated: %w", err)
+	}
+
+	cr.config.logger.Printf("All service account tokens has been updated with new Kubernetes CA certificate")
+
+	for _, daemonSet := range cr.config.daemonSetsToRestart {
+		cr.config.logger.Printf("Restarting DaemonSet %s/%s to pick up new Kubernetes CA Certificate",
+			daemonSet.Namespace, daemonSet.Name)
+
+		if err := cr.restartDaemonSetAndWaitToConverge(daemonSet.Namespace, daemonSet.Name); err != nil {
+			return fmt.Errorf("restarting DaemonSet %s/%s: %w", daemonSet.Namespace, daemonSet.Name, err)
+		}
+	}
+
+	for _, deployment := range cr.config.deploymentsToRestart {
+		cr.config.logger.Printf("Restarting Deployment %s/%s to pick up new Kubernetes CA Certificate",
+			deployment.Namespace, deployment.Name)
+
+		if err := cr.restartDeploymentAndWaitToConverge(deployment.Namespace, deployment.Name); err != nil {
+			return fmt.Errorf("restarting Deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (cr *certificateRotator) waitForUpdatedServiceAccountTokens() error {
+	for {
+		allUpToDate, err := cr.allServiceAccountTokensIncludeNewCA()
+		if err != nil {
+			return fmt.Errorf("checking if all service account tokens include new CA certificate: %w", err)
+		}
+
+		if allUpToDate {
+			cr.config.logger.Printf("all service account tokens are up to date and have new CA certificate")
+
+			break
+		}
+	}
+
+	return nil
+}
+
+func (cr *certificateRotator) allServiceAccountTokensIncludeNewCA() (bool, error) {
+	secrets, err := cr.config.clientSet.CoreV1().Secrets("").List(context.TODO(), metav1.ListOptions{
+		FieldSelector: "type=kubernetes.io/service-account-token",
+	})
+	if err != nil {
+		return false, fmt.Errorf("getting secrets: %v", err)
+	}
+
+	allUpToDate := true
+
+	for _, v := range secrets.Items {
+		if string(v.Data["ca.crt"]) != cr.config.newCACert {
+			allUpToDate = false
+		}
+	}
+
+	return allUpToDate, nil
+}

--- a/examples/aws-testing/cluster.lokocfg
+++ b/examples/aws-testing/cluster.lokocfg
@@ -30,6 +30,8 @@ cluster "aws" {
   dns_zone_id      = var.route53_zone_id
   ssh_pubkeys      = var.ssh_public_keys
 
+  certs_validity_period_hours = 1
+
   //os_channel       = "stable"
   //os_version       = "current"
 

--- a/pkg/k8sutil/rollout.go
+++ b/pkg/k8sutil/rollout.go
@@ -1,0 +1,223 @@
+package k8sutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+)
+
+// RolloutRestartDaemonSet is the programmatic equivalent of 'kubectl rollout restart'.
+func RolloutRestartDaemonSet(dsi clientappsv1.DaemonSetInterface, name string) (int64, error) {
+	ds, err := dsi.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("getting DaemonSet: %w", err)
+	}
+
+	if ds.Spec.Template.Annotations == nil {
+		ds.Spec.Template.Annotations = map[string]string{}
+	}
+
+	ds.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().String()
+
+	newDS, err := dsi.Update(context.TODO(), ds, metav1.UpdateOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("updating DaemonSet: %w", err)
+	}
+
+	return newDS.Generation, nil
+}
+
+// RolloutRestartDeployment is the programmatic equivalent of 'kubectl rollout restart'.
+func RolloutRestartDeployment(deployClient clientappsv1.DeploymentInterface, name string) (int64, error) {
+	d, err := deployClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("getting Deployment: %w", err)
+	}
+
+	if d.Spec.Template.Annotations == nil {
+		d.Spec.Template.Annotations = map[string]string{}
+	}
+
+	d.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().String()
+
+	newDeploy, err := deployClient.Update(context.TODO(), d, metav1.UpdateOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("updating Deployment: %w", err)
+	}
+
+	return newDeploy.Generation, nil
+}
+
+// daemonSetUpToDate checks if given DaemonSet converged.
+func daemonSetUpToDate(ds *appsv1.DaemonSet, generation int64) (bool, error) {
+	if ds.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {
+		return true, fmt.Errorf("rollout status is only available for %s strategy type",
+			appsv1.RollingUpdateStatefulSetStrategyType)
+	}
+
+	if generation > 0 && ds.Status.ObservedGeneration < generation {
+		return false, nil
+	}
+
+	replicas := ds.Status.DesiredNumberScheduled
+
+	if replicas == 0 {
+		return false, nil
+	}
+
+	if ds.Status.NumberReady == replicas && ds.Status.UpdatedNumberScheduled == replicas {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// WaitOptions holds optional arguments for WaitFor... functions group.
+type WaitOptions struct {
+	Generation int64
+	Timeout    time.Duration
+}
+
+const (
+	// WaitDefaultTimeout is default timeout after which watching for workload should return error.
+	WaitDefaultTimeout = 5 * time.Minute
+)
+
+// WaitForDaemonSet waits until DaemonSet converges.
+//
+//nolint:dupl
+func WaitForDaemonSet(dsi clientappsv1.DaemonSetInterface, name string, options WaitOptions) error {
+	if dsi == nil {
+		return fmt.Errorf("client must be set")
+	}
+
+	if name == "" {
+		return fmt.Errorf("name must be set")
+	}
+
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+
+			return dsi.List(context.TODO(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+
+			return dsi.Watch(context.TODO(), options)
+		},
+	}
+
+	watchF := func(e watch.Event) (bool, error) {
+		switch t := e.Type; t { //nolint:exhaustive
+		case watch.Added, watch.Modified:
+			return daemonSetUpToDate(e.Object.(*appsv1.DaemonSet), options.Generation)
+		case watch.Deleted:
+			// We need to abort to avoid cases of recreation and not to silently watch the wrong (new) object
+			return true, fmt.Errorf("object has been deleted")
+
+		default:
+			return true, fmt.Errorf("internal error: unexpected event %#v", e)
+		}
+	}
+
+	// if the rollout isn't done yet, keep watching deployment status
+	_, err := watchtools.UntilWithSync(context.TODO(), lw, &appsv1.DaemonSet{}, nil, watchF)
+	if err != nil {
+		return fmt.Errorf("waiting for DaemonSet to restart: %w", err)
+	}
+
+	return nil
+}
+
+// deploymentUpToDate checks if given deployed has converged.
+func deploymentUpToDate(deploy *appsv1.Deployment, generation int64) (bool, error) {
+	// Update has not been observed yet.
+	if deploy.Status.ObservedGeneration < generation {
+		return false, nil
+	}
+
+	var cond *appsv1.DeploymentCondition
+
+	for i := range deploy.Status.Conditions {
+		c := deploy.Status.Conditions[i]
+		if c.Type == appsv1.DeploymentProgressing {
+			cond = &c
+		}
+	}
+
+	if cond != nil && cond.Reason == "ProgressDeadlineExceeded" {
+		return false, fmt.Errorf("deployment %q exceeded its progress deadline", deploy.Name)
+	}
+
+	if deploy.Spec.Replicas != nil && deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas {
+		return false, nil
+	}
+
+	if deploy.Status.Replicas > deploy.Status.UpdatedReplicas {
+		return false, nil
+	}
+
+	if deploy.Status.AvailableReplicas < deploy.Status.UpdatedReplicas {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// WaitForDeployment waits for Deployment to converge.
+//
+//nolint:dupl
+func WaitForDeployment(deployClient clientappsv1.DeploymentInterface, name string, options WaitOptions) error {
+	if deployClient == nil {
+		return fmt.Errorf("client must be set")
+	}
+
+	if name == "" {
+		return fmt.Errorf("name must be set")
+	}
+
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+
+			return deployClient.List(context.TODO(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+
+			return deployClient.Watch(context.TODO(), options)
+		},
+	}
+
+	watchF := func(e watch.Event) (bool, error) {
+		switch t := e.Type; t { //nolint:exhaustive
+		case watch.Added, watch.Modified:
+			return deploymentUpToDate(e.Object.(*appsv1.Deployment), options.Generation)
+		case watch.Deleted:
+			// We need to abort to avoid cases of recreation and not to silently watch the wrong (new) object
+			return true, fmt.Errorf("object has been deleted")
+
+		default:
+			return true, fmt.Errorf("internal error: unexpected event %#v", e)
+		}
+	}
+
+	_, err := watchtools.UntilWithSync(context.TODO(), lw, &appsv1.Deployment{}, nil, watchF)
+	if err != nil {
+		return fmt.Errorf("waiting for Deployment to restart: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -130,6 +130,10 @@ func (c *config) Meta() platform.Meta {
 		AssetDir:           c.AssetDir,
 		ExpectedNodes:      nodes,
 		ControlplaneCharts: platform.CommonControlPlaneCharts(!c.DisableSelfHostedKubelet),
+		Name:               "aws",
+		ClusterName:        c.ClusterName,
+		Deployments:        platform.CommonDeployments(c.ControllerCount),
+		DaemonSets:         platform.CommonDaemonSets(c.ControllerCount, !c.DisableSelfHostedKubelet),
 	}
 }
 

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -83,6 +83,8 @@ func (c *config) Meta() platform.Meta {
 		AssetDir:           c.AssetDir,
 		ExpectedNodes:      len(c.ControllerMacs) + len(c.WorkerMacs),
 		ControlplaneCharts: platform.CommonControlPlaneCharts(!c.DisableSelfHostedKubelet),
+		Deployments:        platform.CommonDeployments(len(c.ControllerMacs)),
+		DaemonSets:         platform.CommonDaemonSets(len(c.ControllerMacs), !c.DisableSelfHostedKubelet),
 	}
 }
 

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -158,6 +158,17 @@ func (c *config) Meta() platform.Meta {
 		AssetDir:           c.AssetDir,
 		ExpectedNodes:      nodes,
 		ControlplaneCharts: charts,
+		Deployments: append(platform.CommonDeployments(c.ControllerCount), []platform.Workload{
+			{
+				Name:      "calico-hostendpoint-controller",
+				Namespace: "kube-system",
+			},
+			{
+				Name:      "packet-cloud-controller-manager",
+				Namespace: "kube-system",
+			},
+		}...),
+		DaemonSets: platform.CommonDaemonSets(c.ControllerCount, !c.DisableSelfHostedKubelet),
 	}
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -110,12 +110,113 @@ type WorkerPool interface {
 	Name() string
 }
 
+// Workload is a generic struct which can be used to construct a reference to
+// Deployment, DaemonSet, StatefulSet etc. objects.
+type Workload struct {
+	Name      string
+	Namespace string
+}
+
+// CommonDeployments returns common Deployments for all Lokomotive platforms.
+//
+// Number of Deployments depends on number of controller nodes in the cluster.
+func CommonDeployments(controllersCount int) []Workload {
+	base := []Workload{
+		{
+			Name:      "calico-kube-controllers",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "admission-webhook-server",
+			Namespace: "lokomotive-system",
+		},
+	}
+
+	if controllersCount > 1 {
+		return base
+	}
+
+	return append(base, []Workload{
+		{
+			Name:      "kube-apiserver",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "coredns",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "kube-controller-manager",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "kube-scheduler",
+			Namespace: "kube-system",
+		},
+	}...)
+}
+
+// CommonDaemonSets returns common DaemonSets for all Lokomotive platforms.
+//
+// Number of DaemonSets depends on number of controller nodes in the cluster and if self-hosted
+// kubelet is enabled.
+func CommonDaemonSets(controllersCount int, selfHostedKubeletEnabled bool) []Workload {
+	base := []Workload{
+		{
+			Name:      "calico-node",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "pod-checkpointer",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "kube-proxy",
+			Namespace: "kube-system",
+		},
+	}
+
+	if selfHostedKubeletEnabled {
+		base = append(base, Workload{
+			Name:      "kubelet",
+			Namespace: "kube-system",
+		})
+	}
+
+	if controllersCount == 1 {
+		return base
+	}
+
+	return append(base, []Workload{
+		{
+			Name:      "kube-apiserver",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "coredns",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "kube-controller-manager",
+			Namespace: "kube-system",
+		},
+		{
+			Name:      "kube-scheduler",
+			Namespace: "kube-system",
+		},
+	}...)
+}
+
 // Meta is a generic information format about the platform.
 type Meta struct {
 	AssetDir           string
 	ExpectedNodes      int
 	Managed            bool
 	ControlplaneCharts []helm.LokomotiveChart
+	Name               string
+	ClusterName        string
+	DaemonSets         []Workload
+	Deployments        []Workload
 }
 
 // AppendVersionTag appends the lokoctl-version tag to a given tags map.

--- a/pkg/platform/tinkerbell/tinkerbell.go
+++ b/pkg/platform/tinkerbell/tinkerbell.go
@@ -137,6 +137,8 @@ func (c *Config) Meta() platform.Meta {
 		AssetDir:           c.AssetDir,
 		ExpectedNodes:      nodes,
 		ControlplaneCharts: platform.CommonControlPlaneCharts(!c.DisableSelfHostedKubelet),
+		Deployments:        platform.CommonDeployments(len(c.ControllerIPAddresses)),
+		DaemonSets:         platform.CommonDaemonSets(len(c.ControllerIPAddresses), !c.DisableSelfHostedKubelet),
 	}
 }
 


### PR DESCRIPTION
Draft on top of #1193

Closes #1215 

TODO:
- [ ] Convert from running on every `cluster apply` to separate sub-command
- [ ] Perhaps don't run updates when rotating the certificates.
- [ ] Figure out how to tell user what's the expiration time of certificates.
- [ ] Add documentation for certificate rotation process, which should mention that ideally all nodes in the cluster should be drained and rebooted after rotation to ensure that all pods using CA certificate etc got restarted.
- [ ] Figure out automated restart of kube-proxy, Calico-node, CoreDNS and other core components.