### PR TITLE
bootstrap-secrets: always quote values

### DIFF
--- a/assets/charts/control-plane/bootstrap-secrets/templates/bootstrap-secret.yaml
+++ b/assets/charts/control-plane/bootstrap-secrets/templates/bootstrap-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: kube-system
 stringData:
   description: "Lokomotive generated bootstrap token"
-  token-id: {{ $token.tokenID }}
-  token-secret: {{ $token.tokenSecret }}
+  token-id: {{ $token.tokenID | quote }}
+  token-secret: {{ $token.tokenSecret | quote }}
   usage-bootstrap-authentication: "true"
 {{- end }}


### PR DESCRIPTION
They should always be strings. If Terraform generates them to be
numbers-only, Helm will fail installing it.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>
