### PR TITLE
Compile all tests code as part of build process and before linter runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run lint
-        run: make lint-bin
+        run: make lint
 
   codespell:
     name: Codespell

--- a/Makefile
+++ b/Makefile
@@ -197,4 +197,4 @@ check-docs: check-working-tree-clean docs
 	@test -z "$$(git status --porcelain)" || (echo "Please run make docs and commit the changes."; git status; exit 1)
 
 .PHONY: ci
-ci: build test check-update-assets check-vendor check-docs
+ci: build build-test test check-update-assets check-vendor check-docs


### PR DESCRIPTION
To make build step fail if tests code cannot be compiled and to make clear error before linter runs if code does not compile.