### PR TITLE
Add docker log options and enable live restore

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -261,6 +261,14 @@ storage:
           kind: KubeletConfiguration
           cgroupDriver: "$${docker_cgroup_driver}"
           EOF
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          {
+            "live-restore": true
+          }
 passwd:
   users:
     - name: core

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -267,7 +267,11 @@ storage:
       contents:
         inline: |
           {
-            "live-restore": true
+            "live-restore": true,
+            "log-opts": {
+              "max-size": "100m",
+              "max-file": "3"
+            }
           }
 passwd:
   users:

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -156,6 +156,14 @@ storage:
             %{~ else ~}
             --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)
             %{ endif }
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          {
+            "live-restore": true
+          }
 passwd:
   users:
     - name: core

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -162,7 +162,11 @@ storage:
       contents:
         inline: |
           {
-            "live-restore": true
+            "live-restore": true,
+            "log-opts": {
+              "max-size": "100m",
+              "max-file": "3"
+            }
           }
 passwd:
   users:

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -229,7 +229,11 @@ storage:
       contents:
         inline: |
           {
-            "live-restore": true
+            "live-restore": true,
+            "log-opts": {
+              "max-size": "100m",
+              "max-file": "3"
+            }
           }
 passwd:
   users:

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -223,6 +223,14 @@ storage:
       contents:
         inline: |
           d    /var/lib/etcd 0700 etcd etcd - -
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          {
+            "live-restore": true
+          }
 passwd:
   users:
     - name: core

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -139,7 +139,11 @@ storage:
       contents:
         inline: |
           {
-            "live-restore": true
+            "live-restore": true,
+            "log-opts": {
+              "max-size": "100m",
+              "max-file": "3"
+            }
           }
 passwd:
   users:

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -133,6 +133,14 @@ storage:
           kind: KubeletConfiguration
           cgroupDriver: "$${docker_cgroup_driver}"
           EOF
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          {
+            "live-restore": true
+          }
 passwd:
   users:
     - name: core

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -406,6 +406,14 @@ storage:
           done
           echo "$record.$zone is available on all nameservers"
           exit 0
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          {
+            "live-restore": true
+          }
 passwd:
   users:
   - name: core

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -412,7 +412,11 @@ storage:
       contents:
         inline: |
           {
-            "live-restore": true
+            "live-restore": true,
+            "log-opts": {
+              "max-size": "100m",
+              "max-file": "3"
+            }
           }
 passwd:
   users:

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -413,6 +413,14 @@ storage:
           done
           echo "$record.$zone is available on all nameservers"
           exit 0
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          {
+            "live-restore": true
+          }
 passwd:
   users:
   - name: core

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -419,7 +419,11 @@ storage:
       contents:
         inline: |
           {
-            "live-restore": true
+            "live-restore": true,
+            "log-opts": {
+              "max-size": "100m",
+              "max-file": "3"
+            }
           }
 passwd:
   users:

--- a/docs/concepts/logging.md
+++ b/docs/concepts/logging.md
@@ -1,0 +1,12 @@
+---
+title: Logging
+weight: 10
+---
+
+## Logging
+
+Lokomotive restricts the logs per Docker container (not Kubernetes pod) to be 300MB divided into
+three files (100MB per file). This should allow running around fifty log intensive containers on a
+20GB disk. Due to this limitation, any log intensive app will have only last 300MB of logs. Anything
+beyond that will be purged by Docker. To preserve logs of such applications for long term access use
+a log shipping solution.

--- a/test/system/docker_live_restore_test.go
+++ b/test/system/docker_live_restore_test.go
@@ -1,0 +1,171 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build aws aws_edge baremetal packet
+// +build e2e
+
+package system_test
+
+import (
+	"context"
+	"testing"
+
+	testutil "github.com/kinvolk/lokomotive/test/components/util"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// Define manifests as YAML and then unmarshal it to a Go struct so that it is easier to write and
+// debug, as it can be copy-pasted to a file and applied manually.
+const dockerLiveRestoreOnNodesDSManifest = `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generateName: test-live-restore-
+spec:
+  selector:
+    matchLabels:
+      name: test-live-restore
+  template:
+    metadata:
+      labels:
+        name: test-live-restore
+    spec:
+      tolerations:
+      - key: ""
+        operator: Exists
+      terminationGracePeriodSeconds: 1
+      initContainers:
+      - name: test-live-restore
+        image: quay.io/kinvolk/docker:stable
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - 'docker info -f {{.LiveRestoreEnabled}} | grep true'
+        volumeMounts:
+        - name: docker-socket
+          mountPath: /var/run/docker.sock
+
+      containers:
+      - name: wait
+        image: quay.io/kinvolk/docker:stable
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - sleep infinity
+      volumes:
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
+`
+
+const dockerLogOptsOnNodesDSManifest = `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generateName: test-log-opts-
+spec:
+  selector:
+    matchLabels:
+      name: test-log-opts
+  template:
+    metadata:
+      labels:
+        name: test-log-opts
+    spec:
+      tolerations:
+      - key: ""
+        operator: Exists
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: wait
+        image: quay.io/kinvolk/jq:1.6
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - sleep infinity
+
+      initContainers:
+      - name: test-log-opts-1
+        image: quay.io/kinvolk/jq:1.6
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - jq '."log-opts"."max-size"' /etc/docker/daemon.json | grep 100m
+        volumeMounts:
+        - name: docker-config
+          mountPath: /etc/docker/daemon.json
+      - name: test-log-opts-2
+        image: quay.io/kinvolk/jq:1.6
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - jq '."log-opts"."max-file"' /etc/docker/daemon.json | grep 3
+        volumeMounts:
+        - name: docker-config
+          mountPath: /etc/docker/daemon.json
+      volumes:
+      - name: docker-config
+        hostPath:
+          path: /etc/docker/daemon.json
+`
+
+func TestDockerNodeConfig(t *testing.T) {
+	tcs := []struct {
+		name   string
+		config string
+	}{
+		{"Is_Live_Restore_Enabled", dockerLiveRestoreOnNodesDSManifest},
+		{"Compare_Log_Options", dockerLogOptsOnNodesDSManifest},
+	}
+
+	namespace := "kube-system"
+	client := testutil.CreateKubeClient(t)
+	dsClient := client.AppsV1().DaemonSets(namespace)
+
+	for _, tc := range tcs {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ds := &appsv1.DaemonSet{}
+			if err := yaml.Unmarshal([]byte(tc.config), ds); err != nil {
+				t.Fatalf("Failed unmarshaling manifest: %v", err)
+			}
+
+			ds, err := dsClient.Create(context.TODO(), ds, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create DaemonSet: %v", err)
+			}
+
+			testutil.WaitForDaemonSet(t, client, namespace, ds.Name, testutil.RetryInterval, testutil.Timeout)
+
+			t.Cleanup(func() {
+				if err := dsClient.Delete(context.TODO(), ds.Name, metav1.DeleteOptions{}); err != nil {
+					t.Logf("Failed to delete DaemonSet: %v", err)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
# Add docker log options and enable live restore

Earlier if the docker daemon was restarted the containers would be restarted as well. This PR enables live restore where containers are not restarted.

This PR also adds log options where if the container log size is more than 100MB then docker daemon creates new log file and only three such log files are kept around.

Fixes #1220
Fixes #1221 

# How to use

- Install a cluster on Packet or AWS or Baremetal with this change. To test the change also install these components to perform tests `openebs-operator`, `openebs-storage-class`, `prometheus-operator`, `contour`, `metallb`, `httpbin`, `external-dns`.
- ssh into any machine of the cluster and look for file `/etc/docker/daemon.json`.

# Testing done

- Start a pod in the cluster to stress the application from:

```bash
kubectl run -it --rm debug-network-$RANDOM --image-pull-policy=Always --image=quay.io/surajd/fedora-networking --restart=Never bash
```

- Install `httperf`:

```
dnf -y install httperf
```

- Run the perf:

```
httperf --hog --server <httpbin endpoint> --uri "/" --num-conn 1200000 --num-call 2 --timeout 5 --rate 4000 --port 80
```

Run this multiple times to increase the log size.

- Simultaenously goto the node and find the envoy directoy:

```
cd /var/lib/docker/containers/$(docker inspect --format='{{.Id}}' $(docker ps | grep envoyproxy | awk '{print $1}'))
watch du -sh ./*
```

Keep an eye on the `*.log*` files. The size of each `*.log*` won't go beyond 100MB, and new files will be created ending with `.log.1` and `.log.2`.

- Optional: Watch the envoy logs

```
kubectl logs -n projectcontour -f -l app=envoy
```