### PR TITLE
ssh_keys_test image fix

### DIFF
--- a/test/system/ssh_keys_test.go
+++ b/test/system/ssh_keys_test.go
@@ -78,12 +78,14 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: test-ssh-keys
-        image: ubuntu
-        command: ["bash"]
+        image: quay.io/bitnami/nginx
+        command: ["/bin/bash"]
         volumeMounts:
         - name: ssh
           mountPath: /home/core/.ssh
           readOnly: true
+        securityContext:
+          runAsUser: 0
       volumes:
       - name: ssh
         hostPath:


### PR DESCRIPTION
No ubuntu image exists on quay, so changed it to kinvolk nginx repo.
This is to avoid docker pull limit errors.

Signed-off-by: knrt10 <kautilya@kinvolk.io>

See build https://yard.lokomotive-k8s.net/builds/43831 for more information