### PR TITLE
contour: parameterise envoy scraping interval

### DIFF
--- a/assets/charts/components/contour/templates/service-monitor.yaml
+++ b/assets/charts/components/contour/templates/service-monitor.yaml
@@ -12,6 +12,9 @@ spec:
   endpoints:
   - port: envoy-metrics
     path: /stats/prometheus
+    {{- if .Values.envoy.metricsScrapeInterval }}
+    interval: {{ .Values.envoy.metricsScrapeInterval }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - projectcontour

--- a/assets/charts/components/contour/values.yaml
+++ b/assets/charts/components/contour/values.yaml
@@ -9,6 +9,7 @@ envoy:
   image: docker.io/envoyproxy/envoy
   tag: v1.16.0
   serviceType:
+  metricsScrapeInterval:
 
 nodeAffinity: {}
 # nodeAffinity:

--- a/docs/configuration-reference/components/contour.md
+++ b/docs/configuration-reference/components/contour.md
@@ -47,6 +47,10 @@ component "contour" {
     value    = "contour"
     effect   = "NoSchedule"
   }
+
+  envoy {
+    metrics_scrape_interval = "30s"
+  }
 }
 ```
 
@@ -60,6 +64,7 @@ Table of all the arguments accepted by the component.
 | `node_affinity`     | Node affinity for deploying the operator pod and envoy daemonset.                                       |       -        | list(object({key = string, operator = string, values = list(string)}))                                         |  false   |
 | `service_type`      | The type of Kubernetes service used to expose Envoy. Set as "NodePort" on the **AWS** platform.         | "LoadBalancer" | string                                                                                                         |  false   |
 | `toleration`        | Tolerations that the operator and envoy pods will tolerate.                                             |       -        | list(object({key = string, effect = string, operator = string, value = string, toleration_seconds = string })) |  false   |
+| `envoy.metrics_scrape_interval` | Interval at which Prometheus will scrape Envoy. Valid only when `enable_monitoring` is set to `true`.   | -              | string                                                                                                         | false    |
 
 
 ## Applying

--- a/docs/configuration-reference/components/contour.md
+++ b/docs/configuration-reference/components/contour.md
@@ -58,12 +58,12 @@ component "contour" {
 
 Table of all the arguments accepted by the component.
 
-| Argument            | Description                                                                                             |    Default     | Type                                                                                                           | Required |
-|---------------------|---------------------------------------------------------------------------------------------------------|:--------------:|:---------------------------------------------------------------------------------------------------------------|:--------:|
-| `enable_monitoring` | Create Prometheus Operator configs to scrape Contour and Envoy metrics. Also deploys Grafana Dashboard. |     false      | bool                                                                                                           |  false   |
-| `node_affinity`     | Node affinity for deploying the operator pod and envoy daemonset.                                       |       -        | list(object({key = string, operator = string, values = list(string)}))                                         |  false   |
-| `service_type`      | The type of Kubernetes service used to expose Envoy. Set as "NodePort" on the **AWS** platform.         | "LoadBalancer" | string                                                                                                         |  false   |
-| `toleration`        | Tolerations that the operator and envoy pods will tolerate.                                             |       -        | list(object({key = string, effect = string, operator = string, value = string, toleration_seconds = string })) |  false   |
+| Argument                        | Description                                                                                             | Default        | Type                                                                                                           | Required |
+|---------------------------------|---------------------------------------------------------------------------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------|----------|
+| `enable_monitoring`             | Create Prometheus Operator configs to scrape Contour and Envoy metrics. Also deploys Grafana Dashboard. | false          | bool                                                                                                           | false    |
+| `node_affinity`                 | Node affinity for deploying the operator pod and envoy daemonset.                                       | -              | list(object({key = string, operator = string, values = list(string)}))                                         | false    |
+| `service_type`                  | The type of Kubernetes service used to expose Envoy. Set as "NodePort" on the **AWS** platform.         | "LoadBalancer" | string                                                                                                         | false    |
+| `toleration`                    | Tolerations that the operator and envoy pods will tolerate.                                             | -              | list(object({key = string, effect = string, operator = string, value = string, toleration_seconds = string })) | false    |
 | `envoy.metrics_scrape_interval` | Interval at which Prometheus will scrape Envoy. Valid only when `enable_monitoring` is set to `true`.   | -              | string                                                                                                         | false    |
 
 

--- a/pkg/components/contour/component.go
+++ b/pkg/components/contour/component.go
@@ -44,6 +44,11 @@ type component struct {
 	ServiceType      string            `hcl:"service_type,optional"`
 	Tolerations      []util.Toleration `hcl:"toleration,block"`
 	TolerationsRaw   string
+	Envoy            *envoy `hcl:"envoy,block"`
+}
+
+type envoy struct {
+	MetricsScrapeInterval string `hcl:"metrics_scrape_interval,optional"`
 }
 
 func newComponent() *component {

--- a/pkg/components/contour/manifest.go
+++ b/pkg/components/contour/manifest.go
@@ -23,6 +23,9 @@ monitoring:
 
 envoy:
   serviceType: {{ .ServiceType }}
+  {{- if .Envoy }}
+  metricsScrapeInterval: {{ .Envoy.MetricsScrapeInterval }}
+  {{- end }}
 
 {{- if .NodeAffinity }}
 nodeAffinity:


### PR DESCRIPTION
This commit adds a parameter to contour's component config, using which now users can choose what (prometheus) scrape interval they want for envoy.

# How to use

Deploy contour using following config:

```tf
component "contour" {
  enable_monitoring = true

  envoy {
    metrics_scrape_interval = "30s"
  }
}
```

And you can watch the field `interval` vary according to the value of `metrics_scrape_interval`. If the field `metrics_scrape_interval` is not provided then the `interval` field is also left out.

```bash
kubectl -n projectcontour get servicemonitor envoy -o yaml | grep interval
```

Fixes: #1194