### PR TITLE
kubelet upgrade doc

### DIFF
--- a/docs/how-to-guides/upgrade-bootstrap-kubelet.md
+++ b/docs/how-to-guides/upgrade-bootstrap-kubelet.md
@@ -51,6 +51,7 @@ Run the following commands:
 
 ```bash
 export latest_kube=<latest kubernetes version e.g. v1.18.0>
+sudo sed -i "s|.*KUBELET_IMAGE_URL.*|KUBELET_IMAGE_URL=quay.io/poseidon/kubelet|g" /etc/kubernetes/kubelet.env
 sudo sed -i "s|.*KUBELET_IMAGE_TAG.*|KUBELET_IMAGE_TAG=${latest_kube}|g" /etc/kubernetes/kubelet.env
 sudo systemctl restart kubelet
 sudo journalctl -fu kubelet

--- a/docs/how-to-guides/upgrade-bootstrap-kubelet.md
+++ b/docs/how-to-guides/upgrade-bootstrap-kubelet.md
@@ -51,7 +51,7 @@ Run the following commands:
 
 ```bash
 export latest_kube=<latest kubernetes version e.g. v1.18.0>
-sudo sed -i "s|$(grep -i kubelet_image_tag /etc/kubernetes/kubelet.env)|KUBELET_IMAGE_TAG=${latest_kube}|g" /etc/kubernetes/kubelet.env
+sudo sed -i "s|.*KUBELET_IMAGE_TAG.*|KUBELET_IMAGE_TAG=${latest_kube}|g" /etc/kubernetes/kubelet.env
 sudo systemctl restart kubelet
 sudo journalctl -fu kubelet
 ```


### PR DESCRIPTION
Update the instructions for upgrading kubelet doc. This introduces an image replacement command. The clusters created with hyperkube image will fail to implement these instructions if they use hyperkube image of 1.19.x.