### PR TITLE
Don't prepull the kubelet images

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -186,8 +186,6 @@ storage:
           #!/bin/bash
           # Wrapper for bootkube start
           set -e
-          # Pre-pull kubelet image because when it is later pulled but takes too long it times out
-          docker pull quay.io/poseidon/kubelet:v1.19.4
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec docker run \

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -147,7 +147,7 @@ storage:
             -v /etc/kubernetes:/etc/kubernetes:ro \
             -v /var/lib/kubelet:/var/lib/kubelet:ro \
             --entrypoint=/usr/local/bin/kubectl \
-            quay.io/poseidon/kubelet:v1.18.8 \
+            quay.io/poseidon/kubelet:v1.19.4 \
             %{~ if enable_tls_bootstrap ~}
             --kubeconfig=/var/lib/kubelet/kubeconfig delete node $(hostname)
             %{~ else ~}

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -197,8 +197,6 @@ storage:
           #!/bin/bash
           # Wrapper for bootkube start
           set -e
-          # Pre-pull kubelet image because when it is later pulled but takes too long it times out
-          docker pull quay.io/poseidon/kubelet:v1.19.4
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec docker run \

--- a/assets/terraform-modules/controller/templates/bootkube.yaml.tmpl
+++ b/assets/terraform-modules/controller/templates/bootkube.yaml.tmpl
@@ -27,8 +27,6 @@ storage:
         #!/bin/bash
         # Wrapper for bootkube start
         set -e
-        # Pre-pull hyperkube image because when it is later pulled but takes too long it times out
-        docker pull ${kubelet_image_name}:${kubelet_image_tag}
         # Move experimental manifests
         [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
         exec docker run \

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -156,8 +156,6 @@ storage:
           #!/bin/bash
           # Wrapper for bootkube start
           set -e
-          # Pre-pull kubelet image because when it is later pulled but takes too long it times out
-          docker pull quay.io/poseidon/kubelet:v1.19.4
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -238,8 +238,6 @@ storage:
           #!/bin/bash
           # Wrapper for bootkube start
           set -e
-          # Pre-pull kubelet image because when it is later pulled but takes too long it times out
-          docker pull quay.io/poseidon/kubelet:v1.19.4-${os_arch}
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec docker run \

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -302,7 +302,7 @@ storage:
             -v /etc/kubernetes:/etc/kubernetes:ro \
             -v /var/lib/kubelet:/var/lib/kubelet:ro \
             --entrypoint=/usr/local/bin/kubectl \
-            quay.io/poseidon/kubelet:v1.18.8 \
+            quay.io/poseidon/kubelet:v1.19.4-${os_arch} \
             %{~ if enable_tls_bootstrap ~}
             --kubeconfig=/var/lib/kubelet/kubeconfig delete node $(hostname)
             %{~ else ~}


### PR DESCRIPTION
This commit removes the unnecessary code which pre pulled images when kubelet was run by rkt. Now it is not needed to do anymore.