### PR TITLE
Update bootkube to include timeout fixes

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -191,7 +191,7 @@ storage:
             -v /opt/bootkube/assets:/assets:ro \
             -v /etc/kubernetes:/etc/kubernetes:rw \
             --network=host \
-            quay.io/kinvolk/bootkube:v0.14.0-helm3-amd64 \
+            quay.io/kinvolk/bootkube:v0.14.0-helm4 \
             /bootkube start --asset-dir=/assets
     - path: /etc/tmpfiles.d/etcd-wrapper.conf
       filesystem: root

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
@@ -102,7 +102,10 @@ resource "null_resource" "bootkube-start" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/assets /opt/bootkube",
-      "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl start bootkube || (stdbuf -i0 -o0 -e0 sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }
 }

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -156,7 +156,7 @@ storage:
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            docker://quay.io/kinvolk/bootkube:v0.14.0-helm3-amd64 \
+            docker://quay.io/kinvolk/bootkube:v0.14.0-helm4 \
             --insecure-options=image \
             --net=host \
             --dns=host \

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -202,7 +202,7 @@ storage:
             -v /opt/bootkube/assets:/assets:ro \
             -v /etc/kubernetes:/etc/kubernetes:rw \
             --network=host \
-            quay.io/kinvolk/bootkube:v0.14.0-helm3-amd64 \
+            quay.io/kinvolk/bootkube:v0.14.0-helm4 \
             /bootkube start --asset-dir=/assets
     - path: /etc/kubernetes/configure-kubelet-cgroup-driver
       filesystem: root

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -141,7 +141,10 @@ resource "null_resource" "bootkube-start" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/assets /opt/bootkube",
-      "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl start bootkube || (stdbuf -i0 -o0 -e0 sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }
 }

--- a/assets/terraform-modules/controller/variables.tf
+++ b/assets/terraform-modules/controller/variables.tf
@@ -39,7 +39,7 @@ variable "bootkube_image_name" {
 variable "bootkube_image_tag" {
   type        = string
   description = "Docker image tag to use for container running bootkube."
-  default     = "v0.14.0-helm3-amd64"
+  default     = "v0.14.0-helm4"
 }
 
 variable "cluster_domain_suffix" {

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -157,7 +157,7 @@ storage:
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            docker://quay.io/kinvolk/bootkube:v0.14.0-helm3-amd64 \
+            docker://quay.io/kinvolk/bootkube:v0.14.0-helm4 \
             --insecure-options=image \
             --net=host \
             --dns=host \

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -165,7 +165,7 @@ storage:
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            docker://quay.io/kinvolk/bootkube:v0.14.0-helm3-amd64 \
+            docker://quay.io/kinvolk/bootkube:v0.14.0-helm4 \
             --insecure-options=image \
             --net=host \
             --dns=host \

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
@@ -108,7 +108,10 @@ resource "null_resource" "bootkube-start" {
       # This is needed, as the bootkube-start script will move all files matching
       # /opt/bootkube/asssets/manifests-*/*.yaml into /opt/bootkube/assets/manifests.
       "sudo mkdir /opt/bootkube/assets/manifests",
-      "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl start bootkube || (stdbuf -i0 -o0 -e0 sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }
 }

--- a/assets/terraform-modules/platforms/tinkerbell/controllers/ssh.tf
+++ b/assets/terraform-modules/platforms/tinkerbell/controllers/ssh.tf
@@ -91,7 +91,10 @@ resource "null_resource" "bootkube-start" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/assets /opt/bootkube",
-      "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl start bootkube || (stdbuf -i0 -o0 -e0 sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }
 }


### PR DESCRIPTION
To include https://github.com/kinvolk/bootkube/pull/19

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

~Draft to make sure it works as expected before I merge PR above and tag it. Doing some local tests too.~

Okay, it works as expected:
```console
module.aws-l8e-mat.null_resource.bootkube-start: Creating...
module.aws-l8e-mat.null_resource.bootkube-start: Provisioning with 'file'...
module.aws-l8e-mat.null_resource.bootkube-start: Still creating... [10s elapsed]
module.aws-l8e-mat.null_resource.bootkube-start: Provisioning with 'remote-exec'...
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Connecting to remote host via SSH...
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec):   Host: 54.93.82.231
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec):   User: core
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec):   Password: false
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec):   Private key: false
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec):   Certificate: false
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec):   SSH Agent: true
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec):   Checking Host Key: false
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Connected!
module.aws-l8e-mat.null_resource.bootkube-start: Still creating... [20s elapsed]
module.aws-l8e-mat.null_resource.bootkube-start: Still creating... [30s elapsed]
module.aws-l8e-mat.null_resource.bootkube-start: Still creating... [40s elapsed]
module.aws-l8e-mat.null_resource.bootkube-start: Still creating... [50s elapsed]
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Job for bootkube.service failed because the control process exited with error code.
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): See "systemctl status bootkube.service" and "journalctl -xe" for details.
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): -- Logs begin at Thu 2020-12-03 19:29:49 UTC, end at Thu 2020-12-03 19:33:59 UTC. --
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:18 ip-10-0-6-3 systemd[1]: Starting Bootstrap a Kubernetes cluster...
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:19 ip-10-0-6-3 bootkube-start[3815]: Unable to find image 'quay.io/kinvolk/bootkube:d387acd36077dc45e56fec4da01eed9058af9bb3' locally
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:20 ip-10-0-6-3 bootkube-start[3815]: d387acd36077dc45e56fec4da01eed9058af9bb3: Pulling from kinvolk/bootkube
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:20 ip-10-0-6-3 bootkube-start[3815]: 8dcd579abacd: Pulling fs layer
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:25 ip-10-0-6-3 bootkube-start[3815]: 8dcd579abacd: Verifying Checksum
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:25 ip-10-0-6-3 bootkube-start[3815]: 8dcd579abacd: Download complete
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:28 ip-10-0-6-3 bootkube-start[3815]: 8dcd579abacd: Pull complete
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:28 ip-10-0-6-3 bootkube-start[3815]: Digest: sha256:5d0f68e40dffd9da0f2de648d4686df87a787b489e0a3afe5245c92c959a01d7
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:28 ip-10-0-6-3 bootkube-start[3815]: Status: Downloaded newer image for quay.io/kinvolk/bootkube:d387acd36077dc45e56fec4da01eed9058af9bb3
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:29 ip-10-0-6-3 bootkube-start[3815]: Starting temporary bootstrap control plane...
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:29 ip-10-0-6-3 bootkube-start[3815]: Waiting for api-server...
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:57 ip-10-0-6-3 bootkube-start[3815]: WARNING: /assets/manifests does not exist, not creating any self-hosted assets.
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:57 ip-10-0-6-3 bootkube-start[3815]: Loading chart "lokomotive"
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:57 ip-10-0-6-3 bootkube-start[3815]: Loading chart "calico"
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:57 ip-10-0-6-3 bootkube-start[3815]: Loading chart "pod-checkpointer"
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:57 ip-10-0-6-3 bootkube-start[3815]: Loading chart "bootstrap-secrets"
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:57 ip-10-0-6-3 bootkube-start[3815]: Loading chart "kube-apiserver"
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:57 ip-10-0-6-3 bootkube-start[3815]: Loading chart "kubelet"
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:57 ip-10-0-6-3 bootkube-start[3815]: Loading chart "kubernetes"
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:58 ip-10-0-6-3 bootkube-start[3815]: kube-system/calico: creating 1 resource(s)
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:58 ip-10-0-6-3 bootkube-start[3815]: kube-system/pod-checkpointer: creating 1 resource(s)
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:58 ip-10-0-6-3 bootkube-start[3815]: kube-system/pod-checkpointer: creating 9 resource(s)
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:58 ip-10-0-6-3 bootkube-start[3815]: kube-system/calico: creating 1 resource(s)
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:58 ip-10-0-6-3 bootkube-start[3815]: kube-system/calico: creating 1 resource(s)
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:59 ip-10-0-6-3 bootkube-start[3815]: Installing chart "kube-apiserver" in namespace "kube-system" failed: YAML parse error on kube-apiserver/templates/kube-apiserver-secret.yaml: error converting YAML to JSON: yaml: line 7: found character that cannot start any tokenError: installing charts failed
module.aws-l8e-mat.null_resource.bootkube-start (remote-exec): Dec 03 19:33:59 ip-10-0-6-3 bootkube-start[3815]: Tearing down temporary bootstrap control plane...
```

Closes #1249