### PR TITLE
components/web-ui: bump to v0.1.3

### DIFF
--- a/assets/charts/components/web-ui/Chart.yaml
+++ b/assets/charts/components/web-ui/Chart.yaml
@@ -4,4 +4,4 @@ description: An easy-to-use and versatile dashboard for Kubernetes brought to yo
 type: application
 
 version: 0.1.0
-appVersion: 0.1.1
+appVersion: 0.1.3

--- a/assets/charts/components/web-ui/values.yaml
+++ b/assets/charts/components/web-ui/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: quay.io/kinvolk/headlamp
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.1.1
+  tag: v0.1.3
 
 imagePullSecrets: []
 nameOverride: ""

--- a/pkg/components/web-ui/component_test.go
+++ b/pkg/components/web-ui/component_test.go
@@ -115,7 +115,7 @@ metadata:
     helm.sh/chart: headlamp-0.1.0
     app.kubernetes.io/name: web-ui
     app.kubernetes.io/instance: web-ui
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
@@ -155,7 +155,7 @@ metadata:
     helm.sh/chart: headlamp-0.1.0
     app.kubernetes.io/name: web-ui
     app.kubernetes.io/instance: web-ui
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/pkg/components/web-ui/template.go
+++ b/pkg/components/web-ui/template.go
@@ -21,7 +21,6 @@ nodeSelector:
   beta.kubernetes.io/os: linux
 image:
   repository: quay.io/kinvolk/lokomotive-web-ui
-  tag: v0.1.1
   pullPolicy: Always
 securityContext:
   capabilities:


### PR DESCRIPTION
This PR update Web UI to v0.1.3.

Let's use the chart to express version changes since the Headlamp and
Lokomotive Web UI versions are locked to each other. This way we avoid
having to modify the version in the template too.