### PR TITLE
tinkerbell: fix printing bootkube logs on error

### DIFF
--- a/assets/terraform-modules/platforms/tinkerbell/controllers/ssh.tf
+++ b/assets/terraform-modules/platforms/tinkerbell/controllers/ssh.tf
@@ -91,7 +91,7 @@ resource "null_resource" "bootkube-start" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/assets /opt/bootkube",
-      "sudo systemctl start bootkube || (sudo journalctl -u bootkube >&2; exit 1)",
+      "sudo systemctl start bootkube || (sudo journalctl -u bootkube --no-pager; exit 1)",
     ]
   }
 }


### PR DESCRIPTION
Instead of piping everything to stderr we should use --no-pager to get
logs printed correctly.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>