### PR TITLE
kube-scheduler: fix access to cluster certificates ConfigMap

### DIFF
--- a/assets/charts/control-plane/kubernetes/templates/kube-scheduler-role-binding.yaml
+++ b/assets/charts/control-plane/kubernetes/templates/kube-scheduler-role-binding.yaml
@@ -10,3 +10,16 @@ subjects:
 - kind: ServiceAccount
   name: kube-scheduler
   namespace: kube-system
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-scheduler-extension-apiserver-authentication-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: kube-scheduler
+  namespace: kube-system


### PR DESCRIPTION
added a rolebinding for role `extension-apiserver-authentication-reader` for kube-scheduler

closes: #1096
Signed-off-by: knrt10 <kautilya@kinvolk.io>


