### PR TITLE
Simplify docs link titles

### DIFF
--- a/docs/configuration-reference/backend/local.md
+++ b/docs/configuration-reference/backend/local.md
@@ -1,5 +1,6 @@
 ---
 title: Local backend configuration reference
+linkTitle: Local
 weight: 10
 ---
 

--- a/docs/configuration-reference/backend/s3.md
+++ b/docs/configuration-reference/backend/s3.md
@@ -1,5 +1,6 @@
 ---
 title: S3 backend configuration reference
+linkTitle: S3
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/aws-ebs-csi-driver.md
+++ b/docs/configuration-reference/components/aws-ebs-csi-driver.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon EBS CSI Driver configuration reference for Lokomotive
+linkTitle: Amazon EBS CSI Driver
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/cert-manager.md
+++ b/docs/configuration-reference/components/cert-manager.md
@@ -1,5 +1,6 @@
 ---
 title: Cert-Manager configuration reference for Lokomotive
+linkTitle: Cert-Manager
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/cluster-autoscaler.md
+++ b/docs/configuration-reference/components/cluster-autoscaler.md
@@ -1,5 +1,6 @@
 ---
-title: Cluster autoscaler configuration reference for Lokomotive
+title: Cluster Autoscaler configuration reference for Lokomotive
+linkTitle: Cluster Autoscaler
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/contour.md
+++ b/docs/configuration-reference/components/contour.md
@@ -1,5 +1,6 @@
 ---
-title: Contour Ingress controller configuration reference for Lokomotive
+title: Contour Ingress Controller configuration reference for Lokomotive
+linkTitle: Contour Ingress Controller
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/dex.md
+++ b/docs/configuration-reference/components/dex.md
@@ -1,5 +1,6 @@
 ---
 title: Dex configuration reference for Lokomotive
+linkTitle: Dex
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/external-dns.md
+++ b/docs/configuration-reference/components/external-dns.md
@@ -1,5 +1,6 @@
 ---
 title: ExternalDNS configuration reference for Lokomotive
+linkTitle: ExternalDNS
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/flatcar-linux-update-operator.md
+++ b/docs/configuration-reference/components/flatcar-linux-update-operator.md
@@ -1,5 +1,6 @@
 ---
-title: Flatcar Container Linux update operator configuration reference for Lokomotive
+title: Flatcar Container Linux Update Operator configuration reference for Lokomotive
+linkTitle: Flatcar Container Linux Update Operator
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/gangway.md
+++ b/docs/configuration-reference/components/gangway.md
@@ -1,5 +1,6 @@
 ---
 title: Gangway configuration reference for Lokomotive
+linkTitle: Gangway
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/httpbin.md
+++ b/docs/configuration-reference/components/httpbin.md
@@ -1,5 +1,6 @@
 ---
 title: httpbin configuration reference for Lokomotive
+linkTitle: httpbin
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/inspektor-gadget.md
+++ b/docs/configuration-reference/components/inspektor-gadget.md
@@ -1,5 +1,6 @@
 ---
 title: Inspektor Gadget configuration reference for Lokomotive
+linkTitle: Inspektor Gadget
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/istio-operator.md
+++ b/docs/configuration-reference/components/istio-operator.md
@@ -1,5 +1,6 @@
 ---
-title: Istio operator configuration reference for Lokomotive
+title: Istio Operator configuration reference for Lokomotive
+linkTitle: Istio Operator
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/linkerd.md
+++ b/docs/configuration-reference/components/linkerd.md
@@ -1,5 +1,6 @@
 ---
 title: Linkerd configuration reference for Lokomotive
+linkTitle: Linkerd
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/metallb.md
+++ b/docs/configuration-reference/components/metallb.md
@@ -1,5 +1,6 @@
 ---
 title: MetalLB configuration reference for LokomotiveLokomotive
+linkTitle: MetalLB
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/metrics-server.md
+++ b/docs/configuration-reference/components/metrics-server.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics Server configuration reference for Lokomotive
+linkTitle: Metrics Server
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/openebs-operator.md
+++ b/docs/configuration-reference/components/openebs-operator.md
@@ -1,5 +1,6 @@
 ---
-title: OpenEBS operator configuration reference for Lokomotive
+title: OpenEBS Operator configuration reference for Lokomotive
+linkTitle: OpenEBS Operator
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/openebs-storage-class.md
+++ b/docs/configuration-reference/components/openebs-storage-class.md
@@ -1,5 +1,6 @@
 ---
-title: OpenEBS storage class configuration reference for Lokomotive
+title: OpenEBS Storage Class configuration reference for Lokomotive
+linkTitle: OpenEBS Storage Class
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/prometheus-operator.md
+++ b/docs/configuration-reference/components/prometheus-operator.md
@@ -1,5 +1,6 @@
 ---
 title: Prometheus Operator configuration reference for Lokomotive
+linkTitle: Prometheus Operator
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/rook-ceph.md
+++ b/docs/configuration-reference/components/rook-ceph.md
@@ -1,5 +1,6 @@
 ---
 title: Rook Ceph configuration reference for Lokomotive
+linkTitle: Rook Ceph
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/rook.md
+++ b/docs/configuration-reference/components/rook.md
@@ -1,5 +1,6 @@
 ---
 title: Rook configuration reference for Lokomotive
+linkTitle: Rook
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/velero.md
+++ b/docs/configuration-reference/components/velero.md
@@ -1,5 +1,6 @@
 ---
 title: Velero configuration reference for Lokomotive
+linkTitle: Velero
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/web-ui.md
+++ b/docs/configuration-reference/components/web-ui.md
@@ -1,5 +1,6 @@
 ---
 title: Web UI configuration reference for Lokomotive
+linkTitle: Web UI
 weight: 10
 ---
 

--- a/docs/configuration-reference/platforms/aks.md
+++ b/docs/configuration-reference/platforms/aks.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive AKS configuration reference
+linkTitle: AKS
 weight: 10
 ---
 

--- a/docs/configuration-reference/platforms/aws.md
+++ b/docs/configuration-reference/platforms/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive AWS configuration reference
+linkTitle: AWS
 weight: 10
 ---
 

--- a/docs/configuration-reference/platforms/baremetal.md
+++ b/docs/configuration-reference/platforms/baremetal.md
@@ -1,5 +1,6 @@
 ---
-title: Lokomotive bare metal configuration reference
+title: Lokomotive Bare Metal configuration reference
+linkTitle: Bare Metal
 weight: 10
 ---
 

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive Packet configuration reference
+linkTitle: Packet
 weight: 10
 ---
 

--- a/docs/configuration-reference/platforms/tinkerbell.md
+++ b/docs/configuration-reference/platforms/tinkerbell.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive Tinkerbell configuration reference
+linkTitle: Tinkerbell
 weight: 10
 ---
 

--- a/docs/quickstarts/aks.md
+++ b/docs/quickstarts/aks.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive AKS quickstart guide
+linkTitle: AKS
 weight: 10
 ---
 

--- a/docs/quickstarts/aws.md
+++ b/docs/quickstarts/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive AWS quickstart guide
+linkTitle: AWS
 weight: 10
 ---
 

--- a/docs/quickstarts/baremetal.md
+++ b/docs/quickstarts/baremetal.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive Bare Metal quickstart guide
+linkTitle: Bare Metal
 weight: 10
 ---
 

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive Packet quickstart guide
+linkTitle: Packet
 weight: 10
 ---
 

--- a/docs/quickstarts/tinkerbell.md
+++ b/docs/quickstarts/tinkerbell.md
@@ -1,5 +1,6 @@
 ---
 title: Lokomotive Tinkerbell quickstart guide
+linkTitle: Tinkerbell
 weight: 10
 ---
 


### PR DESCRIPTION
We are already nested under a heading so we can drop that heading (eg: "quickstart..." or "..... configuration reference") from the link title.

Closes #1217 

Ran `make docs` in root of repository but didn't notice any side effects or changes.
I'm not sure how to locally validate how the docs render.
I was expecting I could do something like `hugo server` or whatever the mechanism is.

