### PR TITLE
Fix iscsi volume mount issue

### DIFF
--- a/assets/charts/control-plane/kubelet/container-image/Dockerfile
+++ b/assets/charts/control-plane/kubelet/container-image/Dockerfile
@@ -1,0 +1,3 @@
+FROM quay.io/poseidon/kubelet:v1.19.4
+
+COPY ./iscsiadm /bin/iscsiadm

--- a/assets/charts/control-plane/kubelet/container-image/README.md
+++ b/assets/charts/control-plane/kubelet/container-image/README.md
@@ -1,0 +1,63 @@
+# Lokomotive Kubelet Image
+
+This image is built on top of the Typhoon Kubelet image. This image includes a wrapper script that runs `isciadm` in the host namespace. This ensures that all the `isciadm` libraries are loaded from the host.
+
+## Updating Image Tag
+
+In this directory run the following command to update the Kubernetes version:
+
+```bash
+export NEW_VERSION=
+```
+
+```bash
+export CURRENT_VERSION=$(grep ^FROM Dockerfile | cut -d":" -f2)
+sed -i "s|$CURRENT_VERSION|$NEW_VERSION|g" Dockerfile
+```
+
+## Building Image
+
+```bash
+export IMAGE_URL=quay.io/kinvolk/kubelet
+```
+
+### x86
+
+```bash
+export ARCH=amd64
+
+docker build -t $IMAGE_URL:$NEW_VERSION-$ARCH . && docker push $IMAGE_URL:$NEW_VERSION-$ARCH
+```
+
+### ARM
+
+```bash
+export ARCH=arm64
+
+docker build -t $IMAGE_URL:$NEW_VERSION-$ARCH . && docker push $IMAGE_URL:$NEW_VERSION-$ARCH
+```
+
+### Combined image tag
+
+Now make sure you have `"experimental": "enabled"` in your
+`~/.docker/config.json` (surrounded by `{` and `}` if the file is otherwise
+empty).
+
+When all images are built on the respective architectures and pushed they can
+be combined through a manifest to build a multiarch image:
+
+```bash
+docker manifest create $IMAGE_URL:$NEW_VERSION \
+    --amend $IMAGE_URL:$NEW_VERSION-amd64 \
+    --amend $IMAGE_URL:$NEW_VERSION-arm64
+
+docker manifest annotate $IMAGE_URL:$NEW_VERSION \
+    $IMAGE_URL:$NEW_VERSION-amd64 --arch=amd64 --os=linux
+
+docker manifest annotate $IMAGE_URL:$NEW_VERSION \
+    $IMAGE_URL:$NEW_VERSION-arm64 --arch=arm64 --os=linux
+
+docker manifest push $IMAGE_URL:$NEW_VERSION
+```
+
+> **NOTE**: Above commands can be run from any machine.

--- a/assets/charts/control-plane/kubelet/container-image/iscsiadm
+++ b/assets/charts/control-plane/kubelet/container-image/iscsiadm
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nsenter -a -t 1 iscsiadm "$@"

--- a/assets/charts/control-plane/kubelet/templates/kubelet-ds.yaml
+++ b/assets/charts/control-plane/kubelet/templates/kubelet-ds.yaml
@@ -125,10 +125,6 @@ spec:
         - name: etc-resolv
           mountPath: /etc/resolv.conf
           readOnly: true
-        # This is mounted so that storage works fine.
-        - name: iscsiadm
-          mountPath: /usr/sbin/iscsiadm
-          readOnly: false
         - name: modules
           mountPath: /lib/modules
           readOnly: true
@@ -191,9 +187,6 @@ spec:
         hostPath:
           path: /etc/resolv.conf
           type: File
-      - name: iscsiadm
-        hostPath:
-          path: /usr/sbin/iscsiadm
       - name: modules
         hostPath:
           path: /lib/modules

--- a/assets/charts/control-plane/kubelet/values.yaml
+++ b/assets/charts/control-plane/kubelet/values.yaml
@@ -1,4 +1,4 @@
-image: quay.io/poseidon/kubelet:v1.19.4
+image: quay.io/kinvolk/kubelet:v1.19.4
 clusterDNS: 10.0.0.10
 clusterDomain: cluster.local
 enableTLSBootstrap: true

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -81,7 +81,6 @@ systemd:
           -v /sys:/sys:rw \
           -v /opt/cni/bin:/opt/cni/bin:ro \
           -v /usr/lib/os-release:/etc/os-release:ro \
-          -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm:rw \
           -v /var/lib/calico:/var/lib/calico:ro \
           -v /var/lib/cni:/var/lib/cni:rw \
           -v /var/lib/docker:/var/lib/docker:rw \

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -139,7 +139,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -118,7 +118,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           NODE_LABELS="${join(",", [for k, v in node_labels : "${k}=${v}"])}"
           NODE_TAINTS="${join(",", [for k, v in taints : "${k}=${v}"])}"
@@ -152,7 +152,7 @@ storage:
             -v /etc/kubernetes:/etc/kubernetes:ro \
             -v /var/lib/kubelet:/var/lib/kubelet:ro \
             --entrypoint=/usr/local/bin/kubectl \
-            quay.io/poseidon/kubelet:v1.19.4 \
+            quay.io/kinvolk/kubelet:v1.19.4 \
             %{~ if enable_tls_bootstrap ~}
             --kubeconfig=/var/lib/kubelet/kubeconfig delete node $(hostname)
             %{~ else ~}

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -6,6 +6,11 @@ systemd:
     - name: iscsid.service
       enable: true
       enabled: true
+      dropins:
+      - name: 00-iscsid.conf
+        contents: |
+          [Service]
+          ExecStartPre=/bin/bash -c 'echo "InitiatorName=$(/sbin/iscsi-iname -p iqn.2020-01.io.kinvolk:01)" > /etc/iscsi/initiatorname.iscsi'
     - name: locksmithd.service
       mask: true
     - name: wait-for-dns.service

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -55,7 +55,6 @@ systemd:
           -v /sys:/sys:rw \
           -v /opt/cni/bin:/opt/cni/bin:ro \
           -v /usr/lib/os-release:/etc/os-release:ro \
-          -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm:rw \
           -v /var/lib/calico:/var/lib/calico:ro \
           -v /var/lib/cni:/var/lib/cni:rw \
           -v /var/lib/docker:/var/lib/docker:rw \

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -4,7 +4,6 @@ systemd:
     - name: docker.service
       enable: true
     - name: iscsid.service
-      enable: true
       enabled: true
       dropins:
       - name: 00-iscsid.conf

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -125,7 +125,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -47,8 +47,6 @@ systemd:
           --mount volume=var-log,target=/var/log \
           --volume etc-cni-netd,kind=host,source=/etc/cni/net.d \
           --mount volume=etc-cni-netd,target=/etc/cni/net.d \
-          --volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
-          --mount volume=iscsiadm,target=/usr/sbin/iscsiadm \
           --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -104,7 +104,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/node"
@@ -125,7 +125,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://quay.io/poseidon/kubelet:v1.19.4 \
+            docker://quay.io/kinvolk/kubelet:v1.19.4 \
             --net=host \
             --dns=host \
             -- \

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -8,6 +8,11 @@ systemd:
     - name: iscsid.service
       enable: true
       enabled: true
+      dropins:
+      - name: 00-iscsid.conf
+        contents: |
+          [Service]
+          ExecStartPre=/bin/bash -c 'echo "InitiatorName=$(/sbin/iscsi-iname -p iqn.2020-01.io.kinvolk:01)" > /etc/iscsi/initiatorname.iscsi'
     - name: wait-for-dns.service
       enable: true
       contents: |

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -6,7 +6,6 @@ systemd:
     - name: locksmithd.service
       mask: true
     - name: iscsid.service
-      enable: true
       enabled: true
       dropins:
       - name: 00-iscsid.conf

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -144,7 +144,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -87,7 +87,6 @@ systemd:
           -v /sys:/sys:rw \
           -v /opt/cni/bin:/opt/cni/bin:ro \
           -v /usr/lib/os-release:/etc/os-release:ro \
-          -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm:rw \
           -v /var/lib/calico:/var/lib/calico:ro \
           -v /var/lib/cni:/var/lib/cni:rw \
           -v /var/lib/docker:/var/lib/docker:rw \

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -5,6 +5,14 @@ systemd:
       enable: true
     - name: locksmithd.service
       mask: true
+    - name: iscsid.service
+      enable: true
+      enabled: true
+      dropins:
+      - name: 00-iscsid.conf
+        contents: |
+          [Service]
+          ExecStartPre=/bin/bash -c 'echo "InitiatorName=$(/sbin/iscsi-iname -p iqn.2020-01.io.kinvolk:01)" > /etc/iscsi/initiatorname.iscsi'
     - name: kubelet.path
       enable: true
       contents: |

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -108,7 +108,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           NODE_LABELS="${join(",", [for k, v in kubelet_labels : "${k}=${v}"])}"
     - path: /etc/hostname

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -6,7 +6,6 @@ systemd:
     - name: locksmithd.service
       mask: true
     - name: iscsid.service
-      enable: true
       enabled: true
       dropins:
       - name: 00-iscsid.conf

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -63,7 +63,6 @@ systemd:
           -v /sys:/sys:rw \
           -v /opt/cni/bin:/opt/cni/bin:ro \
           -v /usr/lib/os-release:/etc/os-release:ro \
-          -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm:rw \
           -v /var/lib/calico:/var/lib/calico:ro \
           -v /var/lib/cni:/var/lib/cni:rw \
           -v /var/lib/docker:/var/lib/docker:rw \

--- a/assets/terraform-modules/bootkube/variables.tf
+++ b/assets/terraform-modules/bootkube/variables.tf
@@ -93,7 +93,7 @@ variable "container_images" {
     calico_cni              = "quay.io/kinvolk/calico-cni:v3.17.0"
     calico_controllers      = "quay.io/kinvolk/calico-kube-controllers:v3.17.0"
     flexvol_driver_image    = "quay.io/kinvolk/calico-pod2daemon-flexvol:v3.17.0"
-    kubelet_image           = "quay.io/poseidon/kubelet:v1.19.4"
+    kubelet_image           = "quay.io/kinvolk/kubelet:v1.19.4"
     coredns                 = "quay.io/kinvolk/coredns:1.8.0"
     pod_checkpointer        = "quay.io/kinvolk/checkpoint:43ec4b414e44f202e07bf43e57d2b5ffbcfd4415"
     kube_apiserver          = "k8s.gcr.io/kube-apiserver:v1.19.4"

--- a/assets/terraform-modules/controller/variables.tf
+++ b/assets/terraform-modules/controller/variables.tf
@@ -69,7 +69,7 @@ variable "clc_snippets" {
 variable "kubelet_image_name" {
   type        = string
   description = "Source of kubelet Docker image."
-  default     = "quay.io/poseidon/kubelet"
+  default     = "quay.io/kinvolk/kubelet"
 }
 
 variable "kubelet_image_tag" {

--- a/assets/terraform-modules/controller/variables.tf
+++ b/assets/terraform-modules/controller/variables.tf
@@ -75,7 +75,7 @@ variable "kubelet_image_name" {
 variable "kubelet_image_tag" {
   type        = string
   description = "Tag for kubelet Docker image."
-  default     = "v1.19.3"
+  default     = "v1.19.4"
 }
 
 variable "host_dns_ip" {

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -126,7 +126,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -95,7 +95,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/node"
@@ -116,7 +116,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://quay.io/poseidon/kubelet:v1.19.4 \
+            docker://quay.io/kinvolk/kubelet:v1.19.4 \
             --net=host \
             --dns=host \
             -- \

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -128,7 +128,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -47,8 +47,6 @@ systemd:
           --mount volume=var-log,target=/var/log \
           --volume etc-cni-netd,kind=host,source=/etc/cni/net.d \
           --mount volume=etc-cni-netd,target=/etc/cni/net.d \
-          --volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
-          --mount volume=iscsiadm,target=/usr/sbin/iscsiadm \
           --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -107,7 +107,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/node"
@@ -147,7 +147,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://quay.io/poseidon/kubelet:v1.19.4 \
+            docker://quay.io/kinvolk/kubelet:v1.19.4 \
             --net=host \
             --dns=host \
             -- \

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -6,6 +6,11 @@ systemd:
     - name: iscsid.service
       enable: true
       enabled: true
+      dropins:
+      - name: 00-iscsid.conf
+        contents: |
+          [Service]
+          ExecStartPre=/bin/bash -c 'echo "InitiatorName=$(/sbin/iscsi-iname -p iqn.2020-01.io.kinvolk:01)" > /etc/iscsi/initiatorname.iscsi'
     - name: locksmithd.service
       mask: true
     - name: wait-for-dns.service

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -4,7 +4,6 @@ systemd:
     - name: docker.service
       enable: true
     - name: iscsid.service
-      enable: true
       enabled: true
       dropins:
       - name: 00-iscsid.conf

--- a/assets/terraform-modules/node/variables.tf
+++ b/assets/terraform-modules/node/variables.tf
@@ -37,7 +37,7 @@ variable "kubelet_image_name" {
 variable "kubelet_image_tag" {
   type        = string
   description = "Tag for kubelet Docker image."
-  default     = "v1.19.3"
+  default     = "v1.19.4"
 }
 
 variable "kubelet_taints" {

--- a/assets/terraform-modules/node/variables.tf
+++ b/assets/terraform-modules/node/variables.tf
@@ -31,7 +31,7 @@ variable "clc_snippet_index" {
 variable "kubelet_image_name" {
   type        = string
   description = "Source of kubelet Docker image."
-  default     = "quay.io/poseidon/kubelet"
+  default     = "quay.io/kinvolk/kubelet"
 }
 
 variable "kubelet_image_tag" {

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -190,7 +190,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4-${os_arch}
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -116,7 +116,6 @@ systemd:
           -v /sys:/sys:rw \
           -v /opt/cni/bin:/opt/cni/bin:ro \
           -v /usr/lib/os-release:/etc/os-release:ro \
-          -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm:rw \
           -v /var/lib/calico:/var/lib/calico:ro \
           -v /var/lib/cni:/var/lib/cni:rw \
           -v /var/lib/docker:/var/lib/docker:rw \

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -138,9 +138,14 @@ systemd:
     - name: "ip6tables-restore.service"
       enabled: true
       enable: true
-    - name: "iscsid.service"
+    - name: iscsid.service
       enabled: true
       enable: true
+      dropins:
+      - name: 00-iscsid.conf
+        contents: |
+          [Service]
+          ExecStartPre=/bin/bash -c 'echo "InitiatorName=$(/sbin/iscsi-iname -p iqn.2020-01.io.kinvolk:01)" > /etc/iscsi/initiatorname.iscsi'
 storage:
   filesystems:
     - name: "OEM"

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -139,7 +139,6 @@ systemd:
       enable: true
     - name: iscsid.service
       enabled: true
-      enable: true
       dropins:
       - name: 00-iscsid.conf
         contents: |

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -77,7 +77,6 @@ systemd:
           -v /sys:/sys:rw \
           -v /opt/cni/bin:/opt/cni/bin:ro \
           -v /usr/lib/os-release:/etc/os-release:ro \
-          -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm:rw \
           -v /var/lib/calico:/var/lib/calico:ro \
           -v /var/lib/cni:/var/lib/cni:rw \
           -v /var/lib/docker:/var/lib/docker:rw \

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -286,7 +286,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=quay.io/poseidon/kubelet
+          KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
           KUBELET_IMAGE_TAG=v1.19.4-${os_arch}
           NODE_LABELS="${join(",", [for k, v in node_labels : "${k}=${v}"])}"
           NODE_TAINTS="${join(",", [for k, v in taints : "${k}=${v}"])}"
@@ -307,7 +307,7 @@ storage:
             -v /etc/kubernetes:/etc/kubernetes:ro \
             -v /var/lib/kubelet:/var/lib/kubelet:ro \
             --entrypoint=/usr/local/bin/kubectl \
-            quay.io/poseidon/kubelet:v1.19.4-${os_arch} \
+            quay.io/kinvolk/kubelet:v1.19.4-${os_arch} \
             %{~ if enable_tls_bootstrap ~}
             --kubeconfig=/var/lib/kubelet/kubeconfig delete node $(hostname)
             %{~ else ~}

--- a/assets/terraform-modules/worker/main.tf
+++ b/assets/terraform-modules/worker/main.tf
@@ -3,7 +3,6 @@ locals {
 systemd:
   units:
     - name: iscsid.service
-      enable: true
       enabled: true
       dropins:
       - name: 00-iscsid.conf

--- a/assets/terraform-modules/worker/main.tf
+++ b/assets/terraform-modules/worker/main.tf
@@ -5,6 +5,11 @@ systemd:
     - name: iscsid.service
       enable: true
       enabled: true
+      dropins:
+      - name: 00-iscsid.conf
+        contents: |
+          [Service]
+          ExecStartPre=/bin/bash -c 'echo "InitiatorName=$(/sbin/iscsi-iname -p iqn.2020-01.io.kinvolk:01)" > /etc/iscsi/initiatorname.iscsi'
 EOF
 
   kubeconfig = <<EOF

--- a/assets/terraform-modules/worker/main.tf
+++ b/assets/terraform-modules/worker/main.tf
@@ -37,10 +37,7 @@ data "ct_config" "config" {
     cluster_dns_service_ip = var.cluster_dns_service_ip
     cluster_domain_suffix  = var.cluster_domain_suffix
     host_dns_ip            = var.host_dns_ip
-    kubelet_docker_extra_args = [
-      # Workers should have iscsiadm mounted for storage solutions support.
-      "-v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm:rw",
-    ]
+    kubelet_docker_extra_args = []
     # Here we set default labels for worker nodes.
     kubelet_labels = length(var.kubelet_labels) > 0 ? var.kubelet_labels : {
       "node.kubernetes.io/node" = ""

--- a/assets/terraform-modules/worker/variables.tf
+++ b/assets/terraform-modules/worker/variables.tf
@@ -37,7 +37,7 @@ variable "clc_snippets" {
 variable "kubelet_image_name" {
   type        = string
   description = "Source of kubelet Docker image."
-  default     = "quay.io/poseidon/kubelet"
+  default     = "quay.io/kinvolk/kubelet"
 }
 
 variable "kubelet_image_tag" {

--- a/assets/terraform-modules/worker/variables.tf
+++ b/assets/terraform-modules/worker/variables.tf
@@ -43,7 +43,7 @@ variable "kubelet_image_name" {
 variable "kubelet_image_tag" {
   type        = string
   description = "Tag for kubelet Docker image."
-  default     = "v1.19.3"
+  default     = "v1.19.4"
 }
 
 variable "kubelet_taints" {

--- a/docs/how-to-guides/upgrade-bootstrap-kubelet.md
+++ b/docs/how-to-guides/upgrade-bootstrap-kubelet.md
@@ -54,13 +54,13 @@ rkt list | grep -i kubelet
 **With `rkt`**
 
 ```bash
-sudo sed -i "s|.*KUBELET_IMAGE_URL.*|KUBELET_IMAGE_URL=docker://quay.io/poseidon/kubelet|g" /etc/kubernetes/kubelet.env
+sudo sed -i "s|.*KUBELET_IMAGE_URL.*|KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet|g" /etc/kubernetes/kubelet.env
 ```
 
 **Without `rkt`**
 
 ```bash
-sudo sed -i "s|.*KUBELET_IMAGE_URL.*|KUBELET_IMAGE_URL=quay.io/poseidon/kubelet|g" /etc/kubernetes/kubelet.env
+sudo sed -i "s|.*KUBELET_IMAGE_URL.*|KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet|g" /etc/kubernetes/kubelet.env
 ```
 
 #### Step 3.2 Update kubelet image tag


### PR DESCRIPTION
- Create iscsi initiator name on workers

  - Enable `iscsid` service on baremetal.
  
  - With new Flatcar `2605.9.0` the `/etc/iscsi` directory is shipped and the initiator name file (`/etc/iscsi/initiatorname.iscsi`) has incomplete config which causes the `iscsid` process to start with warning that the initiator name is improper. This PR makes sure that the initiator name is proper. More explanation: https://github.com/kinvolk/lokomotive/issues/1257#issuecomment-743050474.
  
  - This PR adds a `ExecPreStart` which creates `iscsid` initiator name file.
  
  - Remove deprecated `enable: true` for the existing `iscsid` service configuration.
  
  - We can use the script `iscsi-gen-initiatorname` but it creates the initiator name with FQDN `suse.de` in it, so this script creates the initiator name with FQDN with kinvolk.io in it.

- kubelet image: Add Dockerfile

  This PR adds a Dockerfile and a script which runs `iscsiadm` in host namespace.

- Replace image from quay.io/poseidon/kubelet to quay.io/kinvolk/kubelet

- kubelet: Remove mount of `iscsiadm` binary from host

  This PR removes the mount of `iscsiadm` from the host, expecting the image to ship `iscsiadm`.

- tinkerbell: Update kubelet to v1.19.4

  There was a regression from previous Kubernetes update to `v1.19.4`. This PR fixes that regression.


---

Fixes: #1257 
Fixes: #447
