### PR TITLE
dex: Update to v2.27.0

### DIFF
--- a/assets/charts/components/dex/Chart.yaml
+++ b/assets/charts/components/dex/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v2.25.0
+appVersion: v2.27.0

--- a/assets/charts/components/dex/templates/deployment.yaml
+++ b/assets/charts/components/dex/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: theme
           mountPath: /theme/
       containers:
-      - image: quay.io/dexidp/dex:{{ .Chart.AppVersion }}
+      - image: ghcr.io/dexidp/dex:{{ .Chart.AppVersion }}
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         ports:


### PR DESCRIPTION
Switched registry to ghcr.io for dex deployment

closes: #1268