### PR TITLE
aws_ebs_csi_driver: fix permission issue

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -167,3 +167,9 @@ variable "enable_tls_bootstrap" {
   description = "Enable TLS Bootstrap for Kubelet."
   type        = bool
 }
+
+variable "enable_csi" {
+  description = "Set up IAM role required for dynamic volumes provisioning."
+  type        = bool
+  default     = false
+}

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -52,6 +52,68 @@ resource "aws_autoscaling_group" "workers" {
   ])
 }
 
+# IAM Policy.
+resource "aws_iam_instance_profile" "csi_driver" {
+  count = var.enable_csi ? 1 : 0
+  role  = join("", aws_iam_role.csi_driver.*.name)
+}
+
+resource "aws_iam_role_policy" "csi_driver" {
+  count = var.enable_csi ? 1 : 0
+  role  = join("", aws_iam_role.csi_driver.*.id)
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "ec2:AttachVolume",
+          "ec2:CreateSnapshot",
+          "ec2:CreateTags",
+          "ec2:CreateVolume",
+          "ec2:DeleteSnapshot",
+          "ec2:DeleteTags",
+          "ec2:DeleteVolume",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInstances",
+          "ec2:DescribeSnapshots",
+          "ec2:DescribeTags",
+          "ec2:DescribeVolumes",
+          "ec2:DescribeVolumesModifications",
+          "ec2:DetachVolume",
+          "ec2:ModifyVolume"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "csi_driver" {
+  count = var.enable_csi ? 1 : 0
+  path  = "/"
+  tags  = var.tags
+
+  assume_role_policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+  }
+  EOF
+}
+
 # Worker template
 resource "aws_launch_configuration" "worker" {
   name_prefix       = "${var.cluster_name}-${var.pool_name}-"
@@ -78,6 +140,8 @@ resource "aws_launch_configuration" "worker" {
     create_before_destroy = true
     ignore_changes        = [image_id]
   }
+
+  iam_instance_profile = join("", aws_iam_instance_profile.csi_driver.*.name)
 }
 
 # Worker Ignition config

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -114,6 +114,7 @@ module "aws-{{.Config.ClusterName}}" {
 module "worker-pool-{{ $index }}" {
   source = "../terraform-modules/aws/flatcar-linux/kubernetes/workers"
 
+  enable_csi            = {{ $.Config.EnableCSI }}
   vpc_id                = module.aws-{{ $.Config.ClusterName }}.vpc_id
   subnet_ids            = flatten([module.aws-{{ $.Config.ClusterName }}.subnet_ids])
   security_groups       = module.aws-{{ $.Config.ClusterName }}.worker_security_groups


### PR DESCRIPTION
Fixes: #1219

Whe trying to dynamically provision EBS volumes using the AWS EBS CSI
driver, we run into an error:
```
E1217 08:08:41.495598       1 driver.go:111] GRPC error: rpc error: code
= Internal desc = NoCredentialProviders: no valid providers in chain
caused by: EnvAccessKeyNotFound: failed to find credentials in the
environment.
SharedCredsLoad: failed to load profile, .
EC2RoleRequestError: no EC2 instance role found
```

There reason being that worker nodes are not given this permissions as
mentioned in the github repo of [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver#set-up-driver-permission).

This commit adds such permissions to the worker nodes.

Signed-off-by: Imran Pochi <imran@kinvolk.io>
