### PR TITLE
calico-host-protection: add psp rule

### DIFF
--- a/assets/charts/control-plane/calico-host-protection/templates/host-endpoint-controller.yaml
+++ b/assets/charts/control-plane/calico-host-protection/templates/host-endpoint-controller.yaml
@@ -47,7 +47,7 @@ spec:
 
 ---
 # rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: calico-hostendpoint-controller-role
@@ -58,19 +58,19 @@ rules:
 - apiGroups: ["crd.projectcalico.org"]
   resources: ["hostendpoints"]
   verbs:
-   - create
-   - get
-   - list
-   - update
-   - delete
-   # To use kubectl apply on resources that already exist
-   - patch
+  - create
+  - get
+  - list
+  - update
+  - delete
+  # To use kubectl apply on resources that already exist
+  - patch
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
   resourceNames: ["calico-hostendpoint-controller-psp"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-hostendpoint-controller-role-binding

--- a/assets/charts/control-plane/calico-host-protection/templates/host-endpoint-controller.yaml
+++ b/assets/charts/control-plane/calico-host-protection/templates/host-endpoint-controller.yaml
@@ -33,6 +33,10 @@ spec:
       containers:
       - image: quay.io/kinvolk/calico-hostendpoint-controller:v0.0.4
         name: calico-hostendpoint-controller
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+          runAsGroup: 65534
         volumeMounts:
         - mountPath: /tmp/
           name: tmp-dir
@@ -61,6 +65,10 @@ rules:
    - delete
    # To use kubectl apply on resources that already exist
    - patch
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames: ["calico-hostendpoint-controller-psp"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/assets/charts/control-plane/calico-host-protection/templates/psp.yaml
+++ b/assets/charts/control-plane/calico-host-protection/templates/psp.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  name: calico-hostendpoint-controller-psp
+spec:
+  privileged: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - emptyDir
+  - secret

--- a/test/platform/packet/packet_test.go
+++ b/test/platform/packet/packet_test.go
@@ -98,3 +98,22 @@ func TestWhenBGPIsNotDisabledInConfigurationServersHasBGPSessionCreated(t *testi
 		t.Fatalf("Worker pool with BGP not disabled should have at least one BGP session")
 	}
 }
+
+func TestCalicoHostEndpointControllerRunsWithDedicatedPSP(t *testing.T) {
+	client := testutil.CreateKubeClient(t)
+	labelSelector := "app=calico-hostendpoint-controller"
+	expectedAnnotation := "calico-hostendpoint-controller-psp"
+
+	pods, err := client.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		t.Fatalf("Listing pods with label %q: %v", labelSelector, err)
+	}
+
+	for _, v := range pods.Items {
+		if v.Annotations["kubernetes.io/psp"] != expectedAnnotation {
+			t.Fatalf("Pod: %s annotation expected: %s got: %s", v.Name, expectedAnnotation, v.Annotations["kubernetes.io/psp"])
+		}
+	}
+}


### PR DESCRIPTION
Calico host endpoint controller only needs to talk to the apiserver and
should not be granted privileged PSP.

Update deprecated apiVersion for clusterrole and clusterrolebinding.

closes: #287
Signed-off-by: knrt10 <kautilya@kinvolk.io>

