### PR TITLE
deploy-cluster: Don't create ssh key for tinkerbell

### DIFF
--- a/ci/scripts/deploy-cluster.sh
+++ b/ci/scripts/deploy-cluster.sh
@@ -44,7 +44,7 @@ best_location_for_instance_type() {
 
 # =======================================================================
 
-if [ "${platform}" != baremetal ] && [ "${platform}" != "kvm-libvirt" ]; then
+if [ "${platform}" != baremetal ] && [ "${platform}" != "kvm-libvirt" ] && [ "${platform}" != "tinkerbell" ]; then
   # Generate SSH key pair to be used by lokoctl.
   log "Generating SSH key pair for lokoctl"
   ssh-keygen -f ~/.ssh/id_rsa -N ''


### PR DESCRIPTION
This commit adds a check to disable ssh key creation when the platform
is tinkerbell. This is a regressions introduced since moving from ci
based script that created clusters vs the script in lokomotive repo that
creates a cluster.

Without this code the pipeline stays stuck in interactive y/n question to overwrite the key.