### PR TITLE
fix labels and taints with spaced value for packet, aws, tinkerbell

### DIFF
--- a/pkg/platform/aws/aws_internal_test.go
+++ b/pkg/platform/aws/aws_internal_test.go
@@ -222,3 +222,31 @@ func TestConfigurationIsValidWhen(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckWorkerPoolLabelsWithSpacedValue(t *testing.T) {
+	c := config{
+		WorkerPools: []workerPool{
+			{
+				Labels: map[string]string{"foo-1": "bar "},
+			},
+		},
+	}
+
+	if d := c.checkWorkerPoolLabelsAndTaints(); !d.HasErrors() {
+		t.Error("Should fail with space in worker pool labels")
+	}
+}
+
+func TestCheckWorkerPoolTaintsWithSpacedValue(t *testing.T) {
+	c := config{
+		WorkerPools: []workerPool{
+			{
+				Taints: map[string]string{"foo-1": "bar "},
+			},
+		},
+	}
+
+	if d := c.checkWorkerPoolLabelsAndTaints(); !d.HasErrors() {
+		t.Error("Should fail with space in worker pool taints")
+	}
+}

--- a/pkg/platform/packet/packet_test.go
+++ b/pkg/platform/packet/packet_test.go
@@ -355,3 +355,31 @@ func TestTerraformAddDeps(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckWorkerPoolLabelsWithSpacedValue(t *testing.T) {
+	c := config{
+		WorkerPools: []workerPool{
+			{
+				Labels: map[string]string{"foo-1": "bar "},
+			},
+		},
+	}
+
+	if d := c.checkWorkerPoolLabelsAndTaints(); !d.HasErrors() {
+		t.Error("Should fail with space in worker pool labels")
+	}
+}
+
+func TestCheckWorkerPoolTaintsWithSpacedValue(t *testing.T) {
+	c := config{
+		WorkerPools: []workerPool{
+			{
+				Taints: map[string]string{"foo-1": "bar "},
+			},
+		},
+	}
+
+	if d := c.checkWorkerPoolLabelsAndTaints(); !d.HasErrors() {
+		t.Error("Should fail with space in worker pool taints")
+	}
+}

--- a/pkg/platform/tinkerbell/tinkerbell_test.go
+++ b/pkg/platform/tinkerbell/tinkerbell_test.go
@@ -244,3 +244,31 @@ func TestMeta(t *testing.T) {
 		t.Errorf("Expected %d nodes, got %d", expectedNodes, m.ExpectedNodes)
 	}
 }
+
+func TestCheckWorkerPoolLabelsWithSpacedValue(t *testing.T) {
+	c := &tinkerbell.Config{
+		WorkerPools: []tinkerbell.WorkerPool{
+			{
+				Labels: map[string]string{"foo-1": "bar "},
+			},
+		},
+	}
+
+	if d := c.CheckWorkerPoolLabelsAndTaints(); !d.HasErrors() {
+		t.Error("Should fail with space in worker pool labels")
+	}
+}
+
+func TestCheckWorkerPoolTaintsWithSpacedValue(t *testing.T) {
+	c := &tinkerbell.Config{
+		WorkerPools: []tinkerbell.WorkerPool{
+			{
+				Taints: map[string]string{"foo-1": "bar "},
+			},
+		},
+	}
+
+	if d := c.CheckWorkerPoolLabelsAndTaints(); !d.HasErrors() {
+		t.Error("Should fail with space in worker pool taints")
+	}
+}


### PR DESCRIPTION
Now user cannot have spaced key or value in labels, taints map for worker pools.
Add tests.

closes:   #1280