### PR TITLE
etcd - ETCD_ env var prefix for standard vars only

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -22,11 +22,11 @@ systemd:
           --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
-          -u $(id -u \"$${ETCD_USER}\"):$(id -u \"$${ETCD_USER}\") \
+          -u $(id -u \"$${USER}\"):$(id -u \"$${USER}\") \
           -v $${ETCD_DATA_DIR}:$${ETCD_DATA_DIR}:rw \
-          -v $${ETCD_SSL_DIR}:$${ETCD_SSL_DIR}:ro \
+          -v $${SSL_DIR}:$${SSL_DIR}:ro \
           --env-file /etc/kubernetes/etcd.env \
-          $${ETCD_IMAGE_URL}:$${ETCD_IMAGE_TAG}"
+          $${IMAGE_URL}:$${IMAGE_TAG}"
         ExecStart=docker logs -f etcd
         ExecStop=docker stop etcd
         ExecStopPost=docker rm etcd
@@ -147,11 +147,11 @@ storage:
       mode: 0644
       contents:
         inline: |
-          ETCD_IMAGE_TAG=v3.4.14
-          ETCD_IMAGE_URL=quay.io/coreos/etcd
-          ETCD_SSL_DIR=/etc/ssl/etcd
+          IMAGE_TAG=v3.4.14
+          IMAGE_URL=quay.io/coreos/etcd
+          SSL_DIR=/etc/ssl/etcd
+          USER=etcd
           ETCD_DATA_DIR=/var/lib/etcd
-          ETCD_USER=etcd
           ETCD_NAME=${etcd_name}
           ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379
           ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,9 +7,10 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.4.14"
-            Environment="ETCD_IMAGE_URL=docker://quay.io/coreos/etcd"
+            Environment="IMAGE_TAG=v3.4.14"
+            Environment="IMAGE_URL=docker://quay.io/coreos/etcd"
             Environment="RKT_RUN_ARGS=--insecure-options=image"
+            Environment="SSL_DIR=/etc/ssl/etcd"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"
@@ -18,7 +19,6 @@ systemd:
             Environment="ETCD_LISTEN_METRICS_URLS=http://0.0.0.0:2381"
             Environment="ETCD_INITIAL_CLUSTER=${etcd_initial_cluster}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
-            Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
             Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/server-ca.crt"
             Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd/server.crt"
             Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd/server.key"

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -22,11 +22,11 @@ systemd:
           --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
-          -u $(id -u \"$${ETCD_USER}\"):$(id -u \"$${ETCD_USER}\") \
+          -u $(id -u \"$${USER}\"):$(id -u \"$${USER}\") \
           -v $${ETCD_DATA_DIR}:$${ETCD_DATA_DIR}:rw \
-          -v $${ETCD_SSL_DIR}:$${ETCD_SSL_DIR}:ro \
+          -v $${SSL_DIR}:$${SSL_DIR}:ro \
           --env-file /etc/kubernetes/etcd.env \
-          $${ETCD_IMAGE_URL}:$${ETCD_IMAGE_TAG}"
+          $${IMAGE_URL}:$${IMAGE_TAG}"
         ExecStart=docker logs -f etcd
         ExecStop=docker stop etcd
         ExecStopPost=docker rm etcd
@@ -152,11 +152,11 @@ storage:
       mode: 0644
       contents:
         inline: |
-          ETCD_IMAGE_TAG=v3.4.14
-          ETCD_IMAGE_URL=quay.io/coreos/etcd
-          ETCD_SSL_DIR=/etc/ssl/etcd
+          IMAGE_TAG=v3.4.14
+          IMAGE_URL=quay.io/coreos/etcd
+          SSL_DIR=/etc/ssl/etcd
+          USER=etcd
           ETCD_DATA_DIR=/var/lib/etcd
-          ETCD_USER=etcd
           ETCD_NAME=${etcd_name}
           ETCD_ADVERTISE_CLIENT_URLS=https://${domain_name}:2379
           ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${domain_name}:2380

--- a/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
+++ b/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
@@ -27,11 +27,11 @@ systemd:
           --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
-          -u $(id -u \"$${ETCD_USER}\"):$(id -u \"$${ETCD_USER}\") \
+          -u $(id -u \"$${USER}\"):$(id -u \"$${USER}\") \
           -v $${ETCD_DATA_DIR}:$${ETCD_DATA_DIR}:rw \
-          -v $${ETCD_SSL_DIR}:$${ETCD_SSL_DIR}:ro \
+          -v $${SSL_DIR}:$${SSL_DIR}:ro \
           --env-file /etc/kubernetes/etcd.env \
-          $${ETCD_IMAGE_URL}:$${ETCD_IMAGE_TAG}"
+          $${IMAGE_URL}:$${IMAGE_TAG}"
         ExecStart=docker logs -f etcd
         ExecStop=docker stop etcd
         ExecStopPost=docker rm etcd
@@ -45,11 +45,11 @@ storage:
       mode: 0644
       contents:
         inline: |
-          ETCD_IMAGE_TAG=v3.4.14
-          ETCD_IMAGE_URL=quay.io/coreos/etcd
-          ETCD_SSL_DIR=/etc/ssl/etcd
+          IMAGE_TAG=v3.4.14
+          IMAGE_URL=quay.io/coreos/etcd
+          SSL_DIR=/etc/ssl/etcd
+          USER=etcd
           ETCD_DATA_DIR=/var/lib/etcd
-          ETCD_USER=etcd
           ETCD_NAME=${etcd_name}
           ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379
           ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,9 +7,10 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.4.14"
-            Environment="ETCD_IMAGE_URL=docker://quay.io/coreos/etcd"
+            Environment="IMAGE_TAG=v3.4.14"
+            Environment="IMAGE_URL=docker://quay.io/coreos/etcd"
             Environment="RKT_RUN_ARGS=--insecure-options=image"
+            Environment="SSL_DIR=/etc/ssl/etcd"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"
@@ -18,7 +19,6 @@ systemd:
             Environment="ETCD_LISTEN_METRICS_URLS=http://0.0.0.0:2381"
             Environment="ETCD_INITIAL_CLUSTER=${etcd_initial_cluster}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
-            Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
             Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/server-ca.crt"
             Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd/server.crt"
             Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd/server.key"

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,9 +7,10 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.4.14"
-            Environment="ETCD_IMAGE_URL=docker://quay.io/coreos/etcd"
+            Environment="IMAGE_TAG=v3.4.14"
+            Environment="IMAGE_URL=docker://quay.io/coreos/etcd"
             Environment="RKT_RUN_ARGS=--insecure-options=image"
+            Environment="SSL_DIR=/etc/ssl/etcd"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"
@@ -18,7 +19,6 @@ systemd:
             Environment="ETCD_LISTEN_METRICS_URLS=http://0.0.0.0:2381"
             Environment="ETCD_INITIAL_CLUSTER=${etcd_initial_cluster}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
-            Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
             Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/server-ca.crt"
             Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd/server.crt"
             Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd/server.key"

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -24,11 +24,11 @@ systemd:
           --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
-          -u $(id -u \"$${ETCD_USER}\"):$(id -u \"$${ETCD_USER}\") \
+          -u $(id -u \"$${USER}\"):$(id -u \"$${USER}\") \
           -v $${ETCD_DATA_DIR}:$${ETCD_DATA_DIR}:rw \
-          -v $${ETCD_SSL_DIR}:$${ETCD_SSL_DIR}:ro \
+          -v $${SSL_DIR}:$${SSL_DIR}:ro \
           --env-file /etc/kubernetes/etcd.env \
-          $${ETCD_IMAGE_URL}:$${ETCD_IMAGE_TAG}"
+          $${IMAGE_URL}:$${IMAGE_TAG}"
         ExecStart=docker logs -f etcd
         ExecStop=docker stop etcd
         ExecStopPost=docker rm etcd
@@ -198,11 +198,11 @@ storage:
       mode: 0644
       contents:
         inline: |
-          ETCD_IMAGE_TAG=v3.4.14${etcd_arch_tag_suffix}
-          ETCD_IMAGE_URL=quay.io/coreos/etcd
-          ETCD_SSL_DIR=/etc/ssl/etcd
+          IMAGE_TAG=v3.4.14${etcd_arch_tag_suffix}
+          IMAGE_URL=quay.io/coreos/etcd
+          SSL_DIR=/etc/ssl/etcd
+          USER=etcd
           ETCD_DATA_DIR=/var/lib/etcd
-          ETCD_USER=etcd
           ETCD_NAME=${etcd_name}
           ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379
           ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380

--- a/docs/how-to-guides/update-etcd.md
+++ b/docs/how-to-guides/update-etcd.md
@@ -47,7 +47,7 @@ Run the following commands:
 ```bash
 export etcd_version=<latest etcd version e.g. v3.4.10>
 
-sudo sed -i "s,ETCD_IMAGE_TAG=.*,ETCD_IMAGE_TAG=${etcd_version}\"," \
+sudo sed -i "s,IMAGE_TAG=.*,IMAGE_TAG=${etcd_version}\"," \
         /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf
 sudo systemctl daemon-reload
 sudo systemctl restart etcd-member

--- a/scripts/find-updates.sh
+++ b/scripts/find-updates.sh
@@ -43,7 +43,7 @@ printf "${format}" "calico" "${current_version}" "${version}"
 
 ###########################
 # etcd
-current_version=$(grep 'ETCD_IMAGE_TAG=' assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl | cut -d"=" -f2 | sed 's/"//g')
+current_version=$(grep 'IMAGE_TAG=' assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl | cut -d"=" -f2 | sed 's/"//g')
 
 get_latest_release etcd-io/etcd
 printf "${format}" "etcd" "${current_version}" "${version}"

--- a/test/system/etcd_env_vars_test.go
+++ b/test/system/etcd_env_vars_test.go
@@ -1,0 +1,94 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build packet,baremetal
+// +build e2e
+
+//nolint:dupl
+package system_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	testutil "github.com/kinvolk/lokomotive/test/components/util"
+)
+
+// etcd parses environment variables prefixed with ETCD_ and will log a
+// warning if any variables exist that it doesn't explicitly support.
+const unrecognizedEnvVarString = "unrecognized environment variable"
+
+// Define manifest as YAML and then unmarshal it to a Go struct so that it is easier to
+// write and debug, as it can be copy-pasted to a file and applied manually.
+const etcdEnvVarsDSManifest = `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generateName: test-etcd-env-vars-
+spec:
+  selector:
+    matchLabels:
+      name: test-etcd-env-vars
+  template:
+    metadata:
+      labels:
+        name: test-etcd-env-vars
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: test-etcd-env-vars
+        image: ubuntu
+        command: ["bash"]
+`
+
+func TestEtcdEnvVarsAreAllRecognizedOnAllNodes(t *testing.T) {
+	t.Parallel()
+
+	namespace := "kube-system"
+
+	client := testutil.CreateKubeClient(t)
+
+	ds := &appsv1.DaemonSet{}
+	if err := yaml.Unmarshal([]byte(etcdEnvVarsDSManifest), ds); err != nil {
+		t.Fatalf("failed unmarshaling manifest: %v", err)
+	}
+
+	// Set the right arguments from the manifest with the correct fileName.
+	ds.Spec.Template.Spec.Containers[0].Args = []string{
+		"-c",
+		fmt.Sprintf("test 0 -eq $(journalctl -u etcd.service -q -g '%s' | wc -l) && exec tail -f /dev/null",
+			unrecognizedEnvVarString),
+	}
+
+	ds, err := client.AppsV1().DaemonSets(namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create DaemonSet: %v", err)
+	}
+
+	testutil.WaitForDaemonSet(t, client, namespace, ds.ObjectMeta.Name, testutil.RetryInterval, testutil.Timeout)
+
+	t.Cleanup(func() {
+		if err := client.AppsV1().DaemonSets(namespace).Delete(
+			context.TODO(), ds.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("failed to remove DaemonSet: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #1065 

etcd parses all environment variables beginning with `ETCD_` by default and warns if any variables matching this pattern exist that it doesn't explicitly support.

This PR drops the `ETCD_` prefix for custom environment variables and group these vars together at top of file.

There doesn't appear to be any variable collisions in the files with the new names. For example, `kubelet` env vars are prefixed `KUBELET_`.

# How to use

- build PR
- provision lokomotive on any supported platform

# Testing done

Provision Lokomotive using bare-metal guide on libvirt host.
Wait for etcd to start up and check logs for warnings, finding none.

Log output:
```

Jan 10 03:27:03 k8s-m-amd64-00.k8s.example.com sh[1070]: Status: Downloaded newer image for quay.io/coreos/etcd:v3.4.13
Jan 10 03:27:11 k8s-m-amd64-00.k8s.example.com sh[1070]: 76d58d741b75d030ee644cf2042782d29f40b189a2f36ebd4777743284701ebc
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com systemd[1]: Started etcd (System Application Container).
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538058 I | pkg/flags: recognized and used environment variable ETCD_ADVERTISE_CLIENT_URLS=https://k8s-m-amd64-00.k8s.example.com:2379
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538112 I | pkg/flags: recognized and used environment variable ETCD_CERT_FILE=/etc/ssl/etcd/etcd/server.crt
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538122 I | pkg/flags: recognized and used environment variable ETCD_CLIENT_CERT_AUTH=true
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538130 I | pkg/flags: recognized and used environment variable ETCD_DATA_DIR=/var/lib/etcd
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538150 I | pkg/flags: recognized and used environment variable ETCD_INITIAL_ADVERTISE_PEER_URLS=https://k8s-m-amd64-00.k8s.example.com:2380
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538156 I | pkg/flags: recognized and used environment variable ETCD_INITIAL_CLUSTER=k8s-m-amd64-00=https://k8s-m-amd64-00.k8s.example.com:2380,k8s-m-amd64-01=https://k8s-m-amd64-01.k8s.example.com:2380,k8s-m-amd64-02=https://k8s-m-amd64-02.k8s.example.com:2380
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538163 I | pkg/flags: recognized and used environment variable ETCD_KEY_FILE=/etc/ssl/etcd/etcd/server.key
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538169 I | pkg/flags: recognized and used environment variable ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538176 I | pkg/flags: recognized and used environment variable ETCD_LISTEN_METRICS_URLS=http://0.0.0.0:2381
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538182 I | pkg/flags: recognized and used environment variable ETCD_LISTEN_PEER_URLS=https://0.0.0.0:2380
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538192 I | pkg/flags: recognized and used environment variable ETCD_NAME=k8s-m-amd64-00
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538198 I | pkg/flags: recognized and used environment variable ETCD_PEER_CERT_FILE=/etc/ssl/etcd/etcd/peer.crt
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538231 I | pkg/flags: recognized and used environment variable ETCD_PEER_CLIENT_CERT_AUTH=true
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538240 I | pkg/flags: recognized and used environment variable ETCD_PEER_KEY_FILE=/etc/ssl/etcd/etcd/peer.key
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538245 I | pkg/flags: recognized and used environment variable ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/etcd/etcd/peer-ca.crt
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538254 I | pkg/flags: recognized and used environment variable ETCD_STRICT_RECONFIG_CHECK=true
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538277 I | pkg/flags: recognized and used environment variable ETCD_TRUSTED_CA_FILE=/etc/ssl/etcd/etcd/server-ca.crt
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: [WARNING] Deprecated '--logger=capnslog' flag is set; use '--logger=zap' flag instead
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538316 I | etcdmain: etcd Version: 3.4.13
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538333 I | etcdmain: Git SHA: ae9734ed2
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538337 I | etcdmain: Go Version: go1.12.17
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538341 I | etcdmain: Go OS/Arch: linux/amd64
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: 2021-01-10 03:27:16.538344 I | etcdmain: setting maximum number of CPUs to 1, total number of available CPUs is 1
Jan 10 03:27:17 k8s-m-amd64-00.k8s.example.com docker[1227]: [WARNING] Deprecated '--logger=capnslog' flag is set; use '--logger=zap' flag instead
```