### PR TITLE
etcd - update image to 3.4.14

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -147,7 +147,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          ETCD_IMAGE_TAG=v3.4.13
+          ETCD_IMAGE_TAG=v3.4.14
           ETCD_IMAGE_URL=quay.io/coreos/etcd
           ETCD_SSL_DIR=/etc/ssl/etcd
           ETCD_DATA_DIR=/var/lib/etcd

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.4.13"
+            Environment="ETCD_IMAGE_TAG=v3.4.14"
             Environment="ETCD_IMAGE_URL=docker://quay.io/coreos/etcd"
             Environment="RKT_RUN_ARGS=--insecure-options=image"
             Environment="ETCD_NAME=${etcd_name}"

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -152,7 +152,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          ETCD_IMAGE_TAG=v3.4.13
+          ETCD_IMAGE_TAG=v3.4.14
           ETCD_IMAGE_URL=quay.io/coreos/etcd
           ETCD_SSL_DIR=/etc/ssl/etcd
           ETCD_DATA_DIR=/var/lib/etcd

--- a/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
+++ b/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
@@ -45,7 +45,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          ETCD_IMAGE_TAG=v3.4.13
+          ETCD_IMAGE_TAG=v3.4.14
           ETCD_IMAGE_URL=quay.io/coreos/etcd
           ETCD_SSL_DIR=/etc/ssl/etcd
           ETCD_DATA_DIR=/var/lib/etcd

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.4.13"
+            Environment="ETCD_IMAGE_TAG=v3.4.14"
             Environment="ETCD_IMAGE_URL=docker://quay.io/coreos/etcd"
             Environment="RKT_RUN_ARGS=--insecure-options=image"
             Environment="ETCD_NAME=${etcd_name}"

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.4.13"
+            Environment="ETCD_IMAGE_TAG=v3.4.14"
             Environment="ETCD_IMAGE_URL=docker://quay.io/coreos/etcd"
             Environment="RKT_RUN_ARGS=--insecure-options=image"
             Environment="ETCD_NAME=${etcd_name}"

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -198,7 +198,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          ETCD_IMAGE_TAG=v3.4.13${etcd_arch_tag_suffix}
+          ETCD_IMAGE_TAG=v3.4.14${etcd_arch_tag_suffix}
           ETCD_IMAGE_URL=quay.io/coreos/etcd
           ETCD_SSL_DIR=/etc/ssl/etcd
           ETCD_DATA_DIR=/var/lib/etcd


### PR DESCRIPTION
# Update etcd to latest release 3.4.14

Closes #1293 

Changelog looks safe - https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.4.md

# How to use

build and provision cluster on supported platform

# Testing done

provision bare-metal cluster on libvirt, etcd starts up ok.
```
Jan 10 04:49:20 k8s-m-amd64-00.k8s.example.com sh[1069]: Status: Downloaded newer image for quay.io/coreos/etcd:v3.4.14
Jan 10 04:49:24 k8s-m-amd64-00.k8s.example.com sh[1069]: 9a7cff99dbf2aad5e95cb6722d00c094861c6d69967b5e1c3f91288a6eb4c285
Jan 10 04:49:27 k8s-m-amd64-00.k8s.example.com systemd[1]: Started etcd (System Application Container).
<snip>
```

