### PR TITLE
Add VMware VSphere platform

### DIFF
--- a/assets/terraform-modules/platforms/vmware/controllers/bootkube.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/bootkube.tf
@@ -1,0 +1,30 @@
+locals {
+  api_servers = format("%s-private.%s", var.cluster_name, var.dns_zone)
+}
+
+# Self-hosted Kubernetes assets (kubeconfig, manifests).
+module "bootkube" {
+  source = "../../../bootkube"
+
+  cluster_name = var.cluster_name
+
+  api_servers          = [local.api_servers]
+  api_servers_external = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  api_servers_ips      = var.nodes_ips
+  etcd_servers         = module.controller[0].etcd_servers
+
+  asset_dir             = var.asset_dir
+  network_mtu           = var.network_mtu
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
+
+  certs_validity_period_hours = var.certs_validity_period_hours
+
+  bootstrap_tokens            = concat(module.controller.*.bootstrap_token, var.worker_bootstrap_tokens)
+  enable_tls_bootstrap        = true
+  disable_self_hosted_kubelet = false
+  conntrack_max_per_core      = var.conntrack_max_per_core
+}

--- a/assets/terraform-modules/platforms/vmware/controllers/data.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/data.tf
@@ -1,0 +1,23 @@
+data "vsphere_datacenter" "main" {
+  name = var.datacenter
+}
+
+data "vsphere_datastore" "main" {
+  name          = var.datastore
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_compute_cluster" "main" {
+  name          = var.compute_cluster
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_network" "main" {
+  name          = var.network
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_virtual_machine" "main_template" {
+  name          = var.template
+  datacenter_id = data.vsphere_datacenter.main.id
+}

--- a/assets/terraform-modules/platforms/vmware/controllers/main.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/main.tf
@@ -87,7 +87,7 @@ resource "vsphere_virtual_machine" "main" {
   }
 
   // Advanced options
-  nested_hv_enabled  = var.nested_hv_enabled
+  nested_hv_enabled = var.nested_hv_enabled
 
   depends_on = [
     vsphere_folder.main

--- a/assets/terraform-modules/platforms/vmware/controllers/main.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/main.tf
@@ -1,0 +1,98 @@
+locals {
+  nodes_mask = split("/", var.hosts_cidr)[1]
+  nodes_gw   = cidrhost(var.hosts_cidr, 1)
+}
+
+module "controller" {
+  source = "../../../controller"
+
+  count = var.node_count
+
+  cluster_name           = var.cluster_name
+  controllers_count      = var.node_count
+  dns_zone               = var.dns_zone
+  count_index            = count.index
+  cluster_dns_service_ip = module.bootkube.cluster_dns_service_ip
+  ssh_keys               = var.ssh_keys
+  cluster_domain_suffix  = var.cluster_domain_suffix
+  host_dns_ip            = var.host_dns_ip
+  apiserver              = format("%s.%s", var.cluster_name, var.dns_zone)
+  ca_cert                = module.bootkube.ca_cert
+
+  clc_snippets = concat(var.clc_snippets, [
+    <<EOF
+storage:
+  files:
+  - path: /etc/hostname
+    filesystem: root
+    mode: 0644
+    contents:
+      inline: |
+        ${var.cluster_name}-controller-${count.index}
+EOF
+    ,
+    <<EOF
+networkd:
+  units:
+  - name: 00-ens192.network
+    contents: |
+      [Match]
+      Name=ens192
+
+      [Network]
+      Address=${var.nodes_ips[count.index]}/${local.nodes_mask}
+      Gateway=${local.nodes_gw}
+      %{~for dns in var.dns_servers~}
+      DNS=${dns}
+      %{~endfor~}
+EOF
+    ,
+    ],
+  )
+}
+
+resource "vsphere_folder" "main" {
+  path          = var.folder
+  type          = "vm"
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+resource "vsphere_virtual_machine" "main" {
+  count = var.node_count
+
+  name             = format("%s-controller-%s", var.cluster_name, count.index)
+  resource_pool_id = data.vsphere_compute_cluster.main.resource_pool_id
+  datastore_id     = data.vsphere_datastore.main.id
+  folder           = var.folder
+
+  num_cpus = var.cpus_count
+  memory   = var.memory
+
+  # https://code.vmware.com/apis/358/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
+  #
+  guest_id = "other3xLinux64Guest"
+
+  network_interface {
+    network_id = data.vsphere_network.main.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_size
+    eagerly_scrub    = data.vsphere_virtual_machine.main_template.disks[0].eagerly_scrub
+    thin_provisioned = data.vsphere_virtual_machine.main_template.disks[0].thin_provisioned
+  }
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.main_template.id
+  }
+
+  extra_config = {
+    "guestinfo.ignition.config.data.encoding" = "base64"
+    "guestinfo.ignition.config.data"          = base64encode(module.controller[count.index].clc_config)
+  }
+
+  depends_on = [
+    vsphere_folder.main
+  ]
+}

--- a/assets/terraform-modules/platforms/vmware/controllers/main.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/main.tf
@@ -89,6 +89,12 @@ resource "vsphere_virtual_machine" "main" {
   // Advanced options
   nested_hv_enabled = var.nested_hv_enabled
 
+  lifecycle {
+    ignore_changes = [
+      extra_config["guestinfo.ignition.config.data"]
+    ]
+  }
+
   depends_on = [
     vsphere_folder.main
   ]

--- a/assets/terraform-modules/platforms/vmware/controllers/main.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/main.tf
@@ -42,9 +42,6 @@ networkd:
       [Network]
       Address=${var.nodes_ips[count.index]}/${local.nodes_mask}
       Gateway=${local.nodes_gw}
-      %{~for dns in var.dns_servers~}
-      DNS=${dns}
-      %{~endfor~}
 EOF
     ,
     ],
@@ -67,10 +64,7 @@ resource "vsphere_virtual_machine" "main" {
 
   num_cpus = var.cpus_count
   memory   = var.memory
-
-  # https://code.vmware.com/apis/358/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
-  #
-  guest_id = "other3xLinux64Guest"
+  guest_id = data.vsphere_virtual_machine.main_template.guest_id
 
   network_interface {
     network_id = data.vsphere_network.main.id

--- a/assets/terraform-modules/platforms/vmware/controllers/main.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/main.tf
@@ -86,6 +86,9 @@ resource "vsphere_virtual_machine" "main" {
     "guestinfo.ignition.config.data"          = base64encode(module.controller[count.index].clc_config)
   }
 
+  // Advanced options
+  nested_hv_enabled  = var.nested_hv_enabled
+
   depends_on = [
     vsphere_folder.main
   ]

--- a/assets/terraform-modules/platforms/vmware/controllers/outputs.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/outputs.tf
@@ -1,0 +1,52 @@
+output "kubeconfig-admin" {
+  value = module.bootkube.kubeconfig-admin
+}
+
+output "ca_cert" {
+  value = module.bootkube.ca_cert
+}
+
+output "apiserver" {
+  value = format("%s.%s", var.cluster_name, var.dns_zone)
+}
+
+# values.yaml content for all deployed charts.
+output "pod-checkpointer_values" {
+  value = module.bootkube.pod-checkpointer_values
+}
+
+output "kube-apiserver_values" {
+  value = module.bootkube.kube-apiserver_values
+}
+
+output "kubernetes_values" {
+  value = module.bootkube.kubernetes_values
+}
+
+output "kubelet_values" {
+  value = module.bootkube.kubelet_values
+}
+
+output "calico_values" {
+  value = module.bootkube.calico_values
+}
+
+output "lokomotive_values" {
+  value = module.bootkube.lokomotive_values
+}
+
+output "bootstrap-secrets_values" {
+  value = module.bootkube.bootstrap-secrets_values
+}
+
+output "kubeconfig" {
+  value = module.bootkube.kubeconfig-kubelet
+}
+
+output "cluster_dns_service_ip" {
+  value = module.bootkube.cluster_dns_service_ip
+}
+
+output "controllers_private_ipv4" {
+  value = vsphere_virtual_machine.main.*.default_ip_address
+}

--- a/assets/terraform-modules/platforms/vmware/controllers/ssh.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/ssh.tf
@@ -1,0 +1,100 @@
+# Secure copy etcd TLS assets and kubeconfig to controllers. Activates 'kubelet.service'.
+resource "null_resource" "copy-controller-secrets" {
+  count = var.node_count
+
+  connection {
+    type    = "ssh"
+    host    = vsphere_virtual_machine.main[count.index].default_ip_address
+    user    = "core"
+    timeout = "60m"
+  }
+
+  provisioner "file" {
+    content     = module.controller[count.index].bootstrap_kubeconfig
+    destination = "$HOME/kubeconfig"
+  }
+
+  provisioner "file" {
+    content     = module.bootkube.etcd_ca_cert
+    destination = "$HOME/etcd-client-ca.crt"
+  }
+
+  provisioner "file" {
+    content     = module.bootkube.etcd_client_cert
+    destination = "$HOME/etcd-client.crt"
+  }
+
+  provisioner "file" {
+    content     = module.bootkube.etcd_client_key
+    destination = "$HOME/etcd-client.key"
+  }
+
+  provisioner "file" {
+    content     = module.bootkube.etcd_server_cert
+    destination = "$HOME/etcd-server.crt"
+  }
+
+  provisioner "file" {
+    content     = module.bootkube.etcd_server_key
+    destination = "$HOME/etcd-server.key"
+  }
+
+  provisioner "file" {
+    content     = module.bootkube.etcd_peer_cert
+    destination = "$HOME/etcd-peer.crt"
+  }
+
+  provisioner "file" {
+    content     = module.bootkube.etcd_peer_key
+    destination = "$HOME/etcd-peer.key"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /etc/ssl/etcd/etcd",
+      "sudo mv etcd-client* /etc/ssl/etcd/",
+      "sudo cp /etc/ssl/etcd/etcd-client-ca.crt /etc/ssl/etcd/etcd/server-ca.crt",
+      "sudo mv etcd-server.crt /etc/ssl/etcd/etcd/server.crt",
+      "sudo mv etcd-server.key /etc/ssl/etcd/etcd/server.key",
+      "sudo cp /etc/ssl/etcd/etcd-client-ca.crt /etc/ssl/etcd/etcd/peer-ca.crt",
+      "sudo mv etcd-peer.crt /etc/ssl/etcd/etcd/peer.crt",
+      "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
+      "sudo chown -R etcd:etcd /etc/ssl/etcd",
+      "sudo chmod -R 500 /etc/ssl/etcd",
+      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+    ]
+  }
+}
+
+# Secure copy bootkube assets to ONE controller and start bootkube to perform
+# one-time self-hosted cluster bootstrapping.
+resource "null_resource" "bootkube-start" {
+  # Without depends_on, this remote-exec may start before the kubeconfig copy.
+  # Terraform only does one task at a time, so it would try to bootstrap
+  # while no Kubelets are running.
+  depends_on = [
+    null_resource.copy-controller-secrets,
+  ]
+
+  connection {
+    type    = "ssh"
+    host    = vsphere_virtual_machine.main[0].default_ip_address
+    user    = "core"
+    timeout = "15m"
+  }
+
+  provisioner "file" {
+    source      = var.asset_dir
+    destination = "$HOME/assets"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv $HOME/assets /opt/bootkube",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl start bootkube || (stdbuf -i0 -o0 -e0 sudo journalctl -u bootkube --no-pager; exit 1)",
+    ]
+  }
+}

--- a/assets/terraform-modules/platforms/vmware/controllers/variables.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/variables.tf
@@ -154,9 +154,3 @@ variable "host_dns_ip" {
   description = "IP address of DNS server to configure on the nodes."
   default     = "8.8.8.8"
 }
-
-variable "dns_servers" {
-  type        = list(string)
-  description = "DNS servers for the network interface."
-  default     = []
-}

--- a/assets/terraform-modules/platforms/vmware/controllers/variables.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/variables.tf
@@ -154,3 +154,9 @@ variable "host_dns_ip" {
   description = "IP address of DNS server to configure on the nodes."
   default     = "8.8.8.8"
 }
+
+variable "nested_hv_enabled" {
+  type        = bool
+  description = "Enable nested hardware virtualization on this virtual machine, facilitating nested virtualization in the guest."
+  default     = false
+}

--- a/assets/terraform-modules/platforms/vmware/controllers/variables.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/variables.tf
@@ -1,0 +1,162 @@
+# Required variables.
+variable "datacenter" {
+  type        = string
+  description = "The name of the VMware datacenter. This can be a name or path."
+}
+
+variable "datastore" {
+  type        = string
+  description = "The name of the VMware datastore. This can be a name or path."
+}
+
+variable "compute_cluster" {
+  type        = string
+  description = "The name of the VMware computer cluster used for the placement of the virtual machine."
+}
+
+variable "network" {
+  type        = string
+  description = "The name of the VMware network to connect the main interface to. This can be a name or path."
+}
+
+variable "template" {
+  type        = string
+  description = "The name of the VMware template used for the creation of the instance."
+}
+
+variable "nodes_ips" {
+  type        = list(string)
+  description = "IP addresses of the virtual machines."
+}
+
+variable "hosts_cidr" {
+  type        = string
+  description = "CIDR for all hosts."
+}
+
+variable "dns_zone" {
+  type        = string
+  description = "Domain name for the the cluster. E.g. 'example.com'"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Cluster identifier which will be used in controller node names."
+}
+
+variable "asset_dir" {
+  type        = string
+  description = "Path to a directory where generated assets should be placed (contains secrets)."
+}
+
+variable "worker_bootstrap_tokens" {
+  type = list(object({
+    token_id     = string
+    token_secret = string
+  }))
+  description = "List of token-id and token-secret of each node."
+}
+
+variable "conntrack_max_per_core" {
+  description = "--conntrack-max-per-core value for kube-proxy. Maximum number of NAT connections to track per CPU core (0 to leave the limit as-is and ignore the conntrack-min kube-proxy flag)."
+  type        = number
+}
+
+variable "node_count" {
+  type        = number
+  description = "Number of nodes to create."
+}
+
+# Optional variables.
+variable "folder" {
+  type        = string
+  description = "The path to the folder to put this virtual machine in, relative to the datacenter that the resource pool is in."
+  default     = ""
+}
+
+variable "cpus_count" {
+  type        = number
+  description = "The total number of virtual processor cores to assign to this virtual machine."
+  default     = 4
+}
+
+variable "memory" {
+  type        = number
+  description = "The size of the virtual machine's memory, in MB."
+  default     = 4096
+}
+
+variable "disk_size" {
+  type        = number
+  description = "The size of the virtual machine's disk, in GB."
+  default     = 30
+}
+
+variable "ssh_keys" {
+  type        = list(string)
+  description = "List of SSH public keys for user `core`. Each element must be specified in a valid OpenSSH public key format, as defined in RFC 4253 Section 6.6, e.g. 'ssh-rsa AAAAB3N...'."
+  default     = []
+}
+
+variable "clc_snippets" {
+  type        = list(string)
+  description = "Extra CLC snippets to include in the configuration."
+  default     = []
+}
+
+variable "cluster_domain_suffix" {
+  type        = string
+  description = "Cluster domain suffix. Passed to kubelet as --cluster_domain flag."
+  default     = "cluster.local"
+}
+
+variable "network_mtu" {
+  type        = number
+  description = "CNI interface MTU."
+  default     = 1500
+}
+
+variable "pod_cidr" {
+  type        = string
+  description = "CIDR IP range to assign Kubernetes pods."
+  default     = "10.2.0.0/16"
+}
+
+variable "service_cidr" {
+  type        = string
+  description = <<EOF
+CIDR IP range to assign Kubernetes services.
+The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for kube-dns.
+EOF
+  default     = "10.3.0.0/24"
+}
+
+variable "enable_reporting" {
+  type        = bool
+  description = "Enable usage or analytics reporting to upstream component owners (Tigera: Calico)."
+  default     = false
+}
+
+variable "certs_validity_period_hours" {
+  type        = number
+  description = "Validity of all the certificates in hours."
+  default     = 8760
+}
+
+variable "enable_aggregation" {
+  type        = bool
+  description = "Enable the Kubernetes Aggregation Layer (defaults to false, recommended)."
+  default     = true
+}
+
+variable "host_dns_ip" {
+  type        = string
+  description = "IP address of DNS server to configure on the nodes."
+  default     = "8.8.8.8"
+}
+
+variable "dns_servers" {
+  type        = list(string)
+  description = "DNS servers for the network interface."
+  default     = []
+}

--- a/assets/terraform-modules/platforms/vmware/controllers/versions.tf
+++ b/assets/terraform-modules/platforms/vmware/controllers/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.0.0"
+    }
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "1.24.3"
+    }
+  }
+}

--- a/assets/terraform-modules/platforms/vmware/workerpool/data.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/data.tf
@@ -1,0 +1,23 @@
+data "vsphere_datacenter" "main" {
+  name = var.datacenter
+}
+
+data "vsphere_datastore" "main" {
+  name          = var.datastore
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_compute_cluster" "main" {
+  name          = var.compute_cluster
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_network" "main" {
+  name          = var.network
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_virtual_machine" "main_template" {
+  name          = var.template
+  datacenter_id = data.vsphere_datacenter.main.id
+}

--- a/assets/terraform-modules/platforms/vmware/workerpool/main.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/main.tf
@@ -77,4 +77,7 @@ resource "vsphere_virtual_machine" "main" {
     "guestinfo.ignition.config.data.encoding" = "base64"
     "guestinfo.ignition.config.data"          = base64encode(module.worker[count.index].clc_config)
   }
+
+  // Advanced options
+  nested_hv_enabled  = var.nested_hv_enabled
 }

--- a/assets/terraform-modules/platforms/vmware/workerpool/main.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/main.tf
@@ -39,9 +39,6 @@ networkd:
       [Network]
       Address=${var.nodes_ips[count.index]}/${local.nodes_mask}
       Gateway=${local.nodes_gw}
-      %{~for dns in var.dns_servers~}
-      DNS=${dns}
-      %{~endfor~}
 EOF
     ,
     ],
@@ -59,10 +56,7 @@ resource "vsphere_virtual_machine" "main" {
 
   num_cpus = var.cpus_count
   memory   = var.memory
-
-  # https://code.vmware.com/apis/358/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
-  #
-  guest_id = "other3xLinux64Guest"
+  guest_id = data.vsphere_virtual_machine.main_template.guest_id
 
   network_interface {
     network_id = data.vsphere_network.main.id

--- a/assets/terraform-modules/platforms/vmware/workerpool/main.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/main.tf
@@ -1,0 +1,86 @@
+locals {
+  nodes_mask = split("/", var.hosts_cidr)[1]
+  nodes_gw   = cidrhost(var.hosts_cidr, 1)
+}
+
+module "worker" {
+  source = "../../../worker"
+
+  count       = var.node_count
+  count_index = count.index
+
+  cluster_dns_service_ip = var.cluster_dns_service_ip
+  ssh_keys               = var.ssh_keys
+  cluster_domain_suffix  = var.cluster_domain_suffix
+  host_dns_ip            = var.host_dns_ip
+  ca_cert                = var.ca_cert
+  apiserver              = var.apiserver
+
+  clc_snippets = concat(var.clc_snippets, [
+    <<EOF
+storage:
+  files:
+  - path: /etc/hostname
+    filesystem: root
+    mode: 0644
+    contents:
+      inline: |
+        ${var.cluster_name}-worker-${var.name}-${count.index}
+EOF
+    ,
+    <<EOF
+networkd:
+  units:
+  - name: 00-ens192.network
+    contents: |
+      [Match]
+      Name=ens192
+
+      [Network]
+      Address=${var.nodes_ips[count.index]}/${local.nodes_mask}
+      Gateway=${local.nodes_gw}
+      %{~for dns in var.dns_servers~}
+      DNS=${dns}
+      %{~endfor~}
+EOF
+    ,
+    ],
+  )
+}
+
+resource "vsphere_virtual_machine" "main" {
+  count = var.node_count
+
+  name             = "${var.cluster_name}-worker-${var.name}-${count.index}"
+  resource_pool_id = data.vsphere_compute_cluster.main.resource_pool_id
+  datastore_id     = data.vsphere_datastore.main.id
+  folder           = var.folder
+
+
+  num_cpus = var.cpus_count
+  memory   = var.memory
+
+  # https://code.vmware.com/apis/358/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
+  #
+  guest_id = "other3xLinux64Guest"
+
+  network_interface {
+    network_id = data.vsphere_network.main.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_size
+    eagerly_scrub    = data.vsphere_virtual_machine.main_template.disks[0].eagerly_scrub
+    thin_provisioned = data.vsphere_virtual_machine.main_template.disks[0].thin_provisioned
+  }
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.main_template.id
+  }
+
+  extra_config = {
+    "guestinfo.ignition.config.data.encoding" = "base64"
+    "guestinfo.ignition.config.data"          = base64encode(module.worker[count.index].clc_config)
+  }
+}

--- a/assets/terraform-modules/platforms/vmware/workerpool/main.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/main.tf
@@ -79,5 +79,5 @@ resource "vsphere_virtual_machine" "main" {
   }
 
   // Advanced options
-  nested_hv_enabled  = var.nested_hv_enabled
+  nested_hv_enabled = var.nested_hv_enabled
 }

--- a/assets/terraform-modules/platforms/vmware/workerpool/output.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/output.tf
@@ -1,0 +1,3 @@
+output "bootstrap_tokens" {
+  value = module.worker.*.bootstrap_token
+}

--- a/assets/terraform-modules/platforms/vmware/workerpool/variables.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/variables.tf
@@ -118,3 +118,9 @@ variable "apiserver" {
   description = "Apiserver private endpoint needed in the kubeconfig file."
   type        = string
 }
+
+variable "nested_hv_enabled" {
+  type        = bool
+  description = "Enable nested hardware virtualization on this virtual machine, facilitating nested virtualization in the guest."
+  default     = false
+}

--- a/assets/terraform-modules/platforms/vmware/workerpool/variables.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/variables.tf
@@ -118,9 +118,3 @@ variable "apiserver" {
   description = "Apiserver private endpoint needed in the kubeconfig file."
   type        = string
 }
-
-variable "dns_servers" {
-  type        = list(string)
-  description = "DNS servers for the network interface."
-  default     = []
-}

--- a/assets/terraform-modules/platforms/vmware/workerpool/variables.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/variables.tf
@@ -1,0 +1,126 @@
+# Required variables.
+variable "datacenter" {
+  type        = string
+  description = "The name of the VMware datacenter. This can be a name or path."
+}
+
+variable "datastore" {
+  type        = string
+  description = "The name of the VMware datastore. This can be a name or path."
+}
+
+variable "compute_cluster" {
+  type        = string
+  description = "The name of the VMware computer cluster used for the placement of the virtual machine."
+}
+
+variable "network" {
+  type        = string
+  description = "The name of the VMware network to connect the main interface to. This can be a name or path."
+}
+
+variable "template" {
+  type        = string
+  description = "The name of the VMware template used for the creation of the instance."
+}
+
+variable "nodes_ips" {
+  type        = list(string)
+  description = "IP addresses of the virtual machines."
+}
+
+variable "hosts_cidr" {
+  type        = string
+  description = "CIDR for all hosts."
+}
+
+variable "node_count" {
+  type        = number
+  description = "Number of nodes to create."
+}
+
+variable "name" {
+  type        = string
+  description = "Workerpool name. Must be unique across cluster."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Cluster identifier which will be used in controller node names."
+}
+
+variable "kubeconfig" {
+  type        = string
+  description = "Content of kubelet's kubeconfig file."
+}
+
+# Optional variables.
+variable "folder" {
+  type        = string
+  description = "The path to the folder to put this virtual machine in, relative to the datacenter that the resource pool is in."
+  default     = ""
+}
+
+variable "cpus_count" {
+  type        = number
+  description = "The total number of virtual processor cores to assign to this virtual machine."
+  default     = 4
+}
+
+variable "memory" {
+  type        = number
+  description = "The size of the virtual machine's memory, in MB."
+  default     = 4096
+}
+
+variable "disk_size" {
+  type        = number
+  description = "The size of the virtual machine's disk, in GB."
+  default     = 30
+}
+
+variable "ssh_keys" {
+  type        = list(string)
+  description = "List of SSH public keys for user `core`. Each element must be specified in a valid OpenSSH public key format, as defined in RFC 4253 Section 6.6, e.g. 'ssh-rsa AAAAB3N...'."
+  default     = []
+}
+
+variable "cluster_dns_service_ip" {
+  type        = string
+  description = "IP address of cluster DNS Service. Passed to kubelet as --cluster_dns parameter."
+  default     = "10.3.0.10"
+}
+
+variable "clc_snippets" {
+  type        = list(string)
+  description = "Extra CLC snippets to include in the configuration."
+  default     = []
+}
+
+variable "cluster_domain_suffix" {
+  type        = string
+  description = "Cluster domain suffix. Passed to kubelet as --cluster_domain flag."
+  default     = "cluster.local"
+}
+
+variable "host_dns_ip" {
+  type        = string
+  description = "IP address of DNS server to configure on the nodes."
+  default     = "8.8.8.8"
+}
+
+variable "ca_cert" {
+  description = "Kubernetes CA certificate needed in the kubeconfig file."
+  type        = string
+}
+
+variable "apiserver" {
+  description = "Apiserver private endpoint needed in the kubeconfig file."
+  type        = string
+}
+
+variable "dns_servers" {
+  type        = list(string)
+  description = "DNS servers for the network interface."
+  default     = []
+}

--- a/assets/terraform-modules/platforms/vmware/workerpool/versions.tf
+++ b/assets/terraform-modules/platforms/vmware/workerpool/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "1.24.3"
+    }
+  }
+}

--- a/cli/cmd/cluster/utils.go
+++ b/cli/cmd/cluster/utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/platform/baremetal"
 	"github.com/kinvolk/lokomotive/pkg/platform/packet"
 	"github.com/kinvolk/lokomotive/pkg/platform/tinkerbell"
+	"github.com/kinvolk/lokomotive/pkg/platform/vmware"
 )
 
 const (
@@ -82,6 +83,7 @@ func getPlatform(name string) (platform.Platform, error) {
 		packet.Name:     packet.NewConfig(),
 		baremetal.Name:  baremetal.NewConfig(),
 		tinkerbell.Name: tinkerbell.NewConfig(),
+		vmware.Name:     vmware.NewConfig(),
 	}
 
 	if p, ok := platforms[name]; ok {

--- a/examples/vmware-testing/cluster.lokocfg
+++ b/examples/vmware-testing/cluster.lokocfg
@@ -1,0 +1,76 @@
+variable "dns_zone" {}
+variable "dns_provider" {}
+variable "ssh_public_keys" {}
+
+variable "datacenter" {}
+variable "datastore" {}
+variable "compute_cluster" {}
+variable "network" {}
+variable "template" {}
+variable "folder" {}
+
+variable "asset_dir" {
+  default = "./lokomotive-assets"
+}
+
+variable "pool_path" {
+  default = "./pool"
+}
+
+variable "cluster_name" {
+  default = "lokomotive-cluster"
+}
+
+variable "controller_ips" {
+  default = [
+    "192.168.50.10",
+  ]
+}
+
+variable "worker_ips" {
+  default = [
+    "192.168.50.13",
+  ]
+}
+
+variable "hosts_cidr" {
+  default = "192.168.50.0/24"
+}
+
+variable "dns_servers" {
+  default = [
+    "192.168.50.1"
+  ]
+}
+
+cluster "vmware" {
+  asset_dir        = pathexpand(var.asset_dir)
+  name             = var.cluster_name
+  ssh_public_keys  = var.ssh_public_keys
+
+  dns {
+    zone     = var.dns_zone
+    provider = var.dns_provider
+  }
+
+  datacenter              = var.datacenter
+  datastore               = var.datastore
+  compute_cluster         = var.compute_cluster
+  network                 = var.network
+  folder                  = var.folder
+
+  controller_ip_addresses = var.controller_ips
+  hosts_cidr              = var.hosts_cidr
+  dns_servers             = var.dns_servers
+
+  template = var.template
+
+  worker_pool "my-wp-name" {
+    ip_addresses    = var.worker_ips
+    ssh_public_keys = var.ssh_public_keys
+  }
+}
+
+component "metrics-server" {}
+
+component "flatcar-linux-update-operator" {}

--- a/examples/vmware-testing/cluster.lokocfg
+++ b/examples/vmware-testing/cluster.lokocfg
@@ -23,30 +23,29 @@ variable "cluster_name" {
 
 variable "controller_ips" {
   default = [
-    "192.168.50.10",
+    "10.10.0.100",
   ]
 }
 
 variable "worker_ips" {
   default = [
-    "192.168.50.13",
+    "10.10.0.104",
   ]
 }
 
 variable "hosts_cidr" {
-  default = "192.168.50.0/24"
+  default = "10.10.0.0/22"
 }
 
-variable "dns_servers" {
-  default = [
-    "192.168.50.1"
-  ]
+variable "host_dns_ip" {
+  default = "10.10.0.1"
 }
 
 cluster "vmware" {
   asset_dir        = pathexpand(var.asset_dir)
   name             = var.cluster_name
   ssh_public_keys  = var.ssh_public_keys
+  host_dns_ip      = var.host_dns_ip
 
   dns {
     zone     = var.dns_zone
@@ -61,16 +60,18 @@ cluster "vmware" {
 
   controller_ip_addresses = var.controller_ips
   hosts_cidr              = var.hosts_cidr
-  dns_servers             = var.dns_servers
 
   template = var.template
 
   worker_pool "my-wp-name" {
     ip_addresses    = var.worker_ips
     ssh_public_keys = var.ssh_public_keys
+
+    cpus_count = 8
+    memory     = 16384
   }
 }
 
-component "metrics-server" {}
+component "inspektor-gadget" {}
 
-component "flatcar-linux-update-operator" {}
+component "web-ui" {}

--- a/pkg/platform/vmware/doc.go
+++ b/pkg/platform/vmware/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vmware provides Platform implementation using Terraform provider
+// VSphere
+package vmware

--- a/pkg/platform/vmware/template.go
+++ b/pkg/platform/vmware/template.go
@@ -77,6 +77,8 @@ module "controllers" {
   network         = local.network
   template        = local.template
 
+  nested_hv_enabled = {{.NestedHVEnabled}}
+
   {{- if .Folder }}
   folder = local.folder
   {{- end }}
@@ -164,6 +166,8 @@ module "worker_{{ $pool.Name }}" {
   datastore       = local.datastore
   compute_cluster = local.compute_cluster
   network         = local.network
+
+  nested_hv_enabled = {{ $pool.NestedHVEnabled }}
 
   {{- if $.Folder }}
   folder = local.folder

--- a/pkg/platform/vmware/template.go
+++ b/pkg/platform/vmware/template.go
@@ -1,0 +1,296 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmware
+
+var terraformConfigTmpl = `
+locals {
+  cluster_name = "{{.Name}}"
+  dns_zone     = "{{.DNS.Zone}}"
+
+  # VMware configuration.
+  datacenter      = "{{.Datacenter}}"
+  datastore       = "{{.Datastore}}"
+  compute_cluster = "{{.ComputeCluster}}"
+  network         = "{{.Network}}"
+  template        = "{{.Template}}"
+  {{- if .Folder }}
+  folder = "{{.Folder}}"
+  {{- end }}
+
+  controller_ips = [
+  {{- range .ControllerIPAddresses}}
+    "{{.}}",
+  {{- end}}
+  ]
+
+  dns_servers = [
+  {{- range .DNSServers}}
+    "{{.}}",
+  {{- end}}
+  ]
+  
+  {{- range $index, $pool := .WorkerPools }}
+  worker_{{ $pool.Name }}_ips = [
+  {{- range $pool.IPAddresses}}
+    "{{.}}",
+  {{- end}}
+  ]
+  {{- end}}
+
+  # Convert Go slices into Terraform lists.
+  ssh_keys = [
+  {{- range .SSHPublicKeys}}
+    "{{.}}",
+  {{- end}}
+  ]
+}
+
+terraform {
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "1.24.3"
+    }
+  }
+}
+
+provider "vsphere" {}
+
+module "controllers" {
+  source = "../terraform-modules/platforms/vmware/controllers"
+
+  # Generic configuration.
+  asset_dir     = "../cluster-assets"
+  cluster_name  = local.cluster_name
+  ssh_keys      = local.ssh_keys
+  dns_zone      = local.dns_zone
+
+  datacenter      = local.datacenter
+  datastore       = local.datastore
+  compute_cluster = local.compute_cluster
+  network         = local.network
+  template        = local.template
+
+  {{- if .Folder }}
+  folder = local.folder
+  {{- end }}
+
+  nodes_ips   = local.controller_ips
+  hosts_cidr  = "{{.HostsCIDR}}"
+  dns_servers = local.dns_servers
+
+  node_count = length(local.controller_ips)
+
+  {{- if .CPUs }}
+  cpus_count = {{.CPUs}}
+  {{- end }}
+
+  {{- if .Memory }}
+  memory = {{.Memory}}
+  {{- end }}
+
+  {{- if .DiskSize }}
+  disk_size = {{.DiskSize}}
+  {{- end }}
+
+  {{- if .ControllerCLCSnippets}}
+  clc_snippets = [
+  {{- range .ControllerCLCSnippets }}
+    <<EOF
+{{.}}
+EOF
+    ,
+  {{- end}}
+  ]
+  {{- end}}
+
+  enable_aggregation = {{.EnableAggregation}}
+
+  {{- if .NetworkMTU }}
+  network_mtu = {{.NetworkMTU}}
+  {{- end }}
+
+  {{- if .PodCIDR }}
+  pod_cidr = "{{.PodCIDR}}"
+  {{- end }}
+
+  {{- if .ServiceCIDR }}
+  service_cidr = "{{.ServiceCIDR}}"
+  {{- end }}
+
+  {{- if .ClusterDomainSuffix }}
+  cluster_domain_suffix = "{{.ClusterDomainSuffix}}"
+  {{- end }}
+
+  enable_reporting = {{.EnableReporting}}
+
+  {{- if .CertsValidityPeriodHours }}
+  certs_validity_period_hours = {{.CertsValidityPeriodHours}}
+  {{- end }}
+
+	conntrack_max_per_core = {{.ConntrackMaxPerCore}}
+
+  worker_bootstrap_tokens = concat(
+    {{- range $index, $pool := .WorkerPools }}
+    module.worker_{{ $pool.Name }}.bootstrap_tokens,
+    {{- end }}
+  )
+}
+
+{{- range $index, $pool := .WorkerPools }}
+
+module "worker_{{ $pool.Name }}" {
+  source = "../terraform-modules/platforms/vmware/workerpool"
+
+  kubeconfig             = module.controllers.kubeconfig
+  cluster_dns_service_ip = module.controllers.cluster_dns_service_ip
+  ca_cert                = module.controllers.ca_cert
+  apiserver              = module.controllers.apiserver
+
+  cluster_name = local.cluster_name
+  name         = "{{ $pool.Name }}"
+
+  # VMware configuration.
+  datacenter      = local.datacenter
+  datastore       = local.datastore
+  compute_cluster = local.compute_cluster
+  network         = local.network
+
+  {{- if $.Folder }}
+  folder = local.folder
+  {{- end }}
+
+  nodes_ips   = local.worker_{{ $pool.Name }}_ips
+  hosts_cidr  = "{{ $.HostsCIDR }}"
+  dns_servers = local.dns_servers
+
+  {{- if $pool.Template }}
+  template = "{{$pool.Template}}"
+  {{- else }}
+  template = "{{$.Template}}"
+  {{- end }}
+
+  node_count = length(local.worker_{{ $pool.Name }}_ips)
+
+  {{- if $pool.CPUs }}
+  cpus_count = {{$pool.CPUs}}
+  {{- end }}
+
+  {{- if $pool.Memory }}
+  memory = {{$pool.Memory}}
+  {{- end }}
+
+  {{- if $pool.DiskSize }}
+  disk_size = {{$pool.DiskSize}}
+  {{- end }}
+
+  {{- if $pool.SSHPublicKeys}}
+  ssh_keys = [
+  {{- range $pool.SSHPublicKeys}}
+    "{{.}}",
+  {{- end}}
+  ]
+  {{- end}}
+
+  {{- if $pool.CLCSnippets}}
+  clc_snippets = [
+  {{- range $pool.CLCSnippets}}
+    <<EOF
+{{.}}
+EOF
+    ,
+  {{- end}}
+  ]
+  {{- end}}
+
+  {{- if $pool.Labels }}
+  labels = {
+  {{- range $k, $v := $pool.Labels }}
+    "{{ $k }}" = "{{ $v }}",
+  {{- end }}
+  }
+  {{- end }}
+
+  {{- if $pool.Taints }}
+  taints = {
+  {{- range $k, $v := $pool.Taints }}
+    "{{ $k }}" = "{{ $v }}",
+  {{- end }}
+  }
+  {{- end }}
+
+}
+{{- end}}
+
+module "dns" {
+  source = "../terraform-modules/dns/{{.DNS.Provider}}"
+
+  cluster_name             = local.cluster_name
+  controllers_public_ipv4  = module.controllers.controllers_private_ipv4
+  controllers_private_ipv4 = module.controllers.controllers_private_ipv4
+  dns_zone                 = "{{ .DNS.Zone }}"
+}
+
+{{- if eq .DNS.Provider "manual" }}
+
+output "dns_entries" {
+  value = module.dns.entries
+}
+{{- end }}
+
+# Stub output, which indicates, that Terraform run at least once.
+# Used when checking, if we should ask user for confirmation, when
+# applying changes to the cluster.
+output "initialized" {
+  value			= true
+	sensitive = true
+}
+
+# values.yaml content for all deployed charts.
+output "pod-checkpointer_values" {
+  value 		= module.controllers.pod-checkpointer_values
+	sensitive = true
+}
+
+output "kube-apiserver_values" {
+  value     = module.controllers.kube-apiserver_values
+  sensitive = true
+}
+
+output "kubernetes_values" {
+  value     = module.controllers.kubernetes_values
+  sensitive = true
+}
+
+output "kubelet_values" {
+  value     = module.controllers.kubelet_values
+  sensitive = true
+}
+
+output "calico_values" {
+  value 		= module.controllers.calico_values
+	sensitive = true
+}
+
+output "lokomotive_values" {
+  value     = module.controllers.lokomotive_values
+  sensitive = true
+}
+
+output "bootstrap-secrets_values" {
+  value     = module.controllers.bootstrap-secrets_values
+  sensitive = true
+}
+`

--- a/pkg/platform/vmware/template.go
+++ b/pkg/platform/vmware/template.go
@@ -35,12 +35,6 @@ locals {
   {{- end}}
   ]
 
-  dns_servers = [
-  {{- range .DNSServers}}
-    "{{.}}",
-  {{- end}}
-  ]
-  
   {{- range $index, $pool := .WorkerPools }}
   worker_{{ $pool.Name }}_ips = [
   {{- range $pool.IPAddresses}}
@@ -87,9 +81,12 @@ module "controllers" {
   folder = local.folder
   {{- end }}
 
-  nodes_ips   = local.controller_ips
-  hosts_cidr  = "{{.HostsCIDR}}"
-  dns_servers = local.dns_servers
+  nodes_ips  = local.controller_ips
+  hosts_cidr = "{{.HostsCIDR}}"
+
+  {{- if .HostDNSIP }}
+  host_dns_ip = "{{.HostDNSIP}}"
+  {{- end }}
 
   node_count = length(local.controller_ips)
 
@@ -172,9 +169,12 @@ module "worker_{{ $pool.Name }}" {
   folder = local.folder
   {{- end }}
 
-  nodes_ips   = local.worker_{{ $pool.Name }}_ips
-  hosts_cidr  = "{{ $.HostsCIDR }}"
-  dns_servers = local.dns_servers
+  nodes_ips  = local.worker_{{ $pool.Name }}_ips
+  hosts_cidr = "{{ $.HostsCIDR }}"
+
+  {{- if $.HostDNSIP }}
+  host_dns_ip = "{{$.HostDNSIP}}"
+  {{- end }}
 
   {{- if $pool.Template }}
   template = "{{$pool.Template}}"

--- a/pkg/platform/vmware/vmware.go
+++ b/pkg/platform/vmware/vmware.go
@@ -42,7 +42,7 @@ type Config struct { //nolint:maligned
 	DNS           dns.Config `hcl:"dns,block"`
 	SSHPublicKeys []string   `hcl:"ssh_public_keys"`
 	HostsCIDR     string     `hcl:"hosts_cidr"`
-	DNSServers    []string   `hcl:"dns_servers,optional"`
+	HostDNSIP     string     `hcl:"host_dns_ip,optional"`
 
 	// VMware options
 	Datacenter     string `hcl:"datacenter"`

--- a/pkg/platform/vmware/vmware.go
+++ b/pkg/platform/vmware/vmware.go
@@ -1,0 +1,381 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmware
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/mitchellh/go-homedir"
+
+	"github.com/kinvolk/lokomotive/pkg/dns"
+	"github.com/kinvolk/lokomotive/pkg/platform"
+	"github.com/kinvolk/lokomotive/pkg/terraform"
+)
+
+const (
+	// Name represents VMware platform name as it should be referenced in function calls and configuration.
+	Name = "vmware"
+)
+
+// Config represents VMware platform configuration.
+type Config struct { //nolint:maligned
+	AssetDir      string     `hcl:"asset_dir"`
+	Name          string     `hcl:"name"`
+	DNS           dns.Config `hcl:"dns,block"`
+	SSHPublicKeys []string   `hcl:"ssh_public_keys"`
+	HostsCIDR     string     `hcl:"hosts_cidr"`
+	DNSServers    []string   `hcl:"dns_servers,optional"`
+
+	// VMware options
+	Datacenter     string `hcl:"datacenter"`
+	Datastore      string `hcl:"datastore"`
+	ComputeCluster string `hcl:"compute_cluster"`
+	Network        string `hcl:"network"`
+	Template       string `hcl:"template"`
+	Folder         string `hcl:"folder,optional"`
+
+	// VMware instance configuration.
+	CPUs     int `hcl:"cpus_count,optional"`
+	Memory   int `hcl:"memory,optional"`
+	DiskSize int `hcl:"dize_size,optional"`
+
+	ControllerCLCSnippets []string `hcl:"controller_clc_snippets,optional"`
+	ControllerIPAddresses []string `hcl:"controller_ip_addresses"`
+
+	// Generic options.
+	EnableAggregation        bool   `hcl:"enable_aggregation,optional"`
+	EnableReporting          bool   `hcl:"enable_reporting,optional"`
+	PodCIDR                  string `hcl:"pod_cidr,optional"`
+	ServiceCIDR              string `hcl:"service_cidr,optional"`
+	ClusterDomainSuffix      string `hcl:"cluster_domain_suffix,optional"`
+	CertsValidityPeriodHours int    `hcl:"certs_validity_period_hours,optional"`
+	NetworkMTU               int    `hcl:"network_mtu,optional"`
+	DisableSelfHostedKubelet bool   `hcl:"disable_self_hosted_kubelet,optional"`
+	ConntrackMaxPerCore      int    `hcl:"conntrack_max_per_core,optional"`
+
+	WorkerPools []WorkerPool `hcl:"worker_pool,block"`
+}
+
+// WorkerPool represents VMware worker pool configuration.
+type WorkerPool struct {
+	PoolName string `hcl:"name,label"`
+
+	// VMware instance configuration.
+	CPUs     int    `hcl:"cpus_count,optional"`
+	Memory   int    `hcl:"memory,optional"`
+	DiskSize int    `hcl:"dize_size,optional"`
+	Template string `hcl:"template,optional"`
+
+	SSHPublicKeys []string `hcl:"ssh_public_keys,optional"`
+
+	IPAddresses []string `hcl:"ip_addresses"`
+	CLCSnippets []string `hcl:"clc_snippets,optional"`
+
+	// Generic options.
+	Labels map[string]string `hcl:"labels,optional"`
+	Taints map[string]string `hcl:"taints,optional"`
+}
+
+// Name returns worker pool name.
+func (w *WorkerPool) Name() string {
+	return w.PoolName
+}
+
+// LoadConfig loads platform configuration using given HCL structs.
+func (c *Config) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContext) hcl.Diagnostics {
+	if configBody == nil {
+		emptyConfig := hcl.EmptyBody()
+		configBody = &emptyConfig
+	}
+
+	if diags := gohcl.DecodeBody(*configBody, evalContext, c); len(diags) != 0 {
+		return diags
+	}
+
+	for i, k := range c.SSHPublicKeys {
+		c.SSHPublicKeys[i] = strings.TrimSpace(k)
+	}
+
+	for _, p := range c.WorkerPools {
+		for i, k := range p.SSHPublicKeys {
+			p.SSHPublicKeys[i] = strings.TrimSpace(k)
+		}
+	}
+
+	return c.Validate()
+}
+
+// NewConfig returns VMware default configuration.
+func NewConfig() *Config {
+	return &Config{
+		EnableAggregation:   true,
+		ConntrackMaxPerCore: platform.ConntrackMaxPerCore,
+	}
+}
+
+// Meta is part of Platform interface and returns common information about the platform configuration.
+func (c *Config) Meta() platform.Meta {
+	nodes := len(c.ControllerIPAddresses)
+	for _, workerpool := range c.WorkerPools {
+		nodes += len(workerpool.IPAddresses)
+	}
+
+	return platform.Meta{
+		AssetDir:           c.AssetDir,
+		ExpectedNodes:      nodes,
+		ControlplaneCharts: platform.CommonControlPlaneCharts(!c.DisableSelfHostedKubelet),
+	}
+}
+
+// Initialize unpacks control plane Helm charts into assets directory and creates
+// Terraform configuration file.
+func (c *Config) Initialize(ex *terraform.Executor) error {
+	if os.Getenv("VSPHERE_SERVER") == "" {
+		return fmt.Errorf("cannot find the vSphere server name:\n" +
+			"use the VSPHERE_SERVER environment variable")
+	}
+
+	if os.Getenv("VSPHERE_USER") == "" {
+		return fmt.Errorf("cannot find the vSphere username:\n" +
+			"use the VSPHERE_USER environment variable")
+	}
+
+	if os.Getenv("VSPHERE_PASSWORD") == "" {
+		return fmt.Errorf("cannot find the vSphere password:\n" +
+			"use the VSPHERE_PASSWORD environment variable")
+	}
+
+	if err := c.DNS.Validate(); err != nil {
+		return fmt.Errorf("parsing DNS configuration: %w", err)
+	}
+
+	assetDir, err := homedir.Expand(c.AssetDir)
+	if err != nil {
+		return err
+	}
+
+	terraformRootDir := terraform.GetTerraformRootDir(assetDir)
+
+	return c.createTerraformConfigFile(terraformRootDir)
+}
+
+// Apply applies Terraform configuration.
+func (c *Config) Apply(ex *terraform.Executor) error {
+	assetDir, err := homedir.Expand(c.AssetDir)
+	if err != nil {
+		return err
+	}
+
+	c.AssetDir = assetDir
+
+	if err := c.Initialize(ex); err != nil {
+		return err
+	}
+
+	return c.terraformSmartApply(ex, c.DNS)
+}
+
+// terraformSmartApply applies cluster configuration.
+func (c *Config) terraformSmartApply(ex *terraform.Executor, dc dns.Config) error {
+	// If the provider isn't manual, apply everything in a single step.
+	if dc.Provider != dns.Manual {
+		return ex.Apply()
+	}
+
+	steps := []terraform.ExecutionStep{
+		// We need the controllers' IP addresses before we can apply the 'dns' module.
+		{
+			Description: "create controllers",
+			Args: []string{
+				"apply",
+				"-auto-approve",
+				"-target=module.controllers.vsphere_virtual_machine.main",
+			},
+		},
+		{
+			Description: "construct DNS records",
+			Args:        []string{"apply", "-auto-approve", "-target=module.dns"},
+		},
+		// Run `terraform refresh`. This is required in order to make the outputs from the previous
+		// apply operations available.
+		// TODO: Likely caused by https://github.com/hashicorp/terraform/issues/23158.
+		{
+			Description: "refresh Terraform state",
+			Args:        []string{"refresh"},
+		},
+		{
+			Description:      "complete infrastructure creation",
+			Args:             []string{"apply", "-auto-approve"},
+			PreExecutionHook: c.DNS.ManualConfigPrompt(),
+		},
+	}
+
+	return ex.Execute(steps...)
+}
+
+// Destroy destroys Terraform managed resources.
+func (c *Config) Destroy(ex *terraform.Executor) error {
+	if err := c.Initialize(ex); err != nil {
+		return err
+	}
+
+	return ex.Destroy()
+}
+
+func (c *Config) createTerraformConfigFile(terraformPath string) error {
+	tmplName := "cluster.tf"
+
+	t := template.Must(template.New("cluster.tf").Parse(terraformConfigTmpl))
+
+	path := filepath.Join(terraformPath, tmplName)
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %w", path, err)
+	}
+
+	if err := t.Execute(f, c); err != nil {
+		return fmt.Errorf("failed to write template to file %q: %w", path, err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed closing file %q: %w", path, err)
+	}
+
+	return nil
+}
+
+// Validate validates cluster configuration.
+func (c *Config) Validate() hcl.Diagnostics {
+	var d hcl.Diagnostics
+
+	// Convert VMware worker pool to generic workerpool collection.
+	x := []platform.WorkerPool{}
+	for i, pool := range c.WorkerPools {
+		x = append(x, &c.WorkerPools[i])
+
+		if pool.PoolName == "" {
+			d = append(d, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Worker pools name can't be empty",
+				Detail:   fmt.Sprintf("Worker pool %d name is empty", i),
+			})
+		}
+
+		if len(pool.IPAddresses) == 0 {
+			d = append(d, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Worker pool must have at least one IP address configured",
+				Detail:   fmt.Sprintf("Worker pool %q IP addresses list is empty", pool.PoolName),
+			})
+		}
+	}
+
+	if c.ConntrackMaxPerCore < 0 {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "conntrack_max_per_core can't be negative value",
+			Detail:   fmt.Sprintf("'conntrack_max_per_core' value is %d", c.ConntrackMaxPerCore),
+		})
+	}
+
+	d = append(d, platform.WorkerPoolNamesUnique(x)...)
+	d = append(d, c.validateRequiredFields()...)
+
+	return d
+}
+
+//nolint:funlen,lll
+func (c *Config) validateRequiredFields() hcl.Diagnostics {
+	var d hcl.Diagnostics
+
+	if c.AssetDir == "" {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Asset dir can't be empty",
+		})
+	}
+
+	if c.Name == "" {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Cluster name can't be empty",
+		})
+	}
+
+	if len(c.SSHPublicKeys) == 0 {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Controllers must have at least one SSH key configured",
+		})
+	}
+
+	if c.Datacenter == "" {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Datacenter can't be empty",
+		})
+	}
+
+	if c.Datastore == "" {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Datastore can't be empty",
+		})
+	}
+
+	if c.ComputeCluster == "" {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Compute Cluster can't be empty",
+		})
+	}
+
+	if c.Network == "" {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Network can't be empty",
+		})
+	}
+
+	if c.Template == "" {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Template can't be empty",
+		})
+	}
+
+	if len(c.ControllerIPAddresses) == 0 {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Controllers must have at least one IP address configured",
+		})
+	}
+
+	if c.HostsCIDR == "" {
+		d = append(d, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Hosts CIDR can't be empty",
+		})
+	}
+
+	return d
+}

--- a/pkg/platform/vmware/vmware.go
+++ b/pkg/platform/vmware/vmware.go
@@ -53,9 +53,10 @@ type Config struct { //nolint:maligned
 	Folder         string `hcl:"folder,optional"`
 
 	// VMware instance configuration.
-	CPUs     int `hcl:"cpus_count,optional"`
-	Memory   int `hcl:"memory,optional"`
-	DiskSize int `hcl:"dize_size,optional"`
+	CPUs            int  `hcl:"cpus_count,optional"`
+	Memory          int  `hcl:"memory,optional"`
+	DiskSize        int  `hcl:"dize_size,optional"`
+	NestedHVEnabled bool `hcl:"nested_hv_enabled,optional"`
 
 	ControllerCLCSnippets []string `hcl:"controller_clc_snippets,optional"`
 	ControllerIPAddresses []string `hcl:"controller_ip_addresses"`
@@ -79,10 +80,11 @@ type WorkerPool struct {
 	PoolName string `hcl:"name,label"`
 
 	// VMware instance configuration.
-	CPUs     int    `hcl:"cpus_count,optional"`
-	Memory   int    `hcl:"memory,optional"`
-	DiskSize int    `hcl:"dize_size,optional"`
-	Template string `hcl:"template,optional"`
+	CPUs            int    `hcl:"cpus_count,optional"`
+	Memory          int    `hcl:"memory,optional"`
+	DiskSize        int    `hcl:"dize_size,optional"`
+	NestedHVEnabled bool   `hcl:"nested_hv_enabled,optional"`
+	Template        string `hcl:"template,optional"`
 
 	SSHPublicKeys []string `hcl:"ssh_public_keys,optional"`
 

--- a/pkg/platform/vmware/vmware_test.go
+++ b/pkg/platform/vmware/vmware_test.go
@@ -1,0 +1,155 @@
+// Copyright 2020 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmware_test
+
+import (
+	"testing"
+
+	"github.com/kinvolk/lokomotive/pkg/dns"
+	"github.com/kinvolk/lokomotive/pkg/platform/vmware"
+)
+
+func baseConfig() *vmware.Config {
+	return &vmware.Config{
+		AssetDir: "foo",
+		Name:     "foo",
+		DNS: dns.Config{
+			Provider: "manual",
+			Zone:     "example.com",
+		},
+		Datacenter:            "dc",
+		Datastore:             "datastore",
+		ComputeCluster:        "cluster",
+		Network:               "network",
+		Template:              "mytemplate",
+		SSHPublicKeys:         []string{"foo"},
+		ControllerIPAddresses: []string{"foo"},
+		HostsCIDR:             "10.10.0.0/8",
+		WorkerPools: []vmware.WorkerPool{
+			{
+				PoolName:      "foo",
+				IPAddresses:   []string{"foo"},
+				SSHPublicKeys: []string{"foo"},
+			},
+		},
+	}
+}
+
+//nolint:funlen
+func TestConfigValidation(t *testing.T) {
+	cases := map[string]struct {
+		mutatingF   func(*vmware.Config)
+		expectError bool
+	}{
+		"base config": {
+			mutatingF: func(c *vmware.Config) {},
+		},
+		"require asset dir": {
+			mutatingF: func(c *vmware.Config) {
+				c.AssetDir = ""
+			},
+			expectError: true,
+		},
+		"require name": {
+			mutatingF: func(c *vmware.Config) {
+				c.Name = ""
+			},
+			expectError: true,
+		},
+		"require datacenter": {
+			mutatingF: func(c *vmware.Config) {
+				c.Datacenter = ""
+			},
+			expectError: true,
+		},
+		"require datastore": {
+			mutatingF: func(c *vmware.Config) {
+				c.Datastore = ""
+			},
+			expectError: true,
+		},
+		"require computer cluster": {
+			mutatingF: func(c *vmware.Config) {
+				c.ComputeCluster = ""
+			},
+			expectError: true,
+		},
+		"require network": {
+			mutatingF: func(c *vmware.Config) {
+				c.Network = ""
+			},
+			expectError: true,
+		},
+		"require template": {
+			mutatingF: func(c *vmware.Config) {
+				c.Template = ""
+			},
+			expectError: true,
+		},
+		"allow no folder": {
+			mutatingF: func(c *vmware.Config) {
+				c.Folder = ""
+			},
+		},
+		"require host CIDR": {
+			mutatingF: func(c *vmware.Config) {
+				c.HostsCIDR = ""
+			},
+			expectError: true,
+		},
+		"require SSH public key": {
+			mutatingF: func(c *vmware.Config) {
+				c.SSHPublicKeys = []string{}
+			},
+			expectError: true,
+		},
+		"allow no worker pools": {
+			mutatingF: func(c *vmware.Config) {
+				c.WorkerPools = nil
+			},
+		},
+		"require worker pool name": {
+			mutatingF: func(c *vmware.Config) {
+				c.WorkerPools[0].PoolName = ""
+			},
+			expectError: true,
+		},
+		"require worker pool IP address": {
+			mutatingF: func(c *vmware.Config) {
+				c.WorkerPools[0].IPAddresses = []string{}
+			},
+			expectError: true,
+		},
+	}
+
+	for n, spec := range cases {
+		spec := spec
+
+		t.Run(n, func(t *testing.T) {
+			c := baseConfig()
+			spec.mutatingF(c)
+
+			diags := c.Validate()
+
+			if spec.expectError && !diags.HasErrors() {
+				t.Fatalf("Expected validation error")
+			}
+
+			if !spec.expectError && diags.HasErrors() {
+				t.Fatalf("Unexpected validation error: %v", diags)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Add VMware VSphere platform

This PR adds the initial support for the VMware VSphere platform. The idea is to provide support for both VSphere and ESXi hosts as initially discussed here https://github.com/kinvolk/lokomotive/issues/1300 so to run this k8s distro also on ESXi with a free license.

# How to use

You need to first have in VCenter the Flatcar VM Template available. Download from [Flatcar Releases](https://stable.release.flatcar-linux.net/) the OVA required and then run the following command:

```sh
ovftool --name="Flatcar-stable-2605.10.0" --datastore='<datastore>' --overwrite --skipManifestCheck --noSSLVerify --allowAllExtraConfig --importAsTemplate ./flatcar_production_vmware_ova.ova 'vi://<username>@<server>/<dataceter>/host/<compute_cluster>'
```

This will import the OVA as a VM Template which will be used by Terraform provider to create all the VMware instances.

It has been provided a testing `cluster.lokocfg` file to test it. For VSphere, it is important to export environment variables needed for the Terraform `vsphere` provider and provide ` lokocfg.vars` file.

VMware instances require static IP addresses. 

```sh
export VSPHERE_USER=
export VSPHERE_PASSWORD=
export VSPHERE_SERVER=
# In the case you run VCenter behind a self-signed cert
export VSPHERE_ALLOW_UNVERIFIED_SSL=true 
lokoctl cluster apply --lokocfg ./examples/vmware-testing/cluster.lokocfg --lokocfg-vars ./examples/vmware-testing/lokocfg.vars
```

It is important to set up also the DNS provider as one of `route53`, `cloudflare` or `manual`.

# Testing done

Created a testing cluster starting from the provided `cluster.lokocfg`. Tested with `Cloudflare` as provider and `manual`.

------

# TODO

- [x] Write unit tests for VMware platform
- [x] Configure properly `bootkube`