### PR TITLE
packet: Remove coreos-metadata service config

### DIFF
--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -72,17 +72,6 @@ systemd:
         ExecStart=/bin/sh -c 'echo "ETCD_LISTEN_CLIENT_URLS=https://$COREOS_PACKET_IPV4_PRIVATE_0:2379" > /etc/kubernetes/etcd.config && echo "ETCD_LISTEN_PEER_URLS=https://$COREOS_PACKET_IPV4_PRIVATE_0:2380" >> /etc/kubernetes/etcd.config && echo "ETCD_LISTEN_METRICS_URLS=http://$COREOS_PACKET_IPV4_PRIVATE_0:2381" >> /etc/kubernetes/etcd.config'
         [Install]
         RequiredBy=etcd-member.service
-    - name: coreos-metadata.service
-      enable: true
-      contents: |
-        [Unit]
-        Description=Flatcar Metadata Agent
-        [Service]
-        Type=oneshot
-        Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
-        ExecStart=/usr/bin/coreos-metadata $${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
-        [Install]
-        RequiredBy=metadata.target
     - name: kubelet.service
       enable: true
       contents: |

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -34,17 +34,6 @@ systemd:
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done; /opt/wait-for-dns ${dns_zone} ${cluster_name}-private 3600'
         [Install]
         RequiredBy=kubelet.service
-    - name: coreos-metadata.service
-      enable: true
-      contents: |
-        [Unit]
-        Description=Flatcar Container Linux Metadata Agent
-        [Service]
-        Type=oneshot
-        Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
-        ExecStart=/usr/bin/coreos-metadata $${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
-        [Install]
-        RequiredBy=metadata.target
     - name: kubelet.service
       enable: true
       contents: |


### PR DESCRIPTION
This commit removes the redundant coreos-metadata service config
provided in the ignition file. This config is outdated compared to one
that is shipped by Flatcar.

Fixes #1297 