### PR TITLE
psp: Make the restrictive policy as the first on the list

### DIFF
--- a/assets/charts/control-plane/kubernetes/templates/psp-restricted.yaml
+++ b/assets/charts/control-plane/kubernetes/templates/psp-restricted.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: zz-minimal
+  name: aa-minimal
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
@@ -56,7 +56,7 @@ rules:
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - zz-minimal
+  - aa-minimal
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The policy order of PSP has two methods of selecting a PSP for
applications:

1. If a PSP allows the pod specification as is without a mutation, then
   that PSP is used.
2. If the above condition fails, then the fist PSP is chosen from an
   allowed-PSP list, and the pod is mutated accordingly.

In Lokomotive's case the general cluster-wide PSP for apps that don't
ship PSP is the minimal restrictive PSP. So we need to ensure that it is
on top of the list for selection not bottom.