### PR TITLE
Add diff flag to terraform check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ check-docs: check-working-tree-clean docs
 
 .PHONY: check-terraform
 check-terraform:
-	terraform fmt -check -recursive ./assets/
+	terraform fmt -check -recursive -diff ./assets/
 
 .PHONY: ci
 ci: build build-test test check-update-assets check-vendor check-docs check-terraform

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -59,7 +59,7 @@ data "ct_config" "ignitions" {
       cluster_domain_suffix = var.cluster_domain_suffix
       node_labels = merge({
         "node.kubernetes.io/node"                 = "",
-        "lokomotive.alpha.kinvolk.io/bgp-enabled" = format("%t", !var.disable_bgp),
+        "lokomotive.alpha.kinvolk.io/bgp-enabled" = format("%t", ! var.disable_bgp),
       }, var.labels)
       taints               = var.taints
       setup_raid           = var.setup_raid


### PR DESCRIPTION
This PR adds the adds a `-diff` flag to `terraform fmt`, so that the user can see the output what needs to be fixed.