### PR TITLE
contour: Fix the hostPort regression

### DIFF
--- a/assets/charts/components/contour/templates/03-envoy.yaml
+++ b/assets/charts/components/contour/templates/03-envoy.yaml
@@ -95,11 +95,9 @@ spec:
               fieldPath: metadata.name
         ports:
         - containerPort: 80
-          hostPort: 80
           name: http
           protocol: TCP
         - containerPort: 443
-          hostPort: 443
           name: https
           protocol: TCP
         readinessProbe:

--- a/pkg/components/contour/component_test.go
+++ b/pkg/components/contour/component_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components/internal/testutil"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
 )
 
 //nolint:funlen
@@ -96,7 +97,7 @@ func TestConversion(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		inputConfig          string
-		expectedManifestName string
+		expectedManifestName k8sutil.ObjectMetadata
 		expected             string
 		jsonPath             string
 	}{
@@ -108,9 +109,11 @@ func TestConversion(t *testing.T) {
 					metrics_scrape_interval = "10s"
 				}
 			}`,
-			expectedManifestName: "contour/templates/service-monitor.yaml",
-			jsonPath:             "{.spec.endpoints[0].interval}",
-			expected:             "10s",
+			expectedManifestName: k8sutil.ObjectMetadata{
+				Version: "monitoring.coreos.com/v1", Kind: "ServiceMonitor", Name: "envoy",
+			},
+			jsonPath: "{.spec.endpoints[0].interval}",
+			expected: "10s",
 		},
 	}
 

--- a/pkg/components/contour/component_test.go
+++ b/pkg/components/contour/component_test.go
@@ -130,3 +130,18 @@ func TestConversion(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvoyHostPort(t *testing.T) {
+	t.Parallel()
+
+	componentCfg := `component "contour" {}`
+	expectedManifestName := k8sutil.ObjectMetadata{Version: "apps/v1", Kind: "DaemonSet", Name: "envoy"}
+	jsonPath := "{.spec.template.spec.containers[1].ports[0].hostPort}"
+	errExpected := "hostPort is not found"
+
+	component := NewConfig()
+	m := testutil.RenderManifests(t, component, Name, componentCfg)
+	gotConfig := testutil.ConfigFromMap(t, m, expectedManifestName)
+
+	testutil.JSONPathExists(t, gotConfig, jsonPath, errExpected)
+}

--- a/pkg/components/internal/testutil/jsonpath.go
+++ b/pkg/components/internal/testutil/jsonpath.go
@@ -17,6 +17,7 @@ package testutil
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kinvolk/lokomotive/pkg/k8sutil"
@@ -100,4 +101,23 @@ func MatchJSONPathInt64Value(t *testing.T, yamlConfig string, jsonPath string, e
 	if got != expected {
 		t.Fatalf("Expected: %d, Got: %d", expected, got)
 	}
+}
+
+// JSONPathExists checks if the given YAML config has an object at the given JSON path, also provide
+// what error to expect.
+func JSONPathExists(t *testing.T, yamlConfig string, jsonPath string, errExp string) {
+	_, err := jsonPathValue(yamlConfig, jsonPath)
+	if err != nil && errExp == "" {
+		t.Fatalf("Error not expected and failed with: %v", err)
+	}
+
+	if err == nil && errExp != "" {
+		t.Fatalf("Expected error %q but got none", errExp)
+	}
+
+	if err != nil && !strings.Contains(err.Error(), errExp) {
+		t.Fatalf("Extracting JSON path value, expected error: %v to contain: %q", err, errExp)
+	}
+
+	t.Logf("Failed with error: %v", err)
 }

--- a/pkg/components/internal/testutil/jsonpath.go
+++ b/pkg/components/internal/testutil/jsonpath.go
@@ -15,6 +15,7 @@
 package testutil
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -25,49 +26,53 @@ import (
 
 // valFromObject takes a JSON path as a string and an object of type `unstructured.Unstructured`.
 // This function returns an object of type `reflect.Value` at that JSON path.
-func valFromObject(t *testing.T, jp string, obj *unstructured.Unstructured) reflect.Value {
+func valFromObject(jp string, obj *unstructured.Unstructured) (reflect.Value, error) {
 	jPath := jsonpath.New("parse")
 	if err := jPath.Parse(jp); err != nil {
-		t.Fatalf("Parsing JSONPath: %v", err)
+		return reflect.Value{}, fmt.Errorf("parsing JSONPath: %w", err)
 	}
 
 	v, err := jPath.FindResults(obj.Object)
 	if err != nil {
-		t.Fatalf("Finding results using JSONPath in the YAML file: %v", err)
+		return reflect.Value{}, fmt.Errorf("finding results using JSONPath in the YAML file: %w", err)
 	}
 
 	if len(v) == 0 || len(v[0]) == 0 {
-		t.Fatalf("No result found")
+		return reflect.Value{}, nil
 	}
 
-	return v[0][0]
+	return v[0][0], nil
 }
 
 // jsonPathValue extracts an object at a JSON path from a YAML config, and returns an interface
 // object.
-func jsonPathValue(t *testing.T, yamlConfig string, jsonPath string) interface{} {
+func jsonPathValue(yamlConfig string, jsonPath string) (interface{}, error) {
 	u, err := k8sutil.YAMLToUnstructured([]byte(yamlConfig))
 	if err != nil {
-		t.Fatalf("YAML to unstructured object: %v", err)
+		return nil, fmt.Errorf("YAML to unstructured object: %w", err)
 	}
 
-	got := valFromObject(t, jsonPath, u)
+	got, err := valFromObject(jsonPath, u)
+	if err != nil {
+		return nil, fmt.Errorf("JSON path value in YAML: %w", err)
+	}
 
 	switch got.Kind() { //nolint:exhaustive
 	case reflect.Interface:
 		// TODO: Add type switch here for concrete types.
-		return got.Interface()
+		return got.Interface(), nil
 	default:
-		t.Fatalf("Extracted object has an unknown type: %v", got.Kind())
+		return nil, fmt.Errorf("extracted object has an unknown type: %v", got.Kind())
 	}
-
-	return nil
 }
 
 // MatchJSONPathStringValue is a helper function for component unit tests. It compares the string at
 // a JSON path in a YAML config to the expected string.
 func MatchJSONPathStringValue(t *testing.T, yamlConfig string, jsonPath string, expected string) {
-	obj := jsonPathValue(t, yamlConfig, jsonPath)
+	obj, err := jsonPathValue(yamlConfig, jsonPath)
+	if err != nil {
+		t.Fatalf("Extracting JSON path value: %v", err)
+	}
 
 	got, ok := obj.(string)
 	if !ok {
@@ -82,7 +87,10 @@ func MatchJSONPathStringValue(t *testing.T, yamlConfig string, jsonPath string, 
 // MatchJSONPathInt64Value is a helper function for component unit tests. It compares the integer at
 // a JSON path in a YAML config to the expected integer.
 func MatchJSONPathInt64Value(t *testing.T, yamlConfig string, jsonPath string, expected int64) {
-	obj := jsonPathValue(t, yamlConfig, jsonPath)
+	obj, err := jsonPathValue(yamlConfig, jsonPath)
+	if err != nil {
+		t.Fatalf("Extracting JSON path value: %v", err)
+	}
 
 	got, ok := obj.(int64)
 	if !ok {

--- a/pkg/components/istio-operator/component_test.go
+++ b/pkg/components/istio-operator/component_test.go
@@ -18,31 +18,36 @@ import (
 	"testing"
 
 	"github.com/kinvolk/lokomotive/pkg/components/internal/testutil"
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
 )
 
 func TestConversion(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		inputConfig          string
-		expectedManifestName string
+		expectedManifestName k8sutil.ObjectMetadata
 		expected             string
 		jsonPath             string
 	}{
 		{
-			name:                 "default profile",
-			inputConfig:          `component "experimental-istio-operator" {}`,
-			expectedManifestName: "istio-operator/templates/istio-operator-cr.yaml",
-			jsonPath:             "{.spec.profile}",
-			expected:             "minimal",
+			name:        "default profile",
+			inputConfig: `component "experimental-istio-operator" {}`,
+			expectedManifestName: k8sutil.ObjectMetadata{
+				Version: "install.istio.io/v1alpha1", Kind: "IstioOperator", Name: "istiocontrolplane",
+			},
+			jsonPath: "{.spec.profile}",
+			expected: "minimal",
 		},
 		{
 			name: "demo profile",
 			inputConfig: `component "experimental-istio-operator" {
 				profile = "demo"
 			}`,
-			expectedManifestName: "istio-operator/templates/istio-operator-cr.yaml",
-			jsonPath:             "{.spec.profile}",
-			expected:             "demo",
+			expectedManifestName: k8sutil.ObjectMetadata{
+				Version: "install.istio.io/v1alpha1", Kind: "IstioOperator", Name: "istiocontrolplane",
+			},
+			jsonPath: "{.spec.profile}",
+			expected: "demo",
 		},
 	}
 
@@ -67,5 +72,7 @@ func TestVerifyServiceMonitor(t *testing.T) {
 
 	component := NewConfig()
 	m := testutil.RenderManifests(t, component, Name, inputConfig)
-	testutil.ConfigFromMap(t, m, "istio-operator/templates/service-monitor.yaml")
+	testutil.ConfigFromMap(t, m, k8sutil.ObjectMetadata{
+		Version: "monitoring.coreos.com/v1", Kind: "ServiceMonitor", Name: "istio-operator",
+	})
 }

--- a/pkg/components/node-problem-detector/component_test.go
+++ b/pkg/components/node-problem-detector/component_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/components/internal/testutil"
 	nodeproblemdetector "github.com/kinvolk/lokomotive/pkg/components/node-problem-detector"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
 )
 
 const name = "node-problem-detector"
@@ -92,7 +93,9 @@ component "node-problem-detector" {
 	jsonPath := "{.data.custom-monitor-0\\.json}"
 	expected := "testdata"
 
-	gotConfig := testutil.ConfigFromMap(t, m, "node-problem-detector/templates/custom-config-configmap.yaml")
+	gotConfig := testutil.ConfigFromMap(t, m, k8sutil.ObjectMetadata{
+		Name: "node-problem-detector-custom-config", Kind: "ConfigMap", Version: "v1",
+	})
 
 	testutil.MatchJSONPathStringValue(t, gotConfig, jsonPath, expected)
 }

--- a/pkg/components/prometheus-operator/component_test.go
+++ b/pkg/components/prometheus-operator/component_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components/internal/testutil"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
 )
 
 //nolint:funlen
@@ -133,7 +134,7 @@ func TestConversion(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		inputConfig          string
-		expectedManifestName string
+		expectedManifestName k8sutil.ObjectMetadata
 		expected             string
 		jsonPath             string
 	}{
@@ -146,9 +147,11 @@ component "prometheus-operator" {
   }
 }
 `,
-			expectedManifestName: "kube-prometheus-stack/templates/prometheus/prometheus.yaml",
-			expected:             "https://prometheus.externalurl.net",
-			jsonPath:             "{.spec.externalUrl}",
+			expectedManifestName: k8sutil.ObjectMetadata{
+				Version: "monitoring.coreos.com/v1", Kind: "Prometheus", Name: "prometheus-operator-kube-p-prometheus",
+			},
+			expected: "https://prometheus.externalurl.net",
+			jsonPath: "{.spec.externalUrl}",
 		},
 		{
 			name: "no external_url param",
@@ -163,9 +166,11 @@ component "prometheus-operator" {
 		  }
 		}
 		`,
-			expectedManifestName: "kube-prometheus-stack/templates/prometheus/prometheus.yaml",
-			expected:             "https://prometheus.mydomain.net",
-			jsonPath:             "{.spec.externalUrl}",
+			expectedManifestName: k8sutil.ObjectMetadata{
+				Version: "monitoring.coreos.com/v1", Kind: "Prometheus", Name: "prometheus-operator-kube-p-prometheus",
+			},
+			expected: "https://prometheus.mydomain.net",
+			jsonPath: "{.spec.externalUrl}",
 		},
 		{
 			name: "ingress creation for prometheus",
@@ -180,14 +185,18 @@ component "prometheus-operator" {
 		  }
 		}
 		`,
-			expectedManifestName: "kube-prometheus-stack/templates/prometheus/ingress.yaml",
-			expected:             "prometheus.mydomain.net",
-			jsonPath:             "{.spec.rules[0].host}",
+			expectedManifestName: k8sutil.ObjectMetadata{
+				Version: "networking.k8s.io/v1beta1", Kind: "Ingress", Name: "prometheus-operator-kube-p-prometheus",
+			},
+			expected: "prometheus.mydomain.net",
+			jsonPath: "{.spec.rules[0].host}",
 		},
 		{
-			name:                 "verify foldersFromFilesStructure in configmap",
-			inputConfig:          `component "prometheus-operator" {}`,
-			expectedManifestName: "kube-prometheus-stack/charts/grafana/templates/configmap-dashboard-provider.yaml",
+			name:        "verify foldersFromFilesStructure in configmap",
+			inputConfig: `component "prometheus-operator" {}`,
+			expectedManifestName: k8sutil.ObjectMetadata{
+				Version: "v1", Kind: "ConfigMap", Name: "prometheus-operator-grafana-config-dashboards",
+			},
 			expected: `apiVersion: 1
 providers:
 - name: 'sidecarProvider'

--- a/pkg/components/velero/component_test.go
+++ b/pkg/components/velero/component_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components/internal/testutil"
 	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
 )
 
 func TestEmptyConfig(t *testing.T) {
@@ -210,6 +211,7 @@ component "velero" {
       provider = "aws"
       region   = "myregion"
     }
+
     tolerations {
       key                = "TestResticTolerationKey"
       value              = "TestResticTolerationValue"
@@ -235,15 +237,16 @@ component "velero" {
 	m := testutil.RenderManifests(t, component, Name, configHCL)
 	jsonPath := "{.spec.template.spec.tolerations[0].key}"
 	expected := "TestResticTolerationKey"
-
-	gotConfig := testutil.ConfigFromMap(t, m, "velero/templates/restic-daemonset.yaml")
+	resticDS := k8sutil.ObjectMetadata{
+		Version: "apps/v1", Kind: "DaemonSet", Name: "restic",
+	}
+	gotConfig := testutil.ConfigFromMap(t, m, resticDS)
 
 	testutil.MatchJSONPathStringValue(t, gotConfig, jsonPath, expected)
 
 	jsonPath = "{.spec.template.spec.tolerations[0].tolerationSeconds}"
 	expectedNumber := int64(1)
-
-	gotConfig = testutil.ConfigFromMap(t, m, "velero/templates/restic-daemonset.yaml")
+	gotConfig = testutil.ConfigFromMap(t, m, resticDS)
 
 	testutil.MatchJSONPathInt64Value(t, gotConfig, jsonPath, expectedNumber)
 }

--- a/pkg/k8sutil/create.go
+++ b/pkg/k8sutil/create.go
@@ -28,7 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/yaml"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/kinvolk/lokomotive/internal"
@@ -90,7 +90,7 @@ func LoadManifests(files map[string]string) ([]manifest, error) {
 // parseManifests parses a YAML or JSON document that may contain one or more
 // kubernetes resources.
 func parseManifests(r io.Reader) ([]manifest, error) {
-	reader := yaml.NewYAMLReader(bufio.NewReader(r))
+	reader := yamlutil.NewYAMLReader(bufio.NewReader(r))
 	var manifests []manifest
 	for {
 		yamlManifest, err := reader.Read()
@@ -105,7 +105,7 @@ func parseManifests(r io.Reader) ([]manifest, error) {
 			continue
 		}
 
-		jsonManifest, err := yaml.ToJSON(yamlManifest)
+		jsonManifest, err := yamlutil.ToJSON(yamlManifest)
 		if err != nil {
 			return nil, fmt.Errorf("invalid manifest: %w", err)
 		}


### PR DESCRIPTION
This change was introduced in 8d44c8513f67512527218c8a538e79a61cb7cd34 - "don't expose Envoy using hostPorts". But a later commit overrode it: 6a6a3c5d849b981559c2cc2cf3797bfd6b6c9159 - "contour: Update to v1.7.0". This commit fixes this regression.

Fixes: https://github.com/kinvolk/lokomotive/issues/1336