### PR TITLE
pkg/components/util: Fix bug with multiple hooks in same manifest in helm chart

### DIFF
--- a/pkg/components/util/helm.go
+++ b/pkg/components/util/helm.go
@@ -59,7 +59,11 @@ func RenderChart(helmChart *chart.Chart, name, namespace, values string) (map[st
 
 	// Include hooks
 	for _, m := range template.Hooks {
-		ret[m.Path] = m.Manifest
+		if val, ok := ret[m.Path]; ok {
+			ret[m.Path] = val + "\n---\n" + m.Manifest
+		} else {
+			ret[m.Path] = m.Manifest
+		}
 	}
 
 	// CRD are not rendered, so do this manually

--- a/pkg/components/util/helm.go
+++ b/pkg/components/util/helm.go
@@ -59,11 +59,11 @@ func RenderChart(helmChart *chart.Chart, name, namespace, values string) (map[st
 
 	// Include hooks
 	for _, m := range template.Hooks {
-		if val, ok := ret[m.Path]; ok {
-			ret[m.Path] = val + "\n---\n" + m.Manifest
-		} else {
-			ret[m.Path] = m.Manifest
-		}
+                if _, ok := ret[m.Path]; !ok {
+                        ret[m.Path] = ""
+                }
+                
+                ret[m.Path] += "---\n" + m.Manifest
 	}
 
 	// CRD are not rendered, so do this manually

--- a/pkg/components/util/helm.go
+++ b/pkg/components/util/helm.go
@@ -59,11 +59,11 @@ func RenderChart(helmChart *chart.Chart, name, namespace, values string) (map[st
 
 	// Include hooks
 	for _, m := range template.Hooks {
-                if _, ok := ret[m.Path]; !ok {
-                        ret[m.Path] = ""
-                }
-                
-                ret[m.Path] += "---\n" + m.Manifest
+		if _, ok := ret[m.Path]; !ok {
+			ret[m.Path] = ""
+		}
+
+		ret[m.Path] += "---\n" + m.Manifest
 	}
 
 	// CRD are not rendered, so do this manually


### PR DESCRIPTION
# Allow multiple hooks in same manifest in helm chart

If a helm chart contains multiple hooks in one manisfest file, the hooks result are overridden because the map key is the same for each one.

# How to use

Use chart with multiple hooks in the same manifest file.

# Testing done

Consider a manifest with two TLS certs generated by hooks.

```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: {{ $fullName }}-controller-tls
  annotations:
    "helm.sh/resource-policy": "keep"
    "helm.sh/hook": "pre-install"
    "helm.sh/hook-delete-policy": "before-hook-creation"
    "directives.qbec.io/update-policy": "never"
type: kubernetes.io/tls
data:
  tls.crt: "[...]"
  tls.key: "[...]"
  ca.crt: "[...]"
---
apiVersion: v1
kind: Secret
metadata:
  name: {{ $fullName }}-client-tls
  annotations:
    "helm.sh/resource-policy": "keep"
    "helm.sh/hook": "pre-install"
    "helm.sh/hook-delete-policy": "before-hook-creation"
    "directives.qbec.io/update-policy": "never"
type: kubernetes.io/tls
data:
  tls.crt: [...]
  tls.key: [...]
  ca.crt: [...]
```

With the current behavior, only the second one is kept.
With the patch, all manifests are stored.
