### PR TITLE
packet: update terraform provider to 3.2.1

### DIFF
--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/versions.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/versions.tf
@@ -18,7 +18,7 @@ terraform {
     }
     packet = {
       source  = "packethost/packet"
-      version = "3.0.1"
+      version = "3.2.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/versions.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     packet = {
       source  = "packethost/packet"
-      version = "3.0.1"
+      version = "3.2.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -277,7 +277,7 @@ terraform {
   required_providers {
     packet = {
       source  = "packethost/packet"
-      version = "3.0.1"
+      version = "3.2.1"
     }
   }
 }


### PR DESCRIPTION

# Update the Terraform Packet Provider version

Updating the Terraform Packet Provider version fixes problems with n2 devices due to recent Equinix Metal API changes.

Addresses #1346 

With recent Equinix Metal API changes, v3.0.1 of the provider can not
properly detect the network type configuration for n2.xlarge.86 devices.

v3.2.1 does not have this problem.

# How to use

Deploy a Packet cluster with n2.xlarge.x86 devices

# Testing done

None with `lokoctl`. 😢 

I have verified that this version of the Packet provider does not have the problem stated in #1346.

```hcl
terraform {
  required_providers {
    packet = {
      source = "packethost/packet"
      version = "3.2.1"
    }
  }
}
provider "packet" {
  auth_token = var.token
}
resource "packet_device" "test" {
  hostname         = "test-n2-layer3"
  plan             = "n2.xlarge.x86"
  facilities       = ["da11"]
  operating_system = "ubuntu_16_04"
  billing_cycle    = "hourly"
  project_id       = var.project_id
}
resource "packet_device_network_type" "test" {
  device_id = packet_device.test.id
  type      = "layer3"
}
```

