### PR TITLE
packet: update terraform provider to 3.2.1

### DIFF
--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/versions.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/versions.tf
@@ -18,7 +18,7 @@ terraform {
     }
     packet = {
       source  = "packethost/packet"
-      version = "3.0.1"
+      version = "3.2.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/versions.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     packet = {
       source  = "packethost/packet"
-      version = "3.0.1"
+      version = "3.2.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -277,7 +277,7 @@ terraform {
   required_providers {
     packet = {
       source  = "packethost/packet"
-      version = "3.0.1"
+      version = "3.2.1"
     }
   }
 }


### PR DESCRIPTION
With recent Equinix Metal API changes, `v3.0.1` of the provider can not properly detect the network type configuration for `n2.xlarge.86` devices.

`v3.2.1` does not have this problem.

### Testing

Add the following worker pool to the packet cluster config and it should create the cluster without failing with issues like: `Strange 2-bond ports conf - bond0: layer3, bond1: layer2-bonded`.

```tf
  worker_pool "scylla" {
    count = 1
    node_type = "n2.xlarge.x86"
    disable_bgp = true
  }
```

This is based on the work by @displague from https://github.com/kinvolk/lokomotive/pull/1347. I just ran `make install` to add all the updated assets shipped with the binary.