### PR TITLE
EM: Add worker pool specific facility param

### DIFF
--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -15,8 +15,8 @@ module "bootkube" {
   etcd_endpoints       = packet_device.controllers.*.access_private_ipv4
 
   # Select private Packet NIC by using the can-reach Calico autodetection option with the first
-  # host in our private CIDR.
-  network_ip_autodetection_method = "can-reach=${cidrhost(var.node_private_cidr, 1)}"
+  # controller's private IP.
+  network_ip_autodetection_method = "can-reach=${packet_device.controllers[0].access_private_ipv4}"
 
   pod_cidr              = var.pod_cidr
   service_cidr          = var.service_cidr

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/calico-host-protection.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/calico-host-protection.tf
@@ -30,11 +30,10 @@ resource "local_file" "calico_host_protection" {
       }
     ],
     management_cidrs = var.management_cidrs
-    cluster_cidrs = [
-      var.node_private_cidr,
+    cluster_cidrs = concat([
       var.pod_cidr,
       var.service_cidr
-    ],
+    ], var.node_private_cidrs),
   })
 
   filename = "${var.asset_dir}/charts/kube-system/calico-host-protection.yaml"

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/variables.tf
@@ -134,9 +134,9 @@ variable "management_cidrs" {
   type        = list(string)
 }
 
-variable "node_private_cidr" {
-  description = "Private IPv4 CIDR of the nodes used to allow inter-node traffic"
-  type        = string
+variable "node_private_cidrs" {
+  description = "List of private IPv4 CIDRs of the nodes used to allow inter-node traffic"
+  type        = list(string)
 }
 
 variable "enable_aggregation" {

--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -28,14 +28,14 @@ EOF
 
   project_id = "$PACKET_PROJECT_ID"
 
-  ssh_pubkeys       = ["$PUB_KEY"]
-  management_cidrs  = ["0.0.0.0/0"]
+  ssh_pubkeys        = ["$PUB_KEY"]
+  management_cidrs   = ["0.0.0.0/0"]
   node_private_cidrs = ["10.0.0.0/8"]
 
   worker_pool "pool-1" {
     count     = 2
     node_type = "c2.medium.x86"
-    labels        = {
+    labels = {
       "testing.io" = "yes",
       "roleofnode" = "testing",
     }

--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -30,7 +30,7 @@ EOF
 
   ssh_pubkeys       = ["$PUB_KEY"]
   management_cidrs  = ["0.0.0.0/0"]
-  node_private_cidr = "10.0.0.0/8"
+  node_private_cidrs = ["10.0.0.0/8"]
 
   worker_pool "pool-1" {
     count     = 2

--- a/ci/packet_arm/packet_arm-cluster.lokocfg.envsubst
+++ b/ci/packet_arm/packet_arm-cluster.lokocfg.envsubst
@@ -32,8 +32,8 @@ EOF
   os_channel      = "alpha"
   controller_type = "c2.large.arm"
 
-  ssh_pubkeys       = ["$PUB_KEY"]
-  management_cidrs  = ["0.0.0.0/0"]
+  ssh_pubkeys        = ["$PUB_KEY"]
+  management_cidrs   = ["0.0.0.0/0"]
   node_private_cidrs = ["10.0.0.0/8"]
 
   worker_pool "pool-1" {

--- a/ci/packet_arm/packet_arm-cluster.lokocfg.envsubst
+++ b/ci/packet_arm/packet_arm-cluster.lokocfg.envsubst
@@ -34,7 +34,7 @@ EOF
 
   ssh_pubkeys       = ["$PUB_KEY"]
   management_cidrs  = ["0.0.0.0/0"]
-  node_private_cidr = "10.0.0.0/8"
+  node_private_cidrs = ["10.0.0.0/8"]
 
   worker_pool "pool-1" {
     count           = 1

--- a/ci/packet_fluo/packet_fluo-cluster.lokocfg.envsubst
+++ b/ci/packet_fluo/packet_fluo-cluster.lokocfg.envsubst
@@ -28,8 +28,8 @@ EOF
 
   project_id = "$PACKET_PROJECT_ID"
 
-  ssh_pubkeys       = ["$PUB_KEY"]
-  management_cidrs  = ["0.0.0.0/0"]
+  ssh_pubkeys        = ["$PUB_KEY"]
+  management_cidrs   = ["0.0.0.0/0"]
   node_private_cidrs = ["10.0.0.0/8"]
 
   worker_pool "general" {
@@ -44,7 +44,7 @@ EOF
   }
 
   worker_pool "storage" {
-    count = 3
+    count     = 3
     node_type = "c2.medium.x86"
 
     labels = {
@@ -77,7 +77,7 @@ component "rook" {
 }
 
 component "rook-ceph" {
-  monitor_count = 3
+  monitor_count  = 3
   enable_toolbox = true
 
   node_affinity {
@@ -93,7 +93,7 @@ component "rook-ceph" {
   }
 
   storage_class {
-    enable = true
+    enable  = true
     default = true
   }
 }

--- a/ci/packet_fluo/packet_fluo-cluster.lokocfg.envsubst
+++ b/ci/packet_fluo/packet_fluo-cluster.lokocfg.envsubst
@@ -30,7 +30,7 @@ EOF
 
   ssh_pubkeys       = ["$PUB_KEY"]
   management_cidrs  = ["0.0.0.0/0"]
-  node_private_cidr = "10.0.0.0/8"
+  node_private_cidrs = ["10.0.0.0/8"]
 
   worker_pool "general" {
     count     = 1

--- a/cli/cmd/cluster/utils_internal_test.go
+++ b/cli/cmd/cluster/utils_internal_test.go
@@ -176,7 +176,7 @@ func TestGetKubeconfigSourceFlag(t *testing.T) {
   controller_count  = 0
   facility          = ""
   management_cidrs  = []
-  node_private_cidr = ""
+  node_private_cidrs = ["10.10.10.10"]
   project_id        = ""
   ssh_pubkeys       = []
   dns {
@@ -218,7 +218,7 @@ func TestGetKubeconfigSourceConfigFile(t *testing.T) {
   controller_count  = 0
   facility          = ""
   management_cidrs  = []
-  node_private_cidr = ""
+  node_private_cidrs = ["10.10.10.10"]
   project_id        = ""
   ssh_pubkeys       = []
   dns {
@@ -281,7 +281,7 @@ func TestGetKubeconfigFromAssetsDir(t *testing.T) {
   controller_count  = 0
   facility          = ""
   management_cidrs  = []
-  node_private_cidr = ""
+  node_private_cidrs = ["10.10.10.10"]
   project_id        = ""
   ssh_pubkeys       = []
   dns {

--- a/cli/cmd/cluster/utils_internal_test.go
+++ b/cli/cmd/cluster/utils_internal_test.go
@@ -172,13 +172,13 @@ func TestGetKubeconfigSourceFlag(t *testing.T) {
 		configFile: `cluster "packet" {
   asset_dir = "/bad"
 
-  cluster_name      = ""
-  controller_count  = 0
-  facility          = ""
-  management_cidrs  = []
+  cluster_name       = ""
+  controller_count   = 0
+  facility           = ""
+  management_cidrs   = []
   node_private_cidrs = ["10.10.10.10"]
-  project_id        = ""
-  ssh_pubkeys       = []
+  project_id         = ""
+  ssh_pubkeys        = []
   dns {
     provider = ""
     zone     = ""
@@ -214,13 +214,13 @@ func TestGetKubeconfigSourceConfigFile(t *testing.T) {
 		configFile: `cluster "packet" {
   asset_dir = "/foo"
 
-  cluster_name      = ""
-  controller_count  = 0
-  facility          = ""
-  management_cidrs  = []
+  cluster_name       = ""
+  controller_count   = 0
+  facility           = ""
+  management_cidrs   = []
   node_private_cidrs = ["10.10.10.10"]
-  project_id        = ""
-  ssh_pubkeys       = []
+  project_id         = ""
+  ssh_pubkeys        = []
   dns {
     provider = ""
     zone     = ""
@@ -277,13 +277,13 @@ func TestGetKubeconfigFromAssetsDir(t *testing.T) {
 		configFile: fmt.Sprintf(`cluster "packet" {
   asset_dir = "%s"
 
-  cluster_name      = ""
-  controller_count  = 0
-  facility          = ""
-  management_cidrs  = []
+  cluster_name       = ""
+  controller_count   = 0
+  facility           = ""
+  management_cidrs   = []
   node_private_cidrs = ["10.10.10.10"]
-  project_id        = ""
-  ssh_pubkeys       = []
+  project_id         = ""
+  ssh_pubkeys        = []
   dns {
     provider = ""
     zone     = ""

--- a/docs/configuration-reference/platforms/baremetal.md
+++ b/docs/configuration-reference/platforms/baremetal.md
@@ -36,8 +36,6 @@ variable "controller_names" {}
 variable "worker_domains" {}
 variable "worker_macs" {}
 variable "worker_names" {}
-variable "management_cidrs" {}
-variable "node_private_cidr" {}
 variable "state_s3_bucket" {}
 variable "lock_dynamodb_table" {}
 variable "oidc_issuer_url" {}

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -43,6 +43,7 @@ variable "oidc_client_id" {}
 variable "oidc_username_claim" {}
 variable "oidc_groups_claim" {}
 variable "worker_clc_snippets" {}
+variable "worker_pool_facility" {}
 
 backend "s3" {
   bucket         = var.state_s3_bucket
@@ -144,6 +145,8 @@ cluster "packet" {
 
     disable_bgp = false
 
+    facility = var.worker_pool_facility
+
     node_type = var.workers_type
 
     os_channel = "stable"
@@ -243,6 +246,7 @@ node_type = var.custom_default_worker_type
 | `worker_pool.os_channel`              | Flatcar Container Linux channel to install from (stable, beta, alpha, edge).                                                                                                                                                                                                                                                       | "stable"        | string       | false    |
 | `worker_pool.os_version`              | Flatcar Container Linux version to install. Version such as "2303.3.1" or "current".                                                                                                                                                                                                                                               | "current"       | string       | false    |
 | `worker_pool.node_type`               | Packet instance type for worker nodes.                                                                                                                                                                                                                                                                                             | "c3.small.x86"  | string       | false    |
+| `worker_pool.facility`                | Packet facility to use for deploying the worker pool. Enable ["Backend Transfer"](https://metal.equinix.com/developers/docs/networking/features/#backend-transfer) on the Equinix Metal project for this to work.                                                                                                        | Same as controller nodes. | string       | false    |
 | `worker_pool.labels`                  | Map of extra Kubernetes Node labels for worker nodes.                                                                                                                                                                                                                                                                              | -               | map(string)  | false    |
 | `worker_pool.taints`                  | Map of Taints to assign to worker nodes.                                                                                                                                                                                                                                                                                           | -               | map(string)  | false    |
 | `worker_pool.reservation_ids`         | Block with Packet hardware reservation IDs for worker nodes. Each key must have the format `worker-${index}` and the value is the reservation UUID. Can't be combined with `reservation_ids_default`. Key indexes must be sequential and start from 0. Example: `reservation_ids = { worker-0 = "<reservation_id>" }`.             | -               | map(string)  | false    |

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -35,7 +35,7 @@ variable "route53_zone_id" {}
 variable "packet_project_id" {}
 variable "ssh_public_keys" {}
 variable "management_cidrs" {}
-variable "node_private_cidr" {}
+variable "node_private_cidrs" {}
 variable "state_s3_bucket" {}
 variable "lock_dynamodb_table" {}
 variable "oidc_issuer_url" {}
@@ -90,7 +90,7 @@ cluster "packet" {
 
   management_cidrs = var.management_cidrs
 
-  node_private_cidr = var.node_private_cidr
+  node_private_cidrs = var.node_private_cidrs
 
   cluster_domain_suffix = "cluster.local"
 
@@ -222,7 +222,8 @@ node_type = var.custom_default_worker_type
 | `os_version`                          | Flatcar Container Linux version to install. Version such as "2303.3.1" or "current".                                                                                                                                                                                                                                               | "current"       | string       | false    |
 | `ipxe_script_url`                     | Boot via iPXE. Required for arm64.                                                                                                                                                                                                                                                                                                 | -               | string       | false    |
 | `management_cidrs`                    | List of IPv4 CIDRs authorized to access or manage the cluster. Example ["0.0.0.0/0"] to allow all.                                                                                                                                                                                                                                 | -               | list(string) | true     |
-| `node_private_cidr`                   | Private IPv4 CIDR of the nodes used to allow inter-node traffic. Example "10.0.0.0/8"                                                                                                                                                                                                                                              | -               | string       | true     |
+| `node_private_cidr`                   | (Deprecated, use `node_private_cidrs` instead) Private IPv4 CIDR of the nodes used to allow inter-node traffic. Example "10.0.0.0/8".                                                                                                                                                                                              | -               | string       | true     |
+| `node_private_cidrs`                  | List of Private IPv4 CIDRs of the nodes used to allow inter-node traffic. Example ["10.0.0.0/8"].                                                                                                                                                                                                                                  | -               | list(string) | true     |
 | `enable_aggregation`                  | Enable the Kubernetes Aggregation Layer.                                                                                                                                                                                                                                                                                           | true            | bool         | false    |
 | `enable_tls_bootstrap`                | Enable TLS bootstraping for Kubelet.                                                                                                                                                                                                                                                                                               | true            | bool         | false    |
 | `encrypt_pod_traffic`                 | Enable in-cluster pod traffic encryption. If true `network_mtu` is reduced by 60 to make room for the encryption header.                                                                                                                                                                                                           | false           | bool         | false    |

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -109,7 +109,7 @@ cluster "packet" {
 
   ssh_pubkeys       = ["ssh-rsa AAAA..."]
   management_cidrs  = ["0.0.0.0/0"]
-  node_private_cidr = "10.0.0.0/8"
+  node_private_cidrs = ["10.0.0.0/8"]
 
   controller_count = 1
 

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -94,27 +94,27 @@ Create a file named `cluster.lokocfg` with the following contents:
 
 ```hcl
 cluster "packet" {
-  asset_dir        = "./assets"
-  cluster_name     = "lokomotive-demo"
+  asset_dir    = "./assets"
+  cluster_name = "lokomotive-demo"
 
   dns {
     zone     = "example.com"
     provider = "route53"
   }
 
-  facility = "ams1"
+  facility   = "ams1"
   project_id = "89273817-4f44-4b41-9f0c-cb00bf538542"
 
   controller_type = "c3.small.x86"
 
-  ssh_pubkeys       = ["ssh-rsa AAAA..."]
-  management_cidrs  = ["0.0.0.0/0"]
+  ssh_pubkeys        = ["ssh-rsa AAAA..."]
+  management_cidrs   = ["0.0.0.0/0"]
   node_private_cidrs = ["10.0.0.0/8"]
 
   controller_count = 1
 
   worker_pool "pool-1" {
-    count       = 2
+    count     = 2
     node_type = "c3.small.x86"
   }
 }

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -173,11 +173,11 @@ Your configurations are stored in ./assets
 
 Now checking health and readiness of the cluster nodes ...
 
-Node                             Ready    Reason          Message                            
-                                                                                             
-lokomotive-demo-controller-0       True     KubeletReady    kubelet is posting ready status    
-lokomotive-demo-pool-1-worker-0    True     KubeletReady    kubelet is posting ready status    
-lokomotive-demo-pool-1-worker-1    True     KubeletReady    kubelet is posting ready status    
+Node                             Ready    Reason          Message
+
+lokomotive-demo-controller-0       True     KubeletReady    kubelet is posting ready status
+lokomotive-demo-pool-1-worker-0    True     KubeletReady    kubelet is posting ready status
+lokomotive-demo-pool-1-worker-1    True     KubeletReady    kubelet is posting ready status
 
 Success - cluster is healthy and nodes are ready!
 ```
@@ -219,13 +219,13 @@ Sample output:
 
 ```
 {
-  "args": {}, 
+  "args": {},
   "headers": {
-    "Accept": "*/*", 
-    "Host": "localhost:8080", 
+    "Accept": "*/*",
+    "Host": "localhost:8080",
     "User-Agent": "curl/7.70.0"
-  }, 
-  "origin": "127.0.0.1", 
+  },
+  "origin": "127.0.0.1",
   "url": "http://localhost:8080/get"
 }
 ```

--- a/examples/packet-production/cluster.lokocfg
+++ b/examples/packet-production/cluster.lokocfg
@@ -3,7 +3,7 @@ variable "route53_zone_id" {}
 variable "packet_project_id" {}
 variable "ssh_public_keys" {}
 variable "management_cidrs" {}
-variable "node_private_cidr" {}
+variable "node_private_cidrs" {}
 variable "cert_manager_email" {}
 variable "state_s3_bucket" {}
 variable "lock_dynamodb_table" {}
@@ -78,7 +78,7 @@ cluster "packet" {
 
   ssh_pubkeys       = var.ssh_public_keys
   management_cidrs  = var.management_cidrs
-  node_private_cidr = var.node_private_cidr
+  node_private_cidrs = var.node_private_cidrs
 
   worker_pool "pool-1" {
     count     = var.workers_count

--- a/examples/packet-production/cluster.lokocfg
+++ b/examples/packet-production/cluster.lokocfg
@@ -76,8 +76,8 @@ cluster "packet" {
 
   project_id = var.packet_project_id
 
-  ssh_pubkeys       = var.ssh_public_keys
-  management_cidrs  = var.management_cidrs
+  ssh_pubkeys        = var.ssh_public_keys
+  management_cidrs   = var.management_cidrs
   node_private_cidrs = var.node_private_cidrs
 
   worker_pool "pool-1" {

--- a/examples/packet-testing/cluster.lokocfg
+++ b/examples/packet-testing/cluster.lokocfg
@@ -54,8 +54,8 @@ cluster "packet" {
 
   project_id = var.packet_project_id
 
-  ssh_pubkeys       = var.ssh_public_keys
-  management_cidrs  = var.management_cidrs
+  ssh_pubkeys        = var.ssh_public_keys
+  management_cidrs   = var.management_cidrs
   node_private_cidrs = var.node_private_cidrs
 
   worker_pool "pool-1" {

--- a/examples/packet-testing/cluster.lokocfg
+++ b/examples/packet-testing/cluster.lokocfg
@@ -33,8 +33,8 @@ variable "management_cidrs" {
   default = ["0.0.0.0/0"]
 }
 
-variable "node_private_cidr" {
-  default = "10.0.0.0/8"
+variable "node_private_cidrs" {
+  default = ["10.0.0.0/8"]
 }
 
 cluster "packet" {
@@ -56,7 +56,7 @@ cluster "packet" {
 
   ssh_pubkeys       = var.ssh_public_keys
   management_cidrs  = var.management_cidrs
-  node_private_cidr = var.node_private_cidr
+  node_private_cidrs = var.node_private_cidrs
 
   worker_pool "pool-1" {
     count     = var.workers_count

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kinvolk/lokomotive
 
-go 1.12
+go 1.15
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -46,6 +46,7 @@ const (
 type workerPool struct {
 	Name                  string            `hcl:"pool_name,label"`
 	Count                 int               `hcl:"count"`
+	Facility              string            `hcl:"facility,optional"`
 	DisableBGP            bool              `hcl:"disable_bgp,optional"`
 	IPXEScriptURL         string            `hcl:"ipxe_script_url,optional"`
 	OSArch                string            `hcl:"os_arch,optional"`

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -53,7 +53,12 @@ module "packet-{{.Config.ClusterName}}" {
   ipxe_script_url = "{{ .Config.IPXEScriptURL }}"
   {{ end }}
   management_cidrs = {{.ManagementCIDRs}}
-  node_private_cidr = "{{.Config.NodePrivateCIDR}}"
+
+  node_private_cidrs = [
+    {{- range .NodePrivateCIDRs }}
+    "{{ . }}",
+    {{- end }}
+  ]
 
   enable_aggregation = {{.Config.EnableAggregation}}
 

--- a/pkg/platform/packet/template.go
+++ b/pkg/platform/packet/template.go
@@ -160,7 +160,13 @@ EOF
   {{- end }}
 
   project_id   = "{{$.Config.ProjectID}}"
+
+  {{- if $pool.Facility }}
+  facility     = "{{$pool.Facility}}"
+  {{- else }}
   facility     = "{{$.Config.Facility}}"
+  {{- end }}
+
   {{- if $.Config.ClusterDomainSuffix }}
   cluster_domain_suffix = "{{$.Config.ClusterDomainSuffix}}"
   {{- end }}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,6 +4,7 @@ github.com/Azure/go-ansiterm/winterm
 # github.com/BurntSushi/toml v0.3.1
 github.com/BurntSushi/toml
 # github.com/MakeNowJust/heredoc v1.0.0
+## explicit
 github.com/MakeNowJust/heredoc
 # github.com/Masterminds/goutils v1.1.0
 github.com/Masterminds/goutils
@@ -40,8 +41,10 @@ github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
 # github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
+## explicit
 github.com/StackExchange/wmi
 # github.com/agext/levenshtein v1.2.3
+## explicit
 github.com/agext/levenshtein
 # github.com/apparentlymart/go-textseg/v12 v12.0.0
 github.com/apparentlymart/go-textseg/v12/textseg
@@ -52,6 +55,7 @@ github.com/beorn7/perks/quantile
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/containerd/cgroups v0.0.0-20200308110149-6c3dec43a103
+## explicit
 github.com/containerd/cgroups/stats/v1
 # github.com/containerd/containerd v1.3.4
 github.com/containerd/containerd/archive/compression
@@ -70,6 +74,7 @@ github.com/containerd/containerd/remotes/docker/schema1
 github.com/containerd/containerd/sys
 github.com/containerd/containerd/version
 # github.com/containerd/continuity v0.0.0-20200228182428-0f16d7a0959c
+## explicit
 github.com/containerd/continuity/pathdriver
 # github.com/cpuguy83/go-md2man/v2 v2.0.0
 github.com/cpuguy83/go-md2man/v2/md2man
@@ -85,6 +90,7 @@ github.com/deislabs/oras/pkg/content
 github.com/deislabs/oras/pkg/context
 github.com/deislabs/oras/pkg/oras
 # github.com/docker/cli v0.0.0-20200312141509-ef2f64abbd37
+## explicit
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
 github.com/docker/cli/cli/config/credentials
@@ -103,6 +109,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 # github.com/docker/docker v1.13.1 => github.com/docker/engine v1.4.2-0.20191113042239-ea84732a7725
+## explicit
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev
 github.com/docker/docker/api/types/container
@@ -136,6 +143,7 @@ github.com/docker/go-connections/nat
 github.com/docker/go-connections/sockets
 github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-metrics v0.0.1
+## explicit
 github.com/docker/go-metrics
 # github.com/docker/go-units v0.4.0
 github.com/docker/go-units
@@ -143,6 +151,7 @@ github.com/docker/go-units
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
 # github.com/emicklei/go-restful v2.12.0+incompatible
+## explicit
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.9.0+incompatible
@@ -150,6 +159,7 @@ github.com/evanphx/json-patch
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 github.com/exponent-io/jsonpath
 # github.com/fatih/color v1.9.0
+## explicit
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
@@ -158,6 +168,7 @@ github.com/ghodss/yaml
 # github.com/go-logr/logr v0.2.0
 github.com/go-logr/logr
 # github.com/go-ole/go-ole v1.2.4
+## explicit
 github.com/go-ole/go-ole
 github.com/go-ole/go-ole/oleutil
 # github.com/go-openapi/jsonpointer v0.19.3
@@ -165,8 +176,10 @@ github.com/go-openapi/jsonpointer
 # github.com/go-openapi/jsonreference v0.19.3
 github.com/go-openapi/jsonreference
 # github.com/go-openapi/spec v0.19.7 => github.com/go-openapi/spec v0.19.8
+## explicit
 github.com/go-openapi/spec
 # github.com/go-openapi/swag v0.19.8
+## explicit
 github.com/go-openapi/swag
 # github.com/gobwas/glob v0.2.3
 github.com/gobwas/glob
@@ -183,6 +196,7 @@ github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/protoc-gen-gogo/descriptor
 github.com/gogo/protobuf/sortkeys
 # github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+## explicit
 github.com/golang/glog
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
@@ -195,6 +209,7 @@ github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/go-cmp v0.5.2
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
@@ -209,17 +224,21 @@ github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/openapiv2
 # github.com/gorilla/mux v1.7.4
+## explicit
 github.com/gorilla/mux
 # github.com/gosuri/uitable v0.0.4
 github.com/gosuri/uitable
 github.com/gosuri/uitable/util/strutil
 github.com/gosuri/uitable/util/wordwrap
 # github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
+## explicit
 github.com/gregjones/httpcache
 github.com/gregjones/httpcache/diskcache
 # github.com/hashicorp/go-version v1.2.0
+## explicit
 github.com/hashicorp/go-version
 # github.com/hashicorp/golang-lru v0.5.4
+## explicit
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/hashicorp/hcl v1.0.0
@@ -234,6 +253,7 @@ github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/hashicorp/hcl/v2 v2.7.2
+## explicit
 github.com/hashicorp/hcl/v2
 github.com/hashicorp/hcl/v2/ext/customdecode
 github.com/hashicorp/hcl/v2/gohcl
@@ -242,6 +262,7 @@ github.com/hashicorp/hcl/v2/hclsyntax
 github.com/hashicorp/hcl/v2/hclwrite
 github.com/hashicorp/hcl/v2/json
 # github.com/hpcloud/tail v1.0.0
+## explicit
 github.com/hpcloud/tail
 github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
@@ -259,7 +280,10 @@ github.com/jmoiron/sqlx/reflectx
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
 # github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
+## explicit
 github.com/kardianos/osext
+# github.com/kylelemons/godebug v1.1.0
+## explicit
 # github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
 github.com/lann/builder
 # github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0
@@ -271,30 +295,37 @@ github.com/lib/pq/scram
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 github.com/liggitt/tabwriter
 # github.com/linkerd/linkerd2 v0.5.1-0.20200623171206-83ae0ccf0f1a
+## explicit
 github.com/linkerd/linkerd2/pkg/tls
 # github.com/magiconair/properties v1.8.1
 github.com/magiconair/properties
 # github.com/mailru/easyjson v0.7.1
+## explicit
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
 # github.com/mattn/go-colorable v0.1.6
+## explicit
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.12
 github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.8
+## explicit
 github.com/mattn/go-runewidth
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mitchellh/copystructure v1.0.0
 github.com/mitchellh/copystructure
 # github.com/mitchellh/go-homedir v1.1.0
+## explicit
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-wordwrap v1.0.1
+## explicit
 github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.1
+## explicit
 github.com/mitchellh/reflectwalk
 # github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
 github.com/moby/term
@@ -314,16 +345,20 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
 # github.com/packethost/packngo v0.2.0
+## explicit
 github.com/packethost/packngo
 # github.com/pelletier/go-toml v1.6.0
+## explicit
 github.com/pelletier/go-toml
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/prometheus/alertmanager v0.20.0
+## explicit
 github.com/prometheus/alertmanager/pkg/modtimevfs
 # github.com/prometheus/client_golang v1.7.1
+## explicit
 github.com/prometheus/client_golang/api
 github.com/prometheus/client_golang/api/prometheus/v1
 github.com/prometheus/client_golang/prometheus
@@ -339,14 +374,18 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/rogpeppe/go-internal v1.6.1
+## explicit
 # github.com/rubenv/sql-migrate v0.0.0-20200616145509-8d140a17f351
 github.com/rubenv/sql-migrate
 github.com/rubenv/sql-migrate/sqlparse
 # github.com/russross/blackfriday v2.0.0+incompatible => github.com/russross/blackfriday v1.5.2
+## explicit
 github.com/russross/blackfriday
 # github.com/russross/blackfriday/v2 v2.0.1
 github.com/russross/blackfriday/v2
 # github.com/shirou/gopsutil v2.20.2+incompatible
+## explicit
 github.com/shirou/gopsutil/cpu
 github.com/shirou/gopsutil/internal/common
 github.com/shirou/gopsutil/mem
@@ -355,13 +394,16 @@ github.com/shirou/gopsutil/process
 # github.com/shopspring/decimal v1.2.0
 github.com/shopspring/decimal
 # github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
+## explicit
 github.com/shurcooL/httpfs/union
 github.com/shurcooL/httpfs/vfsutil
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
 # github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
+## explicit
 github.com/shurcooL/vfsgen
 # github.com/sirupsen/logrus v1.7.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero
@@ -369,23 +411,29 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.1
 github.com/spf13/cast
 # github.com/spf13/cobra v1.1.1
+## explicit
 github.com/spf13/cobra
 github.com/spf13/cobra/doc
 # github.com/spf13/jwalterweatherman v1.1.0
+## explicit
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/spf13/viper v1.7.0
+## explicit
 github.com/spf13/viper
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
 # github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb
+## explicit
 github.com/xeipuuv/gojsonpointer
 # github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
 github.com/xeipuuv/gojsonreference
 # github.com/xeipuuv/gojsonschema v1.2.0
 github.com/xeipuuv/gojsonschema
 # github.com/zclconf/go-cty v1.7.0
+## explicit
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/convert
 github.com/zclconf/go-cty/cty/function
@@ -446,6 +494,8 @@ golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 golang.org/x/time/rate
+# golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6
+## explicit
 # google.golang.org/appengine v1.6.5
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/base
@@ -457,6 +507,7 @@ google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.28.0
+## explicit
 google.golang.org/grpc/codes
 google.golang.org/grpc/connectivity
 google.golang.org/grpc/grpclog
@@ -500,12 +551,14 @@ gopkg.in/gorp.v1
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/ini.v1 v1.54.0
+## explicit
 gopkg.in/ini.v1
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.3.0
 gopkg.in/yaml.v2
 # helm.sh/helm/v3 v3.5.1 => github.com/kinvolk/helm/v3 v3.5.1-2-g498bb0c0
+## explicit
 helm.sh/helm/v3/internal/experimental/registry
 helm.sh/helm/v3/internal/fileutil
 helm.sh/helm/v3/internal/ignore
@@ -542,6 +595,7 @@ helm.sh/helm/v3/pkg/storage
 helm.sh/helm/v3/pkg/storage/driver
 helm.sh/helm/v3/pkg/time
 # k8s.io/api v0.20.2
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -593,6 +647,7 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 # k8s.io/apimachinery v0.20.2
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -661,6 +716,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.20.2 => k8s.io/client-go v0.20.2
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
@@ -846,4 +902,12 @@ sigs.k8s.io/kustomize/pkg/types
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.2
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
+# github.com/docker/docker => github.com/docker/engine v1.4.2-0.20191113042239-ea84732a7725
+# github.com/docker/spdystream => github.com/moby/spdystream v0.1.0
+# github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
+# github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+# helm.sh/helm/v3 => github.com/kinvolk/helm/v3 v3.5.1-2-g498bb0c0
+# github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.8
+# k8s.io/client-go => k8s.io/client-go v0.20.2


### PR DESCRIPTION
This commit adds a param to the worker pools called facility. This
allows users to choose a different facility/region than the controller
nodes. The default behaviour is to deploy controllers and workers in the
same facility.

Signed-off-by: Suraj Deshmukh <suraj@kinvolk.io>