### PR TITLE
EM: Add restart on-failure for metadata service

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -45,6 +45,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -99,6 +99,8 @@ systemd:
         [Unit]
         Description=Waiting to delete Kubernetes node on shutdown
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -20,6 +20,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -39,6 +39,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -84,6 +84,8 @@ systemd:
         [Unit]
         Description=Waiting to delete Kubernetes node on shutdown
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -20,6 +20,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -53,6 +53,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -29,6 +29,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -39,6 +39,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -13,6 +13,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -78,6 +78,8 @@ systemd:
         [Unit]
         Description=Waiting to delete Kubernetes node on shutdown
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -39,6 +39,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -87,6 +87,8 @@ systemd:
         [Unit]
         Description=Waiting to delete Kubernetes node on shutdown
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -20,6 +20,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/node/templates/node.yaml.tmpl
+++ b/assets/terraform-modules/node/templates/node.yaml.tmpl
@@ -13,6 +13,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'

--- a/assets/terraform-modules/node/templates/node.yaml.tmpl
+++ b/assets/terraform-modules/node/templates/node.yaml.tmpl
@@ -92,6 +92,8 @@ systemd:
         [Unit]
         Description=Waiting to delete Kubernetes node on shutdown
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -79,6 +79,8 @@ systemd:
         Description=Flatcar Metadata Agent
         [Service]
         Type=oneshot
+        Restart=on-failure
+        RestartSec=10s
         Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
         ExecStart=/usr/bin/coreos-metadata $${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
         [Install]

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -76,7 +76,7 @@ systemd:
       enable: true
       contents: |
         [Unit]
-        Description=Flatcar Metadata Agent
+        Description=Flatcar Container Linux Metadata Agent
         [Service]
         Type=oneshot
         Restart=on-failure

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -49,6 +49,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service etcd-member.service bootkube.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done; /opt/wait-for-dns ${dns_zone} ${cluster_name}-private 3600'

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -129,6 +129,8 @@ systemd:
         [Unit]
         Description=Waiting to delete Kubernetes node on shutdown
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -41,6 +41,8 @@ systemd:
         Description=Flatcar Container Linux Metadata Agent
         [Service]
         Type=oneshot
+        Restart=on-failure
+        RestartSec=10s
         Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
         ExecStart=/usr/bin/coreos-metadata $${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/flatcar
         [Install]

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -29,6 +29,8 @@ systemd:
         Wants=systemd-resolved.service
         Before=kubelet.service
         [Service]
+        Restart=on-failure
+        RestartSec=5s
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done; /opt/wait-for-dns ${dns_zone} ${cluster_name}-private 3600'


### PR DESCRIPTION
This PR adds `Restart=on-failure` and `RestartSec=5s` to the metadata service.

Fixes https://github.com/kinvolk/lokomotive/issues/1298

---

The other services which have `Type=oneshot` are following: `wait-for-dns`, `bootkube`, `delete-node`, `create-etcd-config`, `persist-data-raid`.

Most of them are the type of services which we want them to fail early and the user know about it, instead of them endlessly trying and someone else doing a time out on them.