### PR TITLE
Remove a deprecated cert-manager namespace label

### DIFF
--- a/pkg/components/cert-manager/component.go
+++ b/pkg/components/cert-manager/component.go
@@ -101,9 +101,6 @@ func (c *component) Metadata() components.Metadata {
 		Name: Name,
 		Namespace: k8sutil.Namespace{
 			Name: c.Namespace,
-			Labels: map[string]string{
-				"certmanager.k8s.io/disable-validation": "true",
-			},
 		},
 		Helm: components.HelmMetadata{
 			// Cert-manager registers admission webhooks, so we should wait for the webhook to


### PR DESCRIPTION
# Remove a deprecated cert-manager namespace label

This removed an old label on the Kubernetes namespace that is no longer needed for cert-manager and would no longer work after 0.11 ;) 

# How to use

no new features added, just should be tested that everything stays working

# Testing done

none, any preferred testing I should perform?

