### PR TITLE
Fix wrong etcd settings

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -52,7 +52,7 @@ systemd:
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'
         [Install]
         RequiredBy=kubelet.service
-        RequiredBy=etcd-member.service
+        RequiredBy=etcd.service
     - name: kubelet.service
       enable: true
       contents: |
@@ -211,7 +211,7 @@ storage:
           # Rejoin a cluster as fresh node when etcd cannot join
           # (e.g., after repovisioning, crashing or node being down).
           # Set ExecStopPost=-/opt/etcd-rejoin to run when etcd failed and
-          # use env vars of etcd-member.service.
+          # use env vars of etcd.service.
           # Skip if not provisioned
           if [ ! -d "/etc/ssl/etcd/" ]; then exit 0; fi
           # or got stopped.
@@ -243,13 +243,14 @@ storage:
           etcdctl member add "$ETCD_NAME" --peer-urls="$ETCD_INITIAL_ADVERTISE_PEER_URLS" $ARGS
           # Join fresh without state
           mv /var/lib/etcd "/var/lib/etcd-bkp-$(date +%s)" || true
-          if [ -z "$(grep ETCD_INITIAL_CLUSTER_STATE=existing /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf)" ]; then
-            echo 'Environment="ETCD_INITIAL_CLUSTER_STATE=existing"' >> /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf
+          install -m 700 -o etcd -g etcd -d /var/lib/etcd
+          if [ -z "$(grep ETCD_INITIAL_CLUSTER_STATE=existing /etc/kubernetes/etcd.env)" ]; then
+            echo ETCD_INITIAL_CLUSTER_STATE=existing >> /etc/kubernetes/etcd.env
             # Apply change
             systemctl daemon-reload
           fi
           # Restart unit (yes, within itself)
-          systemctl restart etcd-member &
+          systemctl restart etcd &
     - path: /etc/kubernetes/configure-kubelet-cgroup-driver
       filesystem: root
       mode: 0744

--- a/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
+++ b/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
@@ -82,7 +82,7 @@ storage:
           # Rejoin a cluster as fresh node when etcd cannot join
           # (e.g., after repovisioning, crashing or node being down).
           # Set ExecStopPost=-/opt/etcd-rejoin to run when etcd failed and
-          # use env vars of etcd-member.service.
+          # use env vars of etcd.service.
           # Skip if not provisioned
           if [ ! -d "/etc/ssl/etcd/" ]; then exit 0; fi
           # or got stopped.
@@ -114,10 +114,11 @@ storage:
           etcdctl member add "$ETCD_NAME" --peer-urls="$ETCD_INITIAL_ADVERTISE_PEER_URLS" $ARGS
           # Join fresh without state
           mv /var/lib/etcd "/var/lib/etcd-bkp-$(date +%s)" || true
-          if [ -z "$(grep ETCD_INITIAL_CLUSTER_STATE=existing /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf)" ]; then
-            echo 'Environment="ETCD_INITIAL_CLUSTER_STATE=existing"' >> /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf
+          install -m 700 -o etcd -g etcd -d /var/lib/etcd
+          if [ -z "$(grep ETCD_INITIAL_CLUSTER_STATE=existing /etc/kubernetes/etcd.env)" ]; then
+            echo ETCD_INITIAL_CLUSTER_STATE=existing >> /etc/kubernetes/etcd.env
             # Apply change
             systemctl daemon-reload
           fi
           # Restart unit (yes, within itself)
-          systemctl restart etcd-member &
+          systemctl restart etcd &

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -47,7 +47,7 @@ systemd:
         [Unit]
         Description=Wait for DNS entries
         Wants=systemd-resolved.service
-        Before=kubelet.service etcd-member.service bootkube.service
+        Before=kubelet.service etcd.service bootkube.service
         [Service]
         Restart=on-failure
         RestartSec=5s
@@ -55,16 +55,16 @@ systemd:
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done; /opt/wait-for-dns ${dns_zone} ${cluster_name}-private 3600'
         [Install]
-        RequiredBy=kubelet.service etcd-member.service bootkube.service
+        RequiredBy=kubelet.service etcd.service bootkube.service
     - name: create-etcd-config.service
       # This service will extract value of private interface from the env var file `/run/metadata/flatcar`.
       # And then assign it to the variables that which will be stored in file `/etc/kubernetes/etcd.config`,
-      # this file is sourced by etcd-member service.
+      # this file is sourced by etcd service.
       enable: true
       contents: |
         [Unit]
         Description=Create a etcd env file to be used by etcd to listen on private interface
-        Before=etcd-member.service
+        Before=etcd.service
         Requires=coreos-metadata.service
         After=coreos-metadata.service
         [Service]
@@ -73,7 +73,7 @@ systemd:
         RemainAfterExit=true
         ExecStart=/bin/sh -c 'echo "ETCD_LISTEN_CLIENT_URLS=https://$COREOS_PACKET_IPV4_PRIVATE_0:2379" > /etc/kubernetes/etcd.config && echo "ETCD_LISTEN_PEER_URLS=https://$COREOS_PACKET_IPV4_PRIVATE_0:2380" >> /etc/kubernetes/etcd.config && echo "ETCD_LISTEN_METRICS_URLS=http://$COREOS_PACKET_IPV4_PRIVATE_0:2381" >> /etc/kubernetes/etcd.config'
         [Install]
-        RequiredBy=etcd-member.service
+        RequiredBy=etcd.service
     - name: coreos-metadata.service
       enable: true
       contents: |
@@ -265,7 +265,7 @@ storage:
           # Rejoin a cluster as fresh node when etcd cannot join
           # (e.g., after repovisioning, crashing or node being down).
           # Set ExecStopPost=-/opt/etcd-rejoin to run when etcd failed and
-          # use env vars of etcd-member.service.
+          # use env vars of etcd.service.
           # Skip if not provisioned
           if [ ! -d "/etc/ssl/etcd/" ]; then exit 0; fi
           # or got stopped.
@@ -297,13 +297,14 @@ storage:
           etcdctl member add "$ETCD_NAME" --peer-urls="$ETCD_INITIAL_ADVERTISE_PEER_URLS" $ARGS
           # Join fresh without state
           mv /var/lib/etcd "/var/lib/etcd-bkp-$(date +%s)" || true
-          if [ -z "$(grep ETCD_INITIAL_CLUSTER_STATE=existing /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf)" ]; then
-            echo 'Environment="ETCD_INITIAL_CLUSTER_STATE=existing"' >> /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf
+          install -m 700 -o etcd -g etcd -d /var/lib/etcd
+          if [ -z "$(grep ETCD_INITIAL_CLUSTER_STATE=existing /etc/kubernetes/etcd.env)" ]; then
+            echo ETCD_INITIAL_CLUSTER_STATE=existing >> /etc/kubernetes/etcd.env
             # Apply change
             systemctl daemon-reload
           fi
           # Restart unit (yes, within itself)
-          systemctl restart etcd-member &
+          systemctl restart etcd &
     - path: /var/lib/iptables/rules-save
       filesystem: root
       mode: 0644

--- a/docs/how-to-guides/update-etcd.md
+++ b/docs/how-to-guides/update-etcd.md
@@ -48,9 +48,9 @@ Run the following commands:
 export etcd_version=<latest etcd version e.g. v3.4.10>
 
 sudo sed -i "s,IMAGE_TAG=.*,IMAGE_TAG=${etcd_version}\"," \
-        /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf
+        /etc/kubernetes/etcd.env
 sudo systemctl daemon-reload
-sudo systemctl restart etcd-member
+sudo systemctl restart etcd
 ```
 
 ### Step 4: Verify update
@@ -58,14 +58,14 @@ sudo systemctl restart etcd-member
 Verify that the etcd service is in `active (running)` state:
 
 ```bash
-sudo systemctl status --no-pager etcd-member
+sudo systemctl status --no-pager etcd
 ```
 
 Run the following command to see logs of the process since the last restart:
 
 ```bash
 sudo journalctl _SYSTEMD_INVOCATION_ID=$(sudo systemctl \
-              show -p InvocationID --value etcd-member.service)
+              show -p InvocationID --value etcd.service)
 ```
 
 > **NOTE**: Do not proceed with the update of the rest of the cluster if you encounter any errors.


### PR DESCRIPTION
The rkt-based etcd-member service that is part of Flatcar used a unit
    drop-in file but the new etcd service uses an environment file and
    requires the folder to be set up with certain permissions.

With these changes it works again to recreate a controller node in an HA control plane cluster.
Changes were not done for baremetal because they are part of https://github.com/kinvolk/lokomotive/pull/1333 already.

Fixes https://github.com/kinvolk/lokomotive/issues/1381