### PR TITLE
Add component node-problem-detector

### DIFF
--- a/assets/charts/components/node-problem-detector/Chart.yaml
+++ b/assets/charts/components/node-problem-detector/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+name: node-problem-detector
+version: "1.8.6"
+appVersion: v0.8.5
+home: https://github.com/kubernetes/node-problem-detector
+description: |
+  This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
+icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
+keywords:
+- node
+- problem
+- detector
+- monitoring
+sources:
+- https://github.com/kubernetes/node-problem-detector
+- https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+maintainers:
+- name: max-rocket-internet
+  email: no-reply@deliveryhero.com
+engine: gotpl

--- a/assets/charts/components/node-problem-detector/README.md
+++ b/assets/charts/components/node-problem-detector/README.md
@@ -1,0 +1,90 @@
+# node-problem-detector
+
+![Version: 1.8.6](https://img.shields.io/badge/Version-1.8.6-informational?style=flat-square) ![AppVersion: v0.8.5](https://img.shields.io/badge/AppVersion-v0.8.5-informational?style=flat-square)
+
+This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
+
+**Homepage:** <https://github.com/kubernetes/node-problem-detector>
+
+## How to install this chart
+
+Add Delivery Hero public chart repo:
+
+```console
+helm repo add deliveryhero https://charts.deliveryhero.io/
+```
+
+A simple install with default values:
+
+```console
+helm install deliveryhero/node-problem-detector
+```
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release deliveryhero/node-problem-detector
+```
+
+To install with some set values:
+
+```console
+helm install my-release deliveryhero/node-problem-detector --set values_key1=value1 --set values_key2=value2
+```
+
+To install with custom values file:
+
+```console
+helm install my-release deliveryhero/node-problem-detector -f values.yaml
+```
+
+## Source Code
+
+* <https://github.com/kubernetes/node-problem-detector>
+* <https://kubernetes.io/docs/concepts/architecture/nodes/#condition>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| annotations | object | `{}` |  |
+| env | string | `nil` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| hostNetwork | bool | `false` | Run pod on host network Flag to run Node Problem Detector on the host's network. This is typically not recommended, but may be useful for certain use cases. |
+| hostPID | bool | `false` |  |
+| hostpath.logdir | string | `"/var/log/"` | Log directory path on K8s host |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
+| image.tag | string | `"v0.8.5"` |  |
+| imagePullSecrets | list | `[]` |  |
+| labels | object | `{}` |  |
+| maxUnavailable | int | `1` | The max pods unavailable during an update |
+| metrics.serviceMonitor.additionalLabels | object | `{}` |  |
+| metrics.serviceMonitor.enabled | bool | `false` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| priorityClassName | string | `""` |  |
+| rbac.create | bool | `true` |  |
+| rbac.pspEnabled | bool | `false` |  |
+| resources | object | `{}` |  |
+| securityContext.privileged | bool | `true` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `nil` |  |
+| settings.custom_monitor_definitions | object | `{}` | Custom plugin monitor config files |
+| settings.custom_plugin_monitors | list | `[]` |  |
+| settings.heartBeatPeriod | string | `"5m0s"` | Syncing interval with API server |
+| settings.log_monitors | list | `["/config/kernel-monitor.json","/config/docker-monitor.json"]` | User-specified custom monitor definitions |
+| settings.prometheus_address | string | `"0.0.0.0"` | Prometheus exporter address |
+| settings.prometheus_port | int | `20257` | Prometheus exporter port |
+| tolerations[0].effect | string | `"NoSchedule"` |  |
+| tolerations[0].operator | string | `"Exists"` |  |
+| updateStrategy | string | `"RollingUpdate"` | Manage the daemonset update strategy |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| max-rocket-internet | no-reply@deliveryhero.com |  |

--- a/assets/charts/components/node-problem-detector/templates/NOTES.txt
+++ b/assets/charts/components/node-problem-detector/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that the node-problem-detector pods have started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "node-problem-detector.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/assets/charts/components/node-problem-detector/templates/_helpers.tpl
+++ b/assets/charts/components/node-problem-detector/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "node-problem-detector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "node-problem-detector.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "node-problem-detector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "node-problem-detector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "node-problem-detector.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the configmap for storing custom monitor definitions
+*/}}
+{{- define "node-problem-detector.customConfig" -}}
+{{- $fullname := include "node-problem-detector.fullname" . -}}
+{{- printf "%s-custom-config" $fullname | replace "+" "_" | trunc 63 -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for podSecurityPolicy.
+*/}}
+{{- define "podSecurityPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.10-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/assets/charts/components/node-problem-detector/templates/clusterrole.yaml
+++ b/assets/charts/components/node-problem-detector/templates/clusterrole.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+{{- end -}}

--- a/assets/charts/components/node-problem-detector/templates/clusterrolebinding.yaml
+++ b/assets/charts/components/node-problem-detector/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "node-problem-detector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "node-problem-detector.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/assets/charts/components/node-problem-detector/templates/custom-config-configmap.yaml
+++ b/assets/charts/components/node-problem-detector/templates/custom-config-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+{{ .Values.settings.custom_monitor_definitions | toYaml | indent 2 }}
+kind: ConfigMap
+metadata:
+  name: {{ include "node-problem-detector.customConfig" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/assets/charts/components/node-problem-detector/templates/daemonset.yaml
+++ b/assets/charts/components/node-problem-detector/templates/daemonset.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "node-problem-detector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $val := .Values.labels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end}}
+spec:
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+{{- if eq .Values.updateStrategy "RollingUpdate"}}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.maxUnavailable }}
+{{- end}}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app: {{ include "node-problem-detector.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app: {{ include "node-problem-detector.name" . }}
+        {{- range $key, $val := .Values.labels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end}}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/custom-config-configmap.yaml") . | sha256sum }}
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      hostPID: {{ .Values.hostPID }}
+      terminationGracePeriodSeconds: 30
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" | quote }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "exec /node-problem-detector --logtostderr --config.system-log-monitor={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- if .Values.settings.custom_plugin_monitors }} --custom-plugin-monitors={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }} --prometheus-address={{ .Values.settings.prometheus_address }} --prometheus-port={{ .Values.settings.prometheus_port }} --k8s-exporter-heartbeat-period={{ .Values.settings.heartBeatPeriod }}"
+{{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+{{- end }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 12 }}
+{{- end }}
+          volumeMounts:
+            - name: log
+              mountPath: {{ .Values.hostpath.logdir }}
+            - name: localtime
+              mountPath: /etc/localtime
+              readOnly: true
+            - name: custom-config
+              mountPath: /custom-config
+              readOnly: true
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+{{- end }}
+          ports:
+            - containerPort: {{ .Values.settings.prometheus_port }}
+              name: exporter
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+      volumes:
+        - name: log
+          hostPath:
+            path: {{ .Values.hostpath.logdir }}
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+            type: "FileOrCreate"
+        - name: custom-config
+          configMap:
+            name: {{ include "node-problem-detector.customConfig" . }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}

--- a/assets/charts/components/node-problem-detector/templates/psp-clusterrole.yaml
+++ b/assets/charts/components/node-problem-detector/templates/psp-clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "node-problem-detector.fullname" . }}
+{{- end }}

--- a/assets/charts/components/node-problem-detector/templates/psp-clusterrolebinding.yaml
+++ b/assets/charts/components/node-problem-detector/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "node-problem-detector.fullname" . }}-psp
+subjects:
+- kind: ServiceAccount
+  name: {{ template "node-problem-detector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/assets/charts/components/node-problem-detector/templates/psp.yaml
+++ b/assets/charts/components/node-problem-detector/templates/psp.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'persistentVolumeClaim'
+  - 'hostPath'
+  hostNetwork: {{ .Values.hostNetwork }}
+  hostIPC: false
+  hostPID: {{ .Values.hostPID }}
+  {{- if .Values.hostNetwork }}
+  hostPorts:
+  - min: {{ .Values.settings.prometheus_port }}
+    max: {{ .Values.settings.prometheus_port }}
+  {{- end }}
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/assets/charts/components/node-problem-detector/templates/service.yaml
+++ b/assets/charts/components/node-problem-detector/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app: {{ include "node-problem-detector.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: exporter
+    port: {{ .Values.settings.prometheus_port }}
+    protocol: TCP
+  selector:
+    app: {{ include "node-problem-detector.name" . }}
+{{- end }}

--- a/assets/charts/components/node-problem-detector/templates/serviceaccount.yaml
+++ b/assets/charts/components/node-problem-detector/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "node-problem-detector.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/assets/charts/components/node-problem-detector/templates/servicemonitor.yaml
+++ b/assets/charts/components/node-problem-detector/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "node-problem-detector.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: exporter
+    path: /metrics
+    interval: 60s
+    relabelings:
+    - action: replace
+      targetLabel: node
+      sourceLabels:
+        - __meta_kubernetes_pod_node_name
+    - action: replace
+      targetLabel: host_ip
+      sourceLabels:
+        - __meta_kubernetes_pod_host_ip
+{{- end }}

--- a/assets/charts/components/node-problem-detector/values.yaml
+++ b/assets/charts/components/node-problem-detector/values.yaml
@@ -1,0 +1,98 @@
+settings:
+  # Custom monitor definitions to add to Node Problem Detector - to be
+  # mounted at /custom-config. These are in addition to pre-packaged monitor
+  # definitions provided within the default docker image available at /config:
+  # https://github.com/kubernetes/node-problem-detector/tree/master/config
+  # settings.custom_monitor_definitions -- Custom plugin monitor config files
+  custom_monitor_definitions: {}
+  # settings.log_monitors -- User-specified custom monitor definitions
+  log_monitors:
+    - /config/kernel-monitor.json
+    - /config/docker-monitor.json
+    # - /custom-config/kernel-monitor.json
+    # - /custom-config/docker-monitor-filelog.json
+    # An example of activating a custom log monitor definition in
+    # Node Problem Detector
+    # - /custom-config/docker-monitor-filelog.json
+  custom_plugin_monitors: []
+
+  # settings.prometheus_address -- Prometheus exporter address
+  prometheus_address: 0.0.0.0
+  # settings.prometheus_port -- Prometheus exporter port
+  prometheus_port: 20257
+
+  # The period at which k8s-exporter does forcibly sync with apiserver
+  # settings.heartBeatPeriod -- Syncing interval with API server
+  heartBeatPeriod: 5m0s
+
+hostpath:
+  # hostpath.logdir -- Log directory path on K8s host
+  logdir: /var/log/
+
+image:
+  repository: k8s.gcr.io/node-problem-detector/node-problem-detector
+  tag: v0.8.5
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+rbac:
+  create: true
+  pspEnabled: false
+
+# hostNetwork -- Run pod on host network
+# Flag to run Node Problem Detector on the host's network. This is typically
+# not recommended, but may be useful for certain use cases.
+hostNetwork: false
+hostPID: false
+
+priorityClassName: ""
+
+securityContext:
+  privileged: true
+
+resources: {}
+
+annotations: {}
+
+labels: {}
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+affinity: {}
+
+nodeSelector: {}
+
+metrics:
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+
+env:
+#  - name: FOO
+#    value: BAR
+#  - name: POD_NAME
+#    valueFrom:
+#      fieldRef:
+#        fieldPath: metadata.name
+
+extraVolumes: []
+
+extraVolumeMounts: []
+
+# updateStrategy -- Manage the daemonset update strategy
+updateStrategy: RollingUpdate
+# maxUnavailable -- The max pods unavailable during an update
+maxUnavailable: 1

--- a/ci/aks/aks-cluster.lokocfg.envsubst
+++ b/ci/aks/aks-cluster.lokocfg.envsubst
@@ -127,3 +127,7 @@ component "web-ui" {
 }
 
 component "inspektor-gadget" {}
+
+component "node-problem-detector" {
+  service_monitor = true
+}

--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -294,3 +294,7 @@ component "web-ui" {
 }
 
 component "inspektor-gadget" {}
+
+component "node-problem-detector" {
+  service_monitor = true
+}

--- a/ci/baremetal/baremetal-cluster.lokocfg.envsubst
+++ b/ci/baremetal/baremetal-cluster.lokocfg.envsubst
@@ -59,3 +59,5 @@ cluster "bare-metal" {
 }
 
 component "inspektor-gadget" {}
+
+component "node-problem-detector" {}

--- a/ci/packet/packet-cluster.lokocfg.envsubst
+++ b/ci/packet/packet-cluster.lokocfg.envsubst
@@ -250,3 +250,7 @@ EOF
     service_monitor = true
   }
 }
+
+component "node-problem-detector" {
+  service_monitor = true
+}

--- a/cli/cmd/cluster/component.go
+++ b/cli/cmd/cluster/component.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kinvolk/lokomotive/pkg/components/linkerd"
 	"github.com/kinvolk/lokomotive/pkg/components/metallb"
 	metricsserver "github.com/kinvolk/lokomotive/pkg/components/metrics-server"
+	nodeproblemdetector "github.com/kinvolk/lokomotive/pkg/components/node-problem-detector"
 	openebsoperator "github.com/kinvolk/lokomotive/pkg/components/openebs-operator"
 	openebsstorageclass "github.com/kinvolk/lokomotive/pkg/components/openebs-storage-class"
 	"github.com/kinvolk/lokomotive/pkg/components/prometheus-operator"
@@ -64,6 +65,7 @@ func componentsConfigs() map[string]components.Component {
 		rookceph.Name:                   rookceph.NewConfig(),
 		velero.Name:                     velero.NewConfig(),
 		webui.Name:                      webui.NewConfig(),
+		nodeproblemdetector.Name:        nodeproblemdetector.NewConfig(),
 	}
 }
 

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -92,6 +92,7 @@ Available components:
 	 inspektor-gadget
 	 metallb
 	 metrics-server
+        node-problem-detector
 	 openebs-operator
 	 openebs-storage-class
 	 prometheus-operator

--- a/docs/configuration-reference/components/node-problem-detector.md
+++ b/docs/configuration-reference/components/node-problem-detector.md
@@ -1,0 +1,57 @@
+# node-problem-detector configuration reference for Lokomotive
+
+## Contents
+
+* [Introduction](#introduction)
+* [Prerequisites](#prerequisites)
+* [Configuration](#configuration)
+* [Attribute reference](#attribute-reference)
+* [Applying](#applying)
+* [Deleting](#deleting)
+
+## Introduction
+
+[node-problem-detector](https://github.com/kubernetes/node-problem-detector) aims to make various node problems visible to the upstream layers in the cluster management stack.
+
+It is a daemon that runs on each node, detects node problems and reports them to apiserver.
+
+## Prerequisites
+
+* A Lokomotive cluster accessible via `kubectl`.
+
+## Configuration
+
+```tf
+# node-problem-detector.lokocfg
+component "node-problem-detector" {
+  custom_monitors = [file("system-stats-monitor.json")]
+}
+```
+
+## Attribute reference
+
+Table of all the arguments accepted by the component.
+
+Example:
+
+| Argument          | Description                                                                                                                                                      | Default      | Type   | Required |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|--------|----------|
+| `custom_monitors` | List of paths to system log monitor configuration files. [See](https://github.com/kubernetes/node-problem-detector/tree/master/config) for more custom monitors. | list(string) | string | false    |
+| `service_monitor` | Specifies how metrics can be retrieved from a set of services.                                                                                                   | false        | bool   | false    |
+
+
+## Applying
+
+To apply the node-problem-detector component:
+
+```bash
+lokoctl component apply node-problem-detector
+```
+
+## Deleting
+
+To destroy the component:
+
+```bash
+lokoctl component delete node-problem-detector
+```

--- a/pkg/components/node-problem-detector/component.go
+++ b/pkg/components/node-problem-detector/component.go
@@ -1,0 +1,93 @@
+// Copyright 2021 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nodeproblemdetector is code for node-problem-detector.
+package nodeproblemdetector
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+
+	"github.com/kinvolk/lokomotive/internal/template"
+	"github.com/kinvolk/lokomotive/pkg/components"
+	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
+)
+
+const (
+	// Name represents node-problem-detector component name as it should be referenced in function calls
+	// and in configuration.
+	Name = "node-problem-detector"
+)
+
+type component struct {
+	CustomMonitors []string `hcl:"custom_monitors,optional"`
+	ServiceMonitor bool     `hcl:"service_monitor,optional"`
+	Namespace      string
+}
+
+// NewConfig returns new node-problem-detector component configuration with default values set.
+//
+//nolint:golint
+func NewConfig() *component {
+	return &component{
+		Namespace: "kube-system",
+	}
+}
+
+// LoadConfig loads the component config.
+func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContext) hcl.Diagnostics {
+	if configBody == nil {
+		return hcl.Diagnostics{
+			components.HCLDiagConfigBodyNil,
+		}
+	}
+
+	if err := gohcl.DecodeBody(*configBody, evalContext, c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RenderManifests renders the Helm chart templates with values provided.
+func (c *component) RenderManifests() (map[string]string, error) {
+	helmChart, err := components.Chart(Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving chart from assets: %w", err)
+	}
+
+	values, err := template.Render(chartValuesTmpl, c)
+	if err != nil {
+		return nil, fmt.Errorf("rendering chart values template: %w", err)
+	}
+
+	renderedFiles, err := util.RenderChart(helmChart, Name, c.Metadata().Namespace.Name, values)
+	if err != nil {
+		return nil, fmt.Errorf("rendering chart: %w", err)
+	}
+
+	return renderedFiles, nil
+}
+
+func (c *component) Metadata() components.Metadata {
+	return components.Metadata{
+		Name: Name,
+		Namespace: k8sutil.Namespace{
+			Name: c.Namespace,
+		},
+	}
+}

--- a/pkg/components/node-problem-detector/component_test.go
+++ b/pkg/components/node-problem-detector/component_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeproblemdetector_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/kinvolk/lokomotive/pkg/components/internal/testutil"
+	nodeproblemdetector "github.com/kinvolk/lokomotive/pkg/components/node-problem-detector"
+	"github.com/kinvolk/lokomotive/pkg/components/util"
+)
+
+const name = "node-problem-detector"
+
+func TestRenderManifest(t *testing.T) {
+	tests := []struct {
+		desc    string
+		hcl     string
+		wantErr bool
+	}{
+		{
+			desc: "Valid config",
+			hcl: `
+component "node-problem-detector" {
+	custom_monitors = ["testdata"]
+}
+			`,
+		},
+	}
+
+	for _, tc := range tests {
+		b, d := util.GetComponentBody(tc.hcl, name)
+		if d != nil {
+			t.Errorf("%s - Error getting component body: %v", tc.desc, d)
+		}
+
+		c := nodeproblemdetector.NewConfig()
+
+		d = c.LoadConfig(b, nil)
+
+		if !tc.wantErr && d.HasErrors() {
+			t.Errorf("%s - Valid config should not return error, got: %s", tc.desc, d)
+		}
+
+		if tc.wantErr && !d.HasErrors() {
+			t.Errorf("%s - Wrong config should have returned an error", tc.desc)
+		}
+
+		m, err := c.RenderManifests()
+		if err != nil {
+			t.Errorf("%s - Rendering manifests with valid config should succeed, got: %s", tc.desc, err)
+		}
+
+		if len(m) == 0 {
+			t.Errorf("%s - Rendered manifests shouldn't be empty", tc.desc)
+		}
+	}
+}
+
+func TestRenderManifestConfigMapCustomMonitor(t *testing.T) {
+	configHCL := `
+component "node-problem-detector" {
+	custom_monitors = ["testdata"]
+}
+`
+
+	component := nodeproblemdetector.NewConfig()
+
+	body, d := util.GetComponentBody(configHCL, name)
+	if d.HasErrors() {
+		t.Fatalf("Error getting component body: %v", d)
+	}
+
+	if d = component.LoadConfig(body, &hcl.EvalContext{}); d.HasErrors() {
+		t.Fatalf("Valid config should not return error, got: %v", d)
+	}
+
+	m := testutil.RenderManifests(t, component, name, configHCL)
+	jsonPath := "{.data.custom-monitor-0\\.json}"
+	expected := "testdata"
+
+	gotConfig := testutil.ConfigFromMap(t, m, "node-problem-detector/templates/custom-config-configmap.yaml")
+
+	testutil.MatchJSONPathStringValue(t, gotConfig, jsonPath, expected)
+}

--- a/pkg/components/node-problem-detector/doc.go
+++ b/pkg/components/node-problem-detector/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2021 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeproblemdetector

--- a/pkg/components/node-problem-detector/template.go
+++ b/pkg/components/node-problem-detector/template.go
@@ -1,0 +1,38 @@
+// Copyright 2021 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeproblemdetector
+
+const chartValuesTmpl = `
+image:
+  tag: v0.8.7
+{{- if .CustomMonitors }}
+settings:
+  {{- range $key, $val := .CustomMonitors }}
+  custom_monitor_definitions:
+    "custom-monitor-{{ $key }}.json": '{{ $val }}'
+  log_monitors:
+    - "/custom-config/custom-monitor-{{ $key }}.json"
+  {{- end }}
+    - /config/kernel-monitor.json
+    - /config/docker-monitor.json
+{{- end }}
+{{- if .ServiceMonitor }}
+metrics:
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: prometheus-operator
+{{- end }}
+`

--- a/test/components/node-problem-detector/nodeproblemdetector_test.go
+++ b/test/components/node-problem-detector/nodeproblemdetector_test.go
@@ -1,0 +1,165 @@
+// Copyright 2021 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build aws aws_edge packet aks
+// +build e2e
+
+package nodeproblemdetector_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	testutil "github.com/kinvolk/lokomotive/test/components/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	daemonSetName = "node-problem-detector"
+	namespace     = "kube-system"
+)
+
+func TestNodeProblemDetectorDaemonSet(t *testing.T) {
+	client := testutil.CreateKubeClient(t)
+
+	testutil.WaitForDaemonSet(t, client, namespace, daemonSetName, testutil.RetryInterval, testutil.TimeoutSlow)
+}
+
+//nolint: funlen
+func TestNodeProblemDetectorNodeEvent(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.CreateKubeClient(t).CoreV1()
+	nsclient := client.Namespaces()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: testutil.TestNamespace("node-problem-detector"),
+		},
+	}
+
+	privileged := true
+	// Pod config.
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "node-problem-detector-test-",
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: "Never",
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &privileged,
+					},
+					Command: []string{"sh"},
+					Args: []string{"-c", "echo 'kernel: BUG: " +
+						"unable to handle kernel NULL pointer " +
+						"dereference at TESTING_IS_COOL' >> /dev/kmsg"},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "kmsg",
+							MountPath: "/dev/kmsg",
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "kmsg",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/dev/kmsg",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Creation of namespace.
+	ns, err := nsclient.Create(context.TODO(), ns, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("creating namespace: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := nsclient.Delete(context.TODO(), ns.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("failed removing namespace: %v", err)
+		}
+	})
+
+	podsClient := client.Pods(ns.Name)
+
+	// Retry pod creation. This might fail if node-problem-detector is not ready yet and some requests might fail.
+	if err := wait.PollImmediate(testutil.RetryInterval, testutil.TimeoutSlow, func() (done bool, err error) {
+		pod, err = podsClient.Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("retrying pod creation, failed with: %v", err)
+
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		t.Fatalf("creating pod: %v", err)
+	}
+
+	phase := corev1.PodUnknown
+
+	if err := wait.PollImmediate(testutil.RetryInterval, testutil.TimeoutSlow, func() (done bool, err error) {
+		p, err := podsClient.Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("couldn't get the pod %q: %w", pod.Name, err)
+		}
+
+		// Check for event.
+		events, err := client.Events("default").List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("couldn't list the events %w", err)
+		}
+
+		phase = p.Status.Phase
+		if phase == corev1.PodSucceeded || phase == corev1.PodFailed {
+			for _, v := range events.Items {
+				if v.Reason == "KernelOops" && strings.Contains(v.Message, "TESTING_IS_COOL") {
+					return true, nil
+				}
+			}
+		}
+
+		return false, nil
+	}); err != nil {
+		t.Errorf("waiting for the pod: %v", err)
+	}
+
+	// Since pod failed print the logs.
+	if phase == corev1.PodFailed {
+		t.Error("pod failed with following error:")
+
+		err := testutil.PrintPodsLogs(t, podsClient, &metav1.LabelSelector{MatchLabels: pod.Labels})
+		if err != nil {
+			t.Errorf("printing error logs failed: %v", err)
+		}
+	}
+}

--- a/test/monitoring/components_metrics_test.go
+++ b/test/monitoring/components_metrics_test.go
@@ -107,6 +107,11 @@ func testComponentsPrometheusMetrics(t *testing.T, v1api v1.API) {
 			query:         "controller_runtime_reconcile_time_seconds_count{controller=\"istiocontrolplane-controller\"}",
 			platforms:     []testutil.Platform{testutil.PlatformPacket, testutil.PlatformAWS, testutil.PlatformAKS},
 		},
+		{
+			componentName: "node-problem-detector",
+			query:         "problem_counter{reason=\"KernelOops\"}",
+			platforms:     []testutil.Platform{testutil.PlatformPacket, testutil.PlatformAWS, testutil.PlatformAKS},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This adds component node-problem-detector. For more information
refer to https://github.com/kubernetes/node-problem-detector.

closes: #39
Signed-off-by: knrt10 <kautilya@kinvolk.io>

## TODO

- [x] Add tests
- [x] Add component to CI

## How to use

Pass the following in your cluster config. To use `service_monitor` feature, make sure [Prometheus Operator](https://kinvolk.io/docs/lokomotive/0.6/configuration-reference/components/prometheus-operator/) component is installed

```bash
component "node-problem-detector" {
  service_monitor = true
}
```
