### PR TITLE
examples: Fix EM config

### DIFF
--- a/examples/packet-testing/cluster.lokocfg
+++ b/examples/packet-testing/cluster.lokocfg
@@ -30,7 +30,7 @@ variable "workers_type" {
 }
 
 variable "management_cidrs" {
-  default = "0.0.0.0/0"
+  default = ["0.0.0.0/0"]
 }
 
 variable "node_private_cidr" {


### PR DESCRIPTION
EM config shows management_cidrs as a string when it is a list of
string.
