### PR TITLE
tinkerbell: pass cluster_name to worker module

### DIFF
--- a/assets/terraform-modules/platforms/tinkerbell/workerpool/main.tf
+++ b/assets/terraform-modules/platforms/tinkerbell/workerpool/main.tf
@@ -4,6 +4,7 @@ module "worker" {
   count       = var.node_count
   count_index = count.index
 
+  cluster_name           = var.cluster_name
   cluster_dns_service_ip = var.cluster_dns_service_ip
   ssh_keys               = var.ssh_keys
   cluster_domain_suffix  = var.cluster_domain_suffix


### PR DESCRIPTION
This commit fixes a regression that came about when `cluster_name`
variable was added to the generic `worker` module in this commit
ee39dabb7a2a5fe4f1a5035d2284756e6d84ce22.

Since it is a required variable, tinkerbell ci failed.

This commit fixes the above issue, by passing the `cluster_name` to the
worker module.

Failed CI build : https://yard.lokomotive-k8s.net/teams/main/pipelines/master-tinkerbell/jobs/test-lokomotive-deployment/builds/43

Signed-off-by: Imran Pochi <imran@kinvolk.io>