### PR TITLE
EM: Add remain RemainAfterExit to metadata service

### DIFF
--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -81,6 +81,7 @@ systemd:
         Description=Flatcar Container Linux Metadata Agent
         [Service]
         Type=oneshot
+        RemainAfterExit=true
         Restart=on-failure
         RestartSec=10s
         Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -43,6 +43,7 @@ systemd:
         Description=Flatcar Container Linux Metadata Agent
         [Service]
         Type=oneshot
+        RemainAfterExit=true
         Restart=on-failure
         RestartSec=10s
         Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline


### PR DESCRIPTION
This commit adds `RemainAfterExit=true` to metadata service. Other
services of type `oneshot` already have it.

Fixes: #1371