### PR TITLE
Remove the Webhook setting of cert-manager

### DIFF
--- a/docs/configuration-reference/components/cert-manager.md
+++ b/docs/configuration-reference/components/cert-manager.md
@@ -23,7 +23,6 @@ cert-manager component configuration example:
 component "cert-manager" {
   email = "example@example.com"
   namespace = "cert-manager"
-  webhooks = false
 }
 ```
 
@@ -35,7 +34,6 @@ Table of all the arguments accepted by the component.
 |-------------------|----------------------------------------------------------------|:------------:|:------:|:--------:|
 | `email`           | Email used for certificates to receive expiry notifications.   |      -       | string |   true   |
 | `namespace`       | Namespace to deploy the cert-manager into.                     | cert-manager | string |  false   |
-| `webhooks`        | Controls if webhooks should be deployed.                       |     true     |  bool  |  false   |
 | `service_monitor` | Specifies how metrics can be retrieved from a set of services. |    false     |  bool  |  false   |
 
 

--- a/docs/configuration-reference/components/cert-manager.md
+++ b/docs/configuration-reference/components/cert-manager.md
@@ -1,5 +1,5 @@
 ---
-title: Cert-Manager configuration reference for Lokomotive
+title: cert-manager configuration reference for Lokomotive
 weight: 10
 ---
 

--- a/docs/configuration-reference/components/cert-manager.md
+++ b/docs/configuration-reference/components/cert-manager.md
@@ -21,7 +21,7 @@ cert-manager component configuration example:
 
 ```tf
 component "cert-manager" {
-  email = "example@example.com"
+  email     = "example@example.com"
   namespace = "cert-manager"
 }
 ```

--- a/pkg/components/cert-manager/component.go
+++ b/pkg/components/cert-manager/component.go
@@ -35,7 +35,6 @@ const (
 type component struct {
 	Email          string `hcl:"email,attr"`
 	Namespace      string `hcl:"namespace,optional"`
-	Webhooks       bool   `hcl:"webhooks,optional"`
 	ServiceMonitor bool   `hcl:"service_monitor,optional"`
 }
 
@@ -45,15 +44,12 @@ type component struct {
 func NewConfig() *component {
 	return &component{
 		Namespace:      "cert-manager",
-		Webhooks:       true,
 		ServiceMonitor: false,
 	}
 }
 
 const chartValuesTmpl = `
 email: {{.Email}}
-webhook:
-  enabled: {{.Webhooks}}
 {{ if .ServiceMonitor }}
 prometheus:
   servicemonitor:
@@ -103,7 +99,7 @@ func (c *component) Metadata() components.Metadata {
 			Name: c.Namespace,
 		},
 		Helm: components.HelmMetadata{
-			// Cert-manager registers admission webhooks, so we should wait for the webhook to
+			// cert-manager registers admission webhooks, so we should wait for the webhook to
 			// become ready before proceeding with installing other components, as it may fail.
 			// If webhooks are registered with 'failurePolicy: Fail', then kube-apiserver will reject
 			// creating objects requiring the webhook until the webhook itself becomes ready. So if the


### PR DESCRIPTION
# Remove the Webhook settiing of cert-manager

This removes the webhook flag from the cert-manager component as it did not function any longer. The no webhook version no longer exists.

# How to use

- install cert-manager

# Testing done

- Checked creation of fresh cluster
- Checked when upgrading from 0.6.1 to this commit

# Notes

~~So removing the HCL flag might need some upgrade path, keeping it draft for now till I worked that out :) Just a quick patch in between other work.~~

As discussed in Slack removing the flag is fine pre-1.0 , should be released in a new minor release with a note however. 
