### PR TITLE
Include a "v" in version strings when releasing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ builds:
   - CGO_ENABLED=0
   - GO111MODULE=on
   ldflags:
-  - -X github.com/kinvolk/lokomotive/pkg/version.Version={{.Version}}
+  - -X github.com/kinvolk/lokomotive/pkg/version.Version={{.Tag}}
   - -extldflags '-static'
   flags:
   - -buildmode=exe
@@ -35,3 +35,7 @@ release:
 
 archives:
 - wrap_in_directory: true
+  name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Tag }}_checksums.txt"

--- a/docs/quickstarts/packet.md
+++ b/docs/quickstarts/packet.md
@@ -70,8 +70,8 @@ Download the latest `lokoctl` binary for your platform:
 ```console
 export os=linux  # For macOS, use `os=darwin`.
 
-export release=$(curl -s https://api.github.com/repos/kinvolk/lokomotive/releases | jq -r '.[0].name' | tr -d v)
-curl -LO "https://github.com/kinvolk/lokomotive/releases/download/v${release}/lokoctl_${release}_${os}_amd64.tar.gz"
+export release=$(curl -s https://api.github.com/repos/kinvolk/lokomotive/releases | jq -r '.[0].name')
+curl -LO "https://github.com/kinvolk/lokomotive/releases/download/${release}/lokoctl_${release}_${os}_amd64.tar.gz"
 ```
 
 Extract the binary and copy it to a place under your `$PATH`:

--- a/docs/quickstarts/tinkerbell.md
+++ b/docs/quickstarts/tinkerbell.md
@@ -55,8 +55,8 @@ Download the latest `lokoctl` binary for your platform:
 ```console
 export os=linux  # For macOS, use `os=darwin`.
 
-export release=$(curl -s https://api.github.com/repos/kinvolk/lokomotive/releases | jq -r '.[0].name' | tr -d v)
-curl -LO "https://github.com/kinvolk/lokomotive/releases/download/v${release}/lokoctl_${release}_${os}_amd64.tar.gz"
+export release=$(curl -s https://api.github.com/repos/kinvolk/lokomotive/releases | jq -r '.[0].name')
+curl -LO "https://github.com/kinvolk/lokomotive/releases/download/${release}/lokoctl_${release}_${os}_amd64.tar.gz"
 ```
 
 Extract the binary and copy it to a place under your `$PATH`:


### PR DESCRIPTION
This PR ensures the version string printed by `lokoctl version` is consistent for binaries created using `make` and binaries created as part of the release process.

The GitHub URIs for released binaries are updated accordingly as well.

Fixes #1150.

To test the PR, create a fake Git tag, create a release without publishing it and ensure the printed version string has a "v":

```
git tag v0.7.0-test
goreleaser release --skip-publish --skip-sign
./dist/lokoctl_linux_amd64/lokoctl version
```