### PR TITLE
Add owner_id to the external-dns documentation example

### DIFF
--- a/docs/configuration-reference/components/external-dns.md
+++ b/docs/configuration-reference/components/external-dns.md
@@ -27,6 +27,7 @@ ExternalDNS component configuration example:
 ```tf
 component "external-dns" {
   # Required arguments.
+  owner_id = "lokomotive" # Must be unique value across the DNS zone that doesn't change.
   aws {
     # Required arguments
     zone_type = "public"


### PR DESCRIPTION
# Add owner_id to the external-dns documentation example

Discovered a missing example field when doing release testing. As this is required makes the example non functional.

# How to use

Read the documentation

# Testing done

used in a release test

