### PR TITLE
Update certified Kubernetes logo target URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ not shipped with upstream Kubernetes.
 
 ## Features
 
-<a href="https://landscape.cncf.io/selected=lokomotive"><img src="https://raw.githubusercontent.com/cncf/artwork/1c1a10d9cc7de24235e07c8831923874331ef233/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.svg" align="right" width="100px"></a>
+<a href="https://landscape.cncf.io/?selected=lokomotive"><img src="https://raw.githubusercontent.com/cncf/artwork/1c1a10d9cc7de24235e07c8831923874331ef233/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.svg" align="right" width="100px"></a>
 
 * Kubernetes 1.19 (upstream, via
   [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))


### PR DESCRIPTION
The old URL is deprecated and
https://landscape.cncf.io/?selected=lokomotive should be used instead.

# Testing done

Click on the logo and check that not deprecated URL message is shown in the CNCF landscape site. 

