### PR TITLE
docs/installer/lokoctl.md: Add missing "v"

### DIFF
--- a/docs/installer/lokoctl.md
+++ b/docs/installer/lokoctl.md
@@ -20,19 +20,19 @@ These binaries can be manually downloaded and installed.
    keys](https://github.com/kinvolk/lokomotive/blob/master/docs/KEYS.md).
 
 ```console
-gpg --verify lokoctl_0.7.0_linux_amd64.tar.gz.sig
+gpg --verify lokoctl_v0.7.0_linux_amd64.tar.gz.sig
 ```
 
 3. Unpack it
 
 ```console
-tar xvf lokoctl_0.7.0_linux_amd64.tar.gz
+tar xvf lokoctl_v0.7.0_linux_amd64.tar.gz
 ```
 
 4. Find the lokoctl binary in the unpacked directory and move it to its desired location
 
 ```console
-mv lokoctl_0.7.0_linux_amd64/lokoctl ~/.local/bin/lokoctl
+mv lokoctl_v0.7.0_linux_amd64/lokoctl ~/.local/bin/lokoctl
 ```
 
 5. Verify the version of `lokoctl`


### PR DESCRIPTION
Add a missing "v" in the installation guide which became necessary following https://github.com/kinvolk/lokomotive/pull/1417.

While this won't fix the docs for `v0.7.0`, it will help in the next releases.