### PR TITLE
align the golang version used

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.4'
+          # Keep aligned with GOLANG_VERSION in the Makefile.
+          go-version: '1.15.10'
         id: go
 
       - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang
+ARG GOLANG_VERSION=1.15.10
+FROM golang:${GOLANG_VERSION}
 
 COPY . /usr/src/lokomotive
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ ALL_BUILD_TAGS := "aws,packet,aks,e2e,baremetal,disruptivee2e,poste2e,packet_flu
 
 ADMISSION_WEBHOOK_SERVER := "quay.io/kinvolk/lokomotive-admission-webhook-server"
 
+# When you bump this, also bump the version in ./.github/workflows/ci.yaml and for the CI image.
+GOLANG_VERSION ?= 1.15.10
+
 ## Adds a '-dirty' suffix to version string if there are uncommitted changes
 changes := $(shell git status --porcelain)
 ifeq ($(changes),)
@@ -34,7 +37,7 @@ build: update-assets build-slim
 .PHONY: build-in-docker
 build-in-docker:
 	# increase ulimit to workaround https://github.com/golang/go/issues/37436
-	docker run --ulimit memlock=1024000 --rm -ti -v $(shell pwd):/usr/src/lokomotive -w /usr/src/lokomotive golang:1.15.4 sh -c "make"
+	docker run --ulimit memlock=1024000 --rm -ti -v $(shell pwd):/usr/src/lokomotive -w /usr/src/lokomotive golang:$(GOLANG_VERSION) sh -c "make"
 
 .PHONY: build-test
 build-test:
@@ -137,7 +140,7 @@ vendor:
 
 .PHONY: docker-build
 docker-build:
-	docker build -t kinvolk/lokomotive .
+	docker build -t kinvolk/lokomotive --build-arg GOLANG_VERSION=$(GOLANG_VERSION) .
 
 .PHONY: docker-vendor
 docker-vendor: docker-build
@@ -178,7 +181,7 @@ build-webhook:
 
 .PHONY: docker-build-webhook
 docker-build-webhook:
-	docker build -f cmd/admission-webhook-server/Dockerfile -t $(ADMISSION_WEBHOOK_SERVER) .
+	docker build -f cmd/admission-webhook-server/Dockerfile -t $(ADMISSION_WEBHOOK_SERVER) --build-arg GOLANG_VERSION=$(GOLANG_VERSION) .
 
 .PHONY: check-working-tree-clean
 check-working-tree-clean:

--- a/cmd/admission-webhook-server/Dockerfile
+++ b/cmd/admission-webhook-server/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang as builder
+ARG GOLANG_VERSION=1.15.10
+FROM golang:${GOLANG_VERSION) as builder
 
 WORKDIR /usr/src/lokomotive
 


### PR DESCRIPTION
With this the golang version need only be set in the Makefile, then it
trickles into the container builds.

Starting it off at go1.15.10

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>


# How to use

* `make build-in-docker`
* `make docker-build`
* `make docker-build-webhook`

For testing, you could even pass an alternate version to make: 
```shell
vbatts@melisma:~/src/github.com/kinvolk/lokomotive$ make docker-build GOLANG_VERSION=1.16.2
docker build -t kinvolk/lokomotive --build-arg GOLANG_VERSION=1.16.2 .
Sending build context to Docker daemon  230.1MB
Step 1/5 : ARG GOLANG_VERSION=1.15.10
Step 2/5 : FROM golang:${GOLANG_VERSION}
1.16.2: Pulling from library/golang
Digest: sha256:3c4d8b77baf3e12b4a1f08a99bf248f8be125045b4448455884a16e977907f11
Status: Downloaded newer image for golang:1.16.2
 ---> bfb42f2526a7
Step 3/5 : COPY . /usr/src/lokomotive
 ---> 5baac135e126
Step 4/5 : WORKDIR /usr/src/lokomotive
 ---> Running in 321ec8920fcf
Removing intermediate container 321ec8920fcf
 ---> 8fae21aebdc2
Step 5/5 : RUN make MOD=vendor install-slim
 ---> Running in c029d5edcd58
CGO_ENABLED=0 GO111MODULE=on go install \
	-mod=vendor \
	-ldflags "-X github.com/kinvolk/lokomotive/pkg/version.Version=`git describe --tags --always`-dirty -extldflags '-static'" \
	-buildmode=exe \
	./cmd/lokoctl
Removing intermediate container c029d5edcd58
 ---> 7fd1a73c47bf
Successfully built 7fd1a73c47bf
Successfully tagged kinvolk/lokomotive:latest
vbatts@melisma:~/src/github.com/kinvolk/lokomotive$ echo $?
0
```
But don't do this *ever* for releases, as the committed code should match the version of the tools used (really even we ought to record the digest of the container used to build the binary).
