### PR TITLE
[WIP] Support the ARM64 platform on bare-metal

### DIFF
--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -142,7 +142,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.19.4
+          KUBELET_IMAGE_TAG=v1.19.4-${os_arch}
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"
     - path: /etc/kubernetes/etcd.env
@@ -150,7 +150,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          IMAGE_TAG=v3.4.14
+          IMAGE_TAG=v3.4.14${etcd_arch_tag_suffix}
           IMAGE_URL=quay.io/coreos/etcd
           SSL_DIR=/etc/ssl/etcd
           USER=etcd
@@ -171,6 +171,7 @@ storage:
           ETCD_PEER_CERT_FILE=/etc/ssl/etcd/etcd/peer.crt
           ETCD_PEER_KEY_FILE=/etc/ssl/etcd/etcd/peer.key
           ETCD_PEER_CLIENT_CERT_AUTH=true
+          ${etcd_arch_options}
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -200,7 +201,7 @@ storage:
             -v /opt/bootkube/assets:/assets:ro \
             -v /etc/kubernetes:/etc/kubernetes:rw \
             --network=host \
-            quay.io/kinvolk/bootkube:v0.14.0-helm4 \
+            quay.io/kinvolk/bootkube:v0.14.0-helm4-${os_arch} \
             /bootkube start --asset-dir=/assets
     - path: /etc/kubernetes/configure-kubelet-cgroup-driver
       filesystem: root

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -105,7 +105,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.19.4
+          KUBELET_IMAGE_TAG=v1.19.4-${os_arch}
           NODE_LABELS="${join(",", [for k, v in kubelet_labels : "${k}=${v}"])}"
     - path: /etc/hostname
       filesystem: root

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -87,8 +87,11 @@ resource "matchbox_profile" "controllers" {
 data "ct_config" "controller-ignitions" {
   count = length(var.controller_names)
   content = templatefile("${path.module}/cl/controller.yaml.tmpl", {
-    domain_name = var.controller_domains[count.index]
-    etcd_name   = var.controller_names[count.index]
+    os_arch                = var.os_arch
+    domain_name            = var.controller_domains[count.index]
+    etcd_name              = var.controller_names[count.index]
+    etcd_arch_tag_suffix   = var.os_arch == "arm64" ? "-arm64" : ""
+    etcd_arch_options      = var.os_arch == "arm64" ? "ETCD_UNSUPPORTED_ARCH=arm64" : ""
     etcd_initial_cluster = join(
       ",",
       formatlist(
@@ -120,6 +123,7 @@ resource "matchbox_profile" "workers" {
 data "ct_config" "worker-ignitions" {
   count = length(var.worker_names)
   content = templatefile("${path.module}/cl/worker.yaml.tmpl", {
+    os_arch                = var.os_arch
     domain_name            = var.worker_domains[count.index]
     cluster_dns_service_ip = module.bootkube.cluster_dns_service_ip
     cluster_domain_suffix  = var.cluster_domain_suffix

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -10,6 +10,12 @@ variable "matchbox_http_endpoint" {
   description = "Matchbox HTTP read-only endpoint (e.g. http://matchbox.example.com:8080)"
 }
 
+variable "os_arch" {
+  type        = string
+  default     = "amd64"
+  description = "Flatcar Container Linux architecture to install (amd64, arm64)"
+}
+
 variable "os_channel" {
   type        = string
   default     = "stable"

--- a/pkg/platform/aws/template.go
+++ b/pkg/platform/aws/template.go
@@ -56,6 +56,9 @@ module "aws-{{.Config.ClusterName}}" {
   host_cidr = "{{.Config.HostCIDR}}"
   {{- end }}
 
+ {{- if .Config.OSArch }}
+  os_arch = "{{ $pool.OSArch }}"
+ {{- end }}
  {{- if .Config.OSChannel }}
   os_channel = "{{.Config.OSChannel}}"
  {{- end }}

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -45,6 +45,7 @@ type config struct {
 	MatchboxEndpoint             string              `hcl:"matchbox_endpoint"`
 	MatchboxHTTPEndpoint         string              `hcl:"matchbox_http_endpoint"`
 	NetworkMTU                   int                 `hcl:"network_mtu,optional"`
+	OSArch                       string              `hcl:"os_arch,optional"`
 	OSChannel                    string              `hcl:"os_channel,optional"`
 	OSVersion                    string              `hcl:"os_version,optional"`
 	SSHPubKeys                   []string            `hcl:"ssh_pubkeys"`
@@ -212,6 +213,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		MatchboxEndpoint             string
 		MatchboxHTTPEndpoint         string
 		NetworkMTU                   int
+		OSCArch                      string
 		OSChannel                    string
 		OSVersion                    string
 		SSHPublicKeys                string
@@ -243,6 +245,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		MatchboxEndpoint:             cfg.MatchboxEndpoint,
 		MatchboxHTTPEndpoint:         cfg.MatchboxHTTPEndpoint,
 		NetworkMTU:                   cfg.NetworkMTU,
+		OSCArch:                      cfg.OSArch,
 		OSChannel:                    cfg.OSChannel,
 		OSVersion:                    cfg.OSVersion,
 		SSHPublicKeys:                string(keyListBytes),

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -213,7 +213,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		MatchboxEndpoint             string
 		MatchboxHTTPEndpoint         string
 		NetworkMTU                   int
-		OSCArch                      string
+		OSArch                       string
 		OSChannel                    string
 		OSVersion                    string
 		SSHPublicKeys                string
@@ -245,7 +245,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		MatchboxEndpoint:             cfg.MatchboxEndpoint,
 		MatchboxHTTPEndpoint:         cfg.MatchboxHTTPEndpoint,
 		NetworkMTU:                   cfg.NetworkMTU,
-		OSCArch:                      cfg.OSArch,
+		OSArch:                       cfg.OSArch,
 		OSChannel:                    cfg.OSChannel,
 		OSVersion:                    cfg.OSVersion,
 		SSHPublicKeys:                string(keyListBytes),

--- a/pkg/platform/baremetal/template.go
+++ b/pkg/platform/baremetal/template.go
@@ -23,6 +23,7 @@ module "bare-metal-{{.ClusterName}}" {
   matchbox_http_endpoint = "{{.MatchboxHTTPEndpoint}}"
   os_channel             = "{{.OSChannel}}"
   os_version             = "{{.OSVersion}}"
+  os_arch                = "{{.OSArch}}"
 
   # Disable self hosted kubelet
   disable_self_hosted_kubelet = {{ .DisableSelfHostedKubelet }}


### PR DESCRIPTION
# Support the ARM64 platform on bare-metal
This adds the OS Arch option to the bare-metal option to support ARM64.
The changes are taken from the Packet module.

# How to use

set `os_arch = "arm64"`

# Testing done

Needs to be tested tested on my Raspberry Pi 4, will update this a (draft) PR when that is finished. 
Happy to also work on a QEMU baded arm64 CI test if that is desired. 
