### PR TITLE
Use new version of apline/git in Dex

### DIFF
--- a/assets/charts/components/dex/templates/deployment.yaml
+++ b/assets/charts/components/dex/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: dex
       initContainers:
       - name: download-theme
-        image: alpine/git:v2.24.3
+        image: alpine/git:v2.30.1
         command:
         - git
         - clone


### PR DESCRIPTION
# Use new version of apline/git in Dex

This uses the latest alpine/git image to deploy Dex. This release added
ARM64 support which stops Dex from breaking when deploying it on ARM64.

# How to use

Install Dex in an ARM64 cluster

# Testing done
Tested on Raspberry Pi
