### PR TITLE
Use quay.io/kinvolk-ci/registry in Tinkerbel sandbox

### DIFF
--- a/assets/terraform-modules/tinkerbell-sandbox/assets/deploy/registry/Dockerfile
+++ b/assets/terraform-modules/tinkerbell-sandbox/assets/deploy/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:2.7.1
+FROM quay.io/kinvolk-ci/registry:2.7.1
 RUN apk add --no-cache --update curl apache2-utils
 ARG REGISTRY_USERNAME
 ARG REGISTRY_PASSWORD


### PR DESCRIPTION
# Use quay.io/kinvolk-ci/registry in Tinkerbel sandbox

This is needed to bypass the Docker Hub ratelimit which we hit on the CI. Other images like Postgres and Ubuntu seem to be whitelisted as library images against the rate limit at the moment.

# How to use

Check if the CI passes

