### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/configuration-reference/components/metallb.md
+++ b/docs/configuration-reference/components/metallb.md
@@ -1,5 +1,5 @@
 ---
-title: MetalLB configuration reference for LokomotiveLokomotive
+title: MetalLB configuration reference for Lokomotive
 weight: 10
 ---
 


### PR DESCRIPTION
# About

- Fix duplicated `Lokomotive` in docs about MetalLB configuration

<img width="672" alt="スクリーンショット 2021-05-19 0 31 42" src="https://user-images.githubusercontent.com/802339/118680335-9b1dcc00-b839-11eb-8ee9-c34aea0f34e2.png">
https://kinvolk.io/docs/lokomotive/0.5/configuration-reference/components/metallb/

