### PR TITLE
baremetal: enable and document "pod_cidr" and "service_cidr" options

### DIFF
--- a/docs/configuration-reference/platforms/baremetal.md
+++ b/docs/configuration-reference/platforms/baremetal.md
@@ -82,6 +82,10 @@ cluster "bare-metal" {
 
   network_mtu = 1500
 
+  pod_cidr = "10.2.0.0/16"
+
+  service_cidr = "10.3.0.0/16"
+
   controller_domains = var.controller_domains
 
   controller_macs = var.controller_macs
@@ -160,6 +164,8 @@ os_version = var.custom_default_os_version
 | `matchbox_endpoint`               | Matchbox API endpoint.                                                                                                                                                                                                                                                                                                                                                                    | -                      | string       | true     |
 | `matchbox_http_endpoint`          | Matchbox HTTP read-only endpoint. Example: "http://matchbox.example.com:8080"                                                                                                                                                                                                                                                                                                             | -                      | string       | true     |
 | `network_mtu`                     | Physical Network MTU.                                                                                                                                                                                                                                                                                                                                                                     | 1500                   | number       | false    |
+| `pod_cidr`                    | CIDR IPv4 range to assign Kubernetes pods.                                                                                                                                                                                                                                                                   | "10.2.0.0/16"   | string       | false    |
+| `service_cidr`                | CIDR IPv4 range to assign Kubernetes services.                                                                                                                                                                                                                                                               | "10.3.0.0/16"   | string       | false    |
 | `worker_names`                    | Ordered list of worker names. Example: ["node2", "node3"]                                                                                                                                                                                                                                                                                                                                 | -                      | list(string) | true     |
 | `worker_macs`                     | Ordered list of worker identifying MAC addresses. Example ["52:54:00:b2:2f:86", "52:54:00:c3:61:77"]                                                                                                                                                                                                                                                                                      | -                      | list(string) | true     |
 | `worker_domains`                  | Ordered list of worker FQDNs. Example ["node2.example.com", "node3.example.com"]                                                                                                                                                                                                                                                                                                          | -                      | list(string) | true     |

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -45,6 +45,8 @@ type config struct {
 	MatchboxEndpoint             string              `hcl:"matchbox_endpoint"`
 	MatchboxHTTPEndpoint         string              `hcl:"matchbox_http_endpoint"`
 	NetworkMTU                   int                 `hcl:"network_mtu,optional"`
+	PodCIDR                      string              `hcl:"pod_cidr,optional"`
+	ServiceCIDR                  string              `hcl:"service_cidr,optional"`
 	OSChannel                    string              `hcl:"os_channel,optional"`
 	OSVersion                    string              `hcl:"os_version,optional"`
 	SSHPubKeys                   []string            `hcl:"ssh_pubkeys"`
@@ -212,6 +214,8 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		MatchboxEndpoint             string
 		MatchboxHTTPEndpoint         string
 		NetworkMTU                   int
+		PodCIDR                      string
+		ServiceCIDR                  string
 		OSChannel                    string
 		OSVersion                    string
 		SSHPublicKeys                string
@@ -243,6 +247,8 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		MatchboxEndpoint:             cfg.MatchboxEndpoint,
 		MatchboxHTTPEndpoint:         cfg.MatchboxHTTPEndpoint,
 		NetworkMTU:                   cfg.NetworkMTU,
+		PodCIDR:                      cfg.PodCIDR,
+		ServiceCIDR:                  cfg.ServiceCIDR,
 		OSChannel:                    cfg.OSChannel,
 		OSVersion:                    cfg.OSVersion,
 		SSHPublicKeys:                string(keyListBytes),

--- a/pkg/platform/baremetal/template.go
+++ b/pkg/platform/baremetal/template.go
@@ -49,6 +49,14 @@ module "bare-metal-{{.ClusterName}}" {
   network_mtu = {{ .NetworkMTU }}
   {{- end }}
 
+  {{- if .PodCIDR }}
+  pod_cidr = "{{.PodCIDR}}"
+  {{- end }}
+
+  {{- if .ServiceCIDR }}
+  service_cidr = "{{.ServiceCIDR}}"
+  {{- end }}
+
   {{- if .KubeAPIServerExtraFlags }}
   kube_apiserver_extra_flags = [
     {{- range .KubeAPIServerExtraFlags }}


### PR DESCRIPTION
closes #1471

# Allow the customization of pod and service CIDRs also for baremetal setups 

This is a trivial change to the baremetal platform package that allows a user to define custom values for `pod_cidr` and `service_cidr`. Thanks to @invidian for pointing out the necessary code changes :+1: 

