### PR TITLE
Lokomotive component azure-arc-onboarding

### DIFF
--- a/assets/charts/components/azure-arc-onboarding/Chart.yaml
+++ b/assets/charts/components/azure-arc-onboarding/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: azure-arc-onboarding
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: v0.1.0

--- a/assets/charts/components/azure-arc-onboarding/templates/_helpers.tpl
+++ b/assets/charts/components/azure-arc-onboarding/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{- define "azure-arc-onboarding.envVars" -}}
+- name: AZURE_APPLICATION_CLIENT_ID
+  value: {{ .Values.applicationClientID | required "applicationClientID is required" }}
+- name: AZURE_APPLICATION_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: azure-application-password
+      key: azure-application-password
+- name: AZURE_TENANT_ID
+  value: {{ .Values.tenantID | required "tenantID is required" }}
+- name: CONNECTED_CLUSTER_NAME
+  value: {{ .Values.clusterName | required "clusterName is required" }}
+- name: AZURE_RESOURCE_GROUP
+  value: {{ .Values.resourceGroup | required " resourceGroup is required" }}
+{{- end -}}

--- a/assets/charts/components/azure-arc-onboarding/templates/rbac.yaml
+++ b/assets/charts/components/azure-arc-onboarding/templates/rbac.yaml
@@ -1,0 +1,87 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: zz-azure-arc-onboarding
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: true
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  # Allow core volume types.
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  # Assume that persistentVolumes set up by the cluster admin are safe to use.
+  - 'persistentVolumeClaim'
+  # This capability is required for kube-aad-proxy deployment from azure-arc
+  # to mount hostPath volumes.
+  - 'hostPath'
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: azure-arc-onboarding-for-psp
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - zz-azure-arc-onboarding
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: azure-arc-onboarding
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-delete,post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  # cluster-admin privileges is a requirement for Azure-arc.
+  # https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/troubleshooting#connecting-kubernetes-clusters-to-azure-arc
+  # https://docs.microsoft.com/en-us/azure/architecture/hybrid/arc-hybrid-kubernetes#cluster-registration
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: azure-arc-onboarding
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: azure-arc-onboarding-for-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: azure-arc-onboarding-for-psp
+subjects:
+  # This is needed because the deployment `kube-aad-proxy` uses the hostpath volumes
+  # which the default PSP `zz-minimal` doesn't provide hence we create a rolebinding
+  # for the ServiceAccount used by the `kube-aad-proxy` deployment and assign the newly
+  # created PSP `zz-azure-arc-onboarding` for `azure-arc-onboarding` Lokomotive component.
+- kind: ServiceAccount
+  name: azure-arc-kube-aad-proxy-sa
+  namespace: azure-arc

--- a/assets/charts/components/azure-arc-onboarding/templates/register.yaml
+++ b/assets/charts/components/azure-arc-onboarding/templates/register.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install"
+  name: azure-arc-register
+spec:
+  template:
+    spec:
+      serviceAccountName: azure-arc-onboarding
+      restartPolicy: Never
+      containers:
+      - image: quay.io/kinvolk/az-cli-with-helm:v0.1
+        name: install-azure-arc
+        args:
+          - register
+        env:
+        {{- include "azure-arc-onboarding.envVars" . | nindent 8 }}

--- a/assets/charts/components/azure-arc-onboarding/templates/remove.yaml
+++ b/assets/charts/components/azure-arc-onboarding/templates/remove.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-delete"
+  name: azure-arc-remove
+spec:
+  template:
+    spec:
+      serviceAccountName: azure-arc-onboarding
+      restartPolicy: Never
+      containers:
+      - image: quay.io/kinvolk/az-cli-with-helm:v0.1
+        name: install-azure-arc
+        args:
+          - remove
+        env:
+        {{- include "azure-arc-onboarding.envVars" . | nindent 8 }}

--- a/assets/charts/components/azure-arc-onboarding/templates/secret.yaml
+++ b/assets/charts/components/azure-arc-onboarding/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-application-password
+type: Opaque
+data:
+  azure-application-password: {{ .Values.applicationPassword | required "password required" | b64enc | quote }}

--- a/assets/charts/components/azure-arc-onboarding/templates/serviceaccount.yaml
+++ b/assets/charts/components/azure-arc-onboarding/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: azure-arc-onboarding
+automountServiceAccountToken: true

--- a/assets/charts/components/azure-arc-onboarding/values.yaml
+++ b/assets/charts/components/azure-arc-onboarding/values.yaml
@@ -1,0 +1,5 @@
+applicationClientID:
+tenantID:
+applicationPassword:
+resourceGroup:
+clusterName:

--- a/cli/cmd/cluster/component.go
+++ b/cli/cmd/cluster/component.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kinvolk/lokomotive/pkg/components"
 	awsebscsidriver "github.com/kinvolk/lokomotive/pkg/components/aws-ebs-csi-driver"
+	azurearconboarding "github.com/kinvolk/lokomotive/pkg/components/azure-arc-onboarding"
 	certmanager "github.com/kinvolk/lokomotive/pkg/components/cert-manager"
 	clusterautoscaler "github.com/kinvolk/lokomotive/pkg/components/cluster-autoscaler"
 	"github.com/kinvolk/lokomotive/pkg/components/contour"
@@ -66,6 +67,7 @@ func componentsConfigs() map[string]components.Component {
 		velero.Name:                     velero.NewConfig(),
 		webui.Name:                      webui.NewConfig(),
 		nodeproblemdetector.Name:        nodeproblemdetector.NewConfig(),
+		azurearconboarding.Name:         azurearconboarding.NewConfig(),
 	}
 }
 

--- a/docs/configuration-reference/components/azure-arc-onboarding.md
+++ b/docs/configuration-reference/components/azure-arc-onboarding.md
@@ -1,0 +1,81 @@
+---
+title: Azure Arc onboarding configuration reference for Lokomotive
+weight: 10
+---
+
+## Introduction
+
+Azure Arc offers simplified management, faster app development, and consistent Azure services.
+
+With Azure Arc, you can:
+
+- Centrally manage a wide range of resources, including
+[Windows](https://azure.microsoft.com/en-in/campaigns/windows-server/) and
+[Linux](https://azure.microsoft.com/en-in/overview/linux-on-azure/) servers, SQL server,
+[Kubernetes](https://azure.microsoft.com/en-in/services/kubernetes-service/) clusters and [Azure
+services](https://azure.microsoft.com/en-in/services/azure-arc/hybrid-data-services/).
+
+- Establish central visibility in the [Azure portal](https://azure.microsoft.com/en-in/features/azure-portal/)
+and enable multi-environment search with Azure Resource Graph.
+
+- Meet [governance](https://azure.microsoft.com/en-in/solutions/governance/) and compliance standards for
+apps, infrastructure and data with [Azure Policy](https://azure.microsoft.com/en-in/services/azure-policy/).
+
+- Delegate access and manage security policies for resources using role-based access control (RBAC) and [Azure
+Lighthouse](https://azure.microsoft.com/en-in/services/azure-lighthouse/).
+
+- Organise and inventory assets through a variety of Azure scopes, such as management groups, subscriptions,
+resource groups and tags.
+
+This component onboards or removes a Lokomotive cluster with Azure Arc.
+
+## Prerequisites
+
+* Microsoft Azure account with permissions to create ResourceGroup and register an application with the
+the Microsoft Identity Platform.
+
+  Detailed instructions and execution steps are mentioned in the
+  [How-to-guide](../../how-to-guides/gitops-using-azure-arc-onboarding-component.md#prerequisites).
+
+## Configuration
+
+Azure Arc onboarding component configuration example:
+
+```tf
+# azure-arc-onboarding.lokocfg
+
+component "azure-arc-onboarding" {
+  application_client_id = "29348jdw-9g23-9kot-21sa-opw129831c2k"
+  application_password  = "foobar"
+  tenant_id             = "s38kjs4k-x123-89h2-7f21-89uffo109921"
+  resource_group        = "azure-arc-lokomotive-resource"
+  cluster_name          = "mercury"
+}
+```
+
+## Attribute reference
+
+Table of all the arguments accepted by the component.
+
+| Argument                | Description                                                                                  | Default  | Type   | Required |
+|-------------------------|----------------------------------------------------------------------------------------------|:--------:|:------:|:--------:|
+| `application_client_id` | Application ID that uniquely identifies your application within the Azure identity platform. | -        | string | true     |
+| `application_password`  | A string value generated that your application can use to identity itself.                   | -        | string | true     |
+| `tenant_id`             | Unique ID of the Azure Active Directory tenant.                                              | -        | string | true     |
+| `resource_group`        | Name or Id of the Azure resource group.                                                      | -        | string | true     |
+| `cluster_name`          | Name of the Lokomotive cluster as provided in the cluster configuration.                     | -        | string | true     |
+
+## Applying
+
+To apply the Azure Arc onboarding component:
+
+```bash
+lokoctl component apply azure-arc-onboarding
+```
+## Deleting
+
+To destroy the component:
+
+```bash
+lokoctl component delete azure-arc-onboarding --delete-namespace
+```

--- a/docs/how-to-guides/gitops-using-azure-arc-onboarding-component.md
+++ b/docs/how-to-guides/gitops-using-azure-arc-onboarding-component.md
@@ -1,0 +1,269 @@
+---
+title: Deploy configuration using GitOps on an Azure Arc enabled Lokomotive cluster
+weight: 10
+---
+
+## Introduction
+
+Azure Arc offers simplified management, faster app development, and consistent Azure services.
+
+With Azure Arc, you can:
+
+- Centrally manage a wide range of resources, including
+[Windows](https://azure.microsoft.com/en-in/campaigns/windows-server/) and
+[Linux](https://azure.microsoft.com/en-in/overview/linux-on-azure/) servers, SQL server,
+[Kubernetes](https://azure.microsoft.com/en-in/services/kubernetes-service/) clusters and [Azure
+services](https://azure.microsoft.com/en-in/services/azure-arc/hybrid-data-services/).
+
+- Establish central visibility in the [Azure portal](https://azure.microsoft.com/en-in/features/azure-portal/)
+and enable multi-environment search with Azure Resource Graph.
+
+- Meet [governance](https://azure.microsoft.com/en-in/solutions/governance/) and compliance standards for
+apps, infrastructure and data with [Azure Policy](https://azure.microsoft.com/en-in/services/azure-policy/).
+
+- Delegate access and manage security policies for resources using role-based access control (RBAC) and [Azure
+Lighthouse](https://azure.microsoft.com/en-in/services/azure-lighthouse/).
+
+- Organise and inventory assets through a variety of Azure scopes, such as management groups, subscriptions,
+resource groups and tags.
+
+This guide provides the steps for onboarding a Lokomotive cluster on Azure Arc.
+
+## Learning objectives
+
+By the end of this guide, the following things would be accomplished:
+* Onboard a Lokomotive cluster on Azure Arc.
+* Create Azure Arc Kubernetes configuration for the GitOps agent.
+* Watch the GitOps agent deploy Kubernetes resources from the git repository.
+
+## Prerequisites
+
+* A Lokomotive cluster.
+
+* Azure command-line interface `az` installed on the local machine.
+
+* `jq` installed on the system.
+
+* Register providers for Azure Arc enabled Kubernetes:
+   ```bash
+   az provider register --namespace Microsoft.Kubernetes
+   az provider register --namespace Microsoft.KubernetesConfiguration
+   az provider register --namespace Microsoft.ExtendedLocation
+   ```
+
+   Monitor the registration process. Registration may take up to 10 minutes.
+
+   ```bash
+   az provider show -n Microsoft.Kubernetes -o table
+   az provider show -n Microsoft.KubernetesConfiguration -o table
+   az provider show -n Microsoft.ExtendedLocation -o table
+   ```
+
+   **NOTE**: This registration is needed only once per tenant.
+
+* Install `k8s-configuration` extension for Azure CLI.
+
+  ```bash
+  az extension add --name k8s-configuration
+  ```
+
+* Create a resource group:
+
+   ```bash
+   RG_NAME="AzureArcTest"
+   az group create --name "${RG_NAME}" --location EastUS --output table
+   ```
+
+* Create a service principal, its credentials and assign roles to the service principal.
+
+  ```bash
+  # Create a ServicePrincipal and its credentials.
+  SP_NAME=azure-arc-onboarding-service-principal
+  az ad sp create-for-rbac -n "${SP_NAME}" --skip-assignment -o jsonc > /tmp/sp-cred.json
+  SP_ID=$(az ad sp list -o tsv --query='[0].objectId' --display-name "${SP_NAME}")
+
+  # Get Subscription ID.
+  SUB_ID=$(az account show --query id --output tsv)
+
+  # Assign "Kubernetes Cluster - Azure Arc Onboarding" Role by its identifier.
+  az role assignment create --assignee "${SP_ID}" \
+    --role "Kubernetes Cluster - Azure Arc Onboarding" \
+    --scope /subscriptions/${SUB_ID}/resourcegroups/${RG_NAME}
+
+  # Assign "Microsoft.Kubernetes connected cluster" Role by its identifier.
+  az role assignment create --assignee "${SP_ID}" \
+    --role "Microsoft.Kubernetes connected cluster role" \
+    --scope /subscriptions/${SUB_ID}/resourcegroups/${RG_NAME}
+  ```
+
+## Steps
+
+### Step 1: Configure [azure-arc-onboarding](../configuration-reference/components/azure-arc-onboarding.md) Lokomotive component.
+
+#### Config
+
+Generate a file named `azure-arc-onboarding.lokocfg` with the following command:
+
+```bash
+# Copy values from /tmp/sp-cred.json created in the prerequisites section.
+APPLICATION_ID=$(jq -r .appId /tmp/sp-cred.json)
+APPLICATION_PASSWORD=$(jq -r .password /tmp/sp-cred.json)
+TENANT_ID=$(jq -r .tenant /tmp/sp-cred.json)
+CLUSTER_NAME=mercury
+
+cat <<EOF > azure-arc-onboarding.lokocfg
+component "azure-arc-onboarding" {
+  application_client_id = "${APPLICATION_ID}"
+  application_password  = "${APPLICATION_PASSWORD}"
+  tenant_id             = "${TENANT_ID}"
+  resource_group        = "${RG_NAME}"
+  cluster_name          = "${CLUSTER_NAME}"
+}
+EOF
+```
+
+Ensure that none of the fields is empty.
+
+Check out the component's [configuration
+reference](../configuration-reference/components/azure-arc-onboarding.md) for more information.
+
+#### Deploy the component
+
+Execute the following command to deploy the `azure-arc-onboarding` component:
+
+```bash
+lokoctl component apply azure-arc-onboarding
+```
+
+Verify the pod in the `azure-arc-onboarding` namespace is in the `Completed` state (this may take a few minutes):
+
+```console
+$ kubectl -n azure-arc-onboarding get pods -n azure-arc-onboarding
+NAME                       READY   STATUS      RESTARTS   AGE
+azure-arc-register-4s54j   0/1     Completed   0          81m
+```
+
+Azure Arc installs various Helm charts in the `azure-arc` namespace, verify that all the deployments are in
+`Running` state:
+
+```console
+$ kubectl -n azure-arc get pods
+NAME                                         READY   STATUS    RESTARTS   AGE
+cluster-metadata-operator-7cff574c4f-ld8cv   2/2     Running   0          83m
+clusterconnect-agent-6dfd867c68-629xg        3/3     Running   0          83m
+clusteridentityoperator-fd498bf96-dqlhr      2/2     Running   0          83m
+config-agent-bd647558d-f46xn                 2/2     Running   0          83m
+controller-manager-8676dcdc6-mv68p           2/2     Running   0          83m
+extension-manager-bcfd5b597-lsk85            2/2     Running   0          83m
+flux-logs-agent-6596f58c56-55l7r             1/1     Running   0          83m
+kube-aad-proxy-97bf4bcf8-g9djl               2/2     Running   0          83m
+metrics-agent-5b9b94754f-qf5q2               2/2     Running   0          83m
+resource-sync-agent-f8c7c6b6b-zvhx4          2/2     Running   0          83m
+```
+
+### Step 3: Create a Kubernetes configuration
+
+#### Create a configuration
+
+Once the Lokomotive cluster is onboarded on Azure Arc, we can proceed ahead with creating a configuration for
+deploying the GitOps agent.
+
+```bash
+az k8s-configuration create \
+  --name cluster-config \
+  --cluster-name "${CLUSTER_NAME}" \
+  --resource-group "${RG_NAME}" \
+  --operator-instance-name cluster-config \
+  --operator-namespace cluster-config \
+  --repository-url https://github.com/ipochi/azure-arc-nginx-demo \
+  --scope cluster \
+  --cluster-type connectedClusters \
+  --operator-params='--git-branch=main'
+```
+
+- `name` - the name of the Kubernetes configuration you want.
+- `cluster-name` - the name of the cluster provided in `azure-arc-onboarding` component configuration.
+- `resource-group` - Azure Resource group name provided in the `azure-arc-onboarding` component configuration.
+- `operator-instance-name` - the name of the Operator instance.
+- `repository-url` - the name of the git repository.
+- `scope` - scope of the operator. Accepted values: `cluster` or `namespace`.
+- `cluster-type` - Arc cluster type. Accepted values: `connectedClusters` or `managedClusters`.
+   **NOTE**: If the Lokomotive cluster is deployed on AKS, then the value of `cluster-type` is `managedClusters`
+- `operator-params` - Additional parameters to pass to the Operator. By default, the GitOps agent tracks and
+   syncs with the `master` branch. In this case, we are changing default the branch to `main`.
+
+This command creates two Deployments in the provided namespace `cluster-config`, corresponding to the GitOps
+agent that Azure Arc uses:
+
+```console
+$ kubectl get deployments -n cluster-config
+NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
+cluster-config               1/1     1            1           103m
+memcached-cluster-config     1/1     1            1           103m
+
+kubectl get pods -n cluster-config
+NAME                                          READY   STATUS    RESTARTS   AGE
+cluster-config-5f68dd9bd5-xsmc9               1/1     Running   0          5d18h
+memcached-cluster-config-857d47969f-v2g8q     1/1     Running   0          5d18h
+```
+
+Once the `cluster-config` pods are in `Running` state, you'll notice the new resources created by the GitOps
+agent in the namespace `demo`. The manifests for these resources are pulled from the provided git repository.
+
+```console
+$ kubectl get all -n demo
+NAME                           READY   STATUS    RESTARTS   AGE
+pod/my-nginx-5bcdc5784-fb87k   1/1     Running   0          105m
+pod/my-nginx-5bcdc5784-g2gt2   1/1     Running   0          105m
+
+NAME               TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
+service/my-nginx   NodePort   10.3.250.153   <none>        8080:32500/TCP   105m
+
+NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/my-nginx   2/2     2            2           105m
+
+NAME                                  DESIRED   CURRENT   READY   AGE
+replicaset.apps/my-nginx-5bcdc5784    2         2         2       105m
+replicaset.apps/my-nginx-5f4dfbff8c   0         0         0       105m
+```
+
+If you used your git repository URL, try pushing some changes to your repository. You'll notice the changes
+propagate instantly without the need for any manual intervention.
+
+## Cleanup
+
+Before removing the Lokomotive cluster from Azure arc, it is good practice to remove the GitOps agent.
+
+```bash
+az k8s-configuration delete \
+  --name cluster-config \
+  --cluster-name "${CLUSTER_NAME}" \
+  --resource-group "${RG_NAME}" \
+  --cluster-type connectedclusters \
+```
+
+Next, we remove the Lokomotive cluster from Azure Arc, by deleting the component:
+
+```bash
+lokoctl component delete azure-arc-onboarding
+```
+
+Finally, if the Lokomotive cluster is not needed, destroy the cluster:
+
+```bash
+lokoctl cluster destroy --confirm
+```
+
+**NOTE**: Store Service principal credentials somewhere safe and delete the temporary credentials file:
+
+```bash
+rm -rf /tmp/sp-cred.json
+```
+
+## Additional resources
+
+- `azure-arc-onboarding` component [configuration reference](../configuration-reference/components/azure-arc-onboarding.md) guide.
+- Azure Arc docs:
+
+  - [Configurations and GitOps with Azure Arc enabled clusters](https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/conceptual-configurations).
+  - [Using Azure Policy to apply GitOps configurations at scale](https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/use-azure-policy).

--- a/pkg/components/azure-arc-onboarding/component.go
+++ b/pkg/components/azure-arc-onboarding/component.go
@@ -1,0 +1,137 @@
+// Copyright 2021 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package azurearconboarding installs the azure-arc-onboarding Lokomotive component.
+package azurearconboarding
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+
+	internaltemplate "github.com/kinvolk/lokomotive/internal/template"
+	"github.com/kinvolk/lokomotive/pkg/components"
+	"github.com/kinvolk/lokomotive/pkg/components/util"
+	"github.com/kinvolk/lokomotive/pkg/k8sutil"
+)
+
+const (
+	// Name represents azure-arc component name as it should be referenced in function calls
+	// and in configuration.
+	Name = "azure-arc-onboarding"
+)
+
+type component struct {
+	ApplicationClientID string `hcl:"application_client_id"`
+	TenantID            string `hcl:"tenant_id"`
+	ApplicationPassword string `hcl:"application_password"`
+	ResourceGroup       string `hcl:"resource_group"`
+	ClusterName         string `hcl:"cluster_name"`
+}
+
+// NewConfig returns new azure-arc component configuration with default values set.
+//
+//nolint:golint
+func NewConfig() *component {
+	return &component{}
+}
+
+func (c *component) LoadConfig(configBody *hcl.Body, evalContext *hcl.EvalContext) hcl.Diagnostics {
+	if configBody == nil {
+		return hcl.Diagnostics{
+			components.HCLDiagConfigBodyNil,
+		}
+	}
+
+	if diags := gohcl.DecodeBody(*configBody, evalContext, c); diags.HasErrors() {
+		return diags
+	}
+
+	return c.validateConfig()
+}
+
+func (c *component) RenderManifests() (map[string]string, error) {
+	helmChart, err := components.Chart(Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving chart from assets: %w", err)
+	}
+
+	values, err := internaltemplate.Render(chartValuesTmpl, c)
+	if err != nil {
+		return nil, fmt.Errorf("rendering values template failed: %w", err)
+	}
+
+	renderedFiles, err := util.RenderChart(helmChart, Name, c.Metadata().Namespace.Name, values)
+	if err != nil {
+		return nil, fmt.Errorf("rendering chart failed: %w", err)
+	}
+
+	return renderedFiles, nil
+}
+
+func (c *component) Metadata() components.Metadata {
+	return components.Metadata{
+		Name: Name,
+		Namespace: k8sutil.Namespace{
+			Name: Name,
+		},
+	}
+}
+
+func (c *component) validateConfig() hcl.Diagnostics {
+	diags := hcl.Diagnostics{}
+
+	if c.TenantID == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Validation of configuration failed: expected non-empty value",
+			Detail:   "`tenant_id` cannot be an empty value",
+		})
+	}
+
+	if c.ApplicationClientID == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Validation of configuration failed: expected non-empty value",
+			Detail:   "`application_client_id` cannot be an empty value",
+		})
+	}
+
+	if c.ApplicationPassword == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Validation of configuration failed: expected non-empty value",
+			Detail:   "`application_password` cannot be an empty value",
+		})
+	}
+
+	if c.ResourceGroup == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Validation of configuration failed: expected non-empty value",
+			Detail:   "`resource_group` cannot be an empty value",
+		})
+	}
+
+	if c.ClusterName == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Validation of configuration failed: expected non-empty value",
+			Detail:   "`cluster_name` cannot be an empty value",
+		})
+	}
+
+	return diags
+}

--- a/pkg/components/azure-arc-onboarding/component_test.go
+++ b/pkg/components/azure-arc-onboarding/component_test.go
@@ -1,0 +1,167 @@
+// Copyright 2021 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azurearconboarding_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+
+	azurearconboarding "github.com/kinvolk/lokomotive/pkg/components/azure-arc-onboarding"
+	"github.com/kinvolk/lokomotive/pkg/components/util"
+)
+
+func TestConfig(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	c := azurearconboarding.NewConfig()
+
+	tests := []struct {
+		desc    string
+		config  string
+		wantErr bool
+	}{
+		{
+			desc: "Valid_config",
+			config: `
+component azure-arc-onboarding {
+  application_client_id = "test-application-id"
+  tenant_id             = "test-tenant-id"
+  application_password  = "test-application-password"
+  resource_group        = "test-resource-group"
+  cluster_name          = "foobar"
+}
+			`,
+		},
+		{
+			desc: "Empty_config",
+			config: `
+component azure-arc-onboarding {}
+			`,
+			wantErr: true,
+		},
+		{
+			desc: "All_fields_set_to_empty_string",
+			config: `
+component azure-arc-onboarding {
+  application_client_id = ""
+  tenant_id             = ""
+  application_password  = ""
+  resource_group        = ""
+  cluster_name          = ""
+}
+			`,
+			wantErr: true,
+		},
+		{
+			desc: "Empty_application_client_id",
+			config: `
+component azure-arc-onboarding {
+  application_client_id = ""
+  tenant_id             = "test-tenant-id"
+  application_password  = "test-application-password"
+  resource_group        = "test-resource-group"
+  cluster_name          = "foobar"
+}
+			`,
+			wantErr: true,
+		},
+		{
+			desc: "Empty_tenant_id",
+			config: `
+component azure-arc-onboarding {
+  application_client_id = "test-application-id"
+  tenant_id             = ""
+  application_password  = "test-application-password"
+  resource_group        = "test-resource-group"
+  cluster_name          = "foobar"
+}
+			`,
+			wantErr: true,
+		},
+		{
+			desc: "Empty_application_password",
+			config: `
+component azure-arc-onboarding {
+  application_client_id = "test-application-id"
+  tenant_id             = "tenant-id"
+  application_password  = ""
+  resource_group        = "test-resource-group"
+  cluster_name          = "foobar"
+}
+			`,
+			wantErr: true,
+		},
+		{
+			desc: "Empty_resource_group",
+			config: `
+component azure-arc-onboarding {
+  application_client_id = "test-application-id"
+  tenant_id             = "test-tenant-id"
+  application_password  = "test-application-password"
+  resource_group        = ""
+  cluster_name          = "foobar"
+}
+			`,
+			wantErr: true,
+		},
+		{
+			desc: "Empty_cluster_name",
+			config: `
+component azure-arc-onboarding {
+  application_client_id = "test-application-id"
+  tenant_id             = "test-tenant-id"
+  application_password  = "test-application-password"
+  resource_group        = "test-resource-group"
+  cluster_name          = ""
+}
+			`,
+			wantErr: true,
+		},
+		{
+			desc: "Expect_no_error",
+			config: `
+component azure-arc-onboarding {
+  application_client_id = "test-application-id"
+  tenant_id             = "test-tenant-id"
+  application_password  = "test-application-password"
+  resource_group        = "test-resource-group"
+  cluster_name          = "cluster-name"
+}
+			`,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			body, diagnostics := util.GetComponentBody(test.config, azurearconboarding.Name)
+			if diagnostics.HasErrors() {
+				t.Fatalf("Error getting component body: %v", diagnostics)
+			}
+
+			diagnostics = c.LoadConfig(body, &hcl.EvalContext{})
+			if test.wantErr && !diagnostics.HasErrors() {
+				t.Errorf(" Failed: expected error got none")
+			}
+
+			if !test.wantErr && diagnostics.HasErrors() {
+				t.Errorf(" Failed: expected no error, got: %v", diagnostics)
+			}
+		})
+	}
+}

--- a/pkg/components/azure-arc-onboarding/image/Dockerfile
+++ b/pkg/components/azure-arc-onboarding/image/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/azure-cli:2.25.0
+
+ENV BASE_URL="https://get.helm.sh"
+
+ENV TAR_FILE="helm-v3.6.1-linux-amd64.tar.gz"
+
+RUN wget ${BASE_URL}/${TAR_FILE} && \
+    tar -xvf ${TAR_FILE} && \
+    mv linux-amd64/helm /usr/bin/helm && \
+    chmod +x /usr/bin/helm && \
+    rm -rf linux-amd64 && \
+    rm -rf ${TAR_FILE}
+
+RUN az extension add --name connectedk8s
+
+WORKDIR /usr/local/bin
+
+COPY azure-arc.sh /usr/local/bin/azure-arc.sh
+
+ENTRYPOINT ["azure-arc.sh"]

--- a/pkg/components/azure-arc-onboarding/image/azure-arc.sh
+++ b/pkg/components/azure-arc-onboarding/image/azure-arc.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Type of action: register or remove the Lokomotive cluster from Azure Arc.
+action=$1
+
+function generate_kubeconfig() {
+  ca="$(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 | tr -d "\n")"
+  namespace="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+  token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token | tr -d "\n")"
+  server="https://kubernetes.default.svc"
+
+  echo "
+  apiVersion: v1
+  kind: Config
+  clusters:
+  - name: default-cluster
+    cluster:
+      certificate-authority-data: ${ca}
+      server: ${server}
+  contexts:
+  - name: default-context
+    context:
+      cluster: default-cluster
+      namespace: ${namespace}
+      user: default-user
+  current-context: default-context
+  users:
+  - name: default-user
+    user:
+      token: ${token}
+  " > sa.kubeconfig
+}
+
+function azure_login() {
+  az login --service-principal -u ${AZURE_APPLICATION_CLIENT_ID} -p ${AZURE_APPLICATION_PASSWORD} --tenant ${AZURE_TENANT_ID}
+}
+
+function perform_action() {
+  case ${action} in
+    register)
+      # Connect the cluster to Azure Arc.
+      az connectedk8s connect --kube-config sa.kubeconfig --name ${CONNECTED_CLUSTER_NAME} --resource-group ${AZURE_RESOURCE_GROUP}
+      ;;
+    remove)
+      # Remove the cluster from Azure Arc.
+      az connectedk8s delete --yes --kube-config sa.kubeconfig --name ${CONNECTED_CLUSTER_NAME} --resource-group ${AZURE_RESOURCE_GROUP}
+      ;;
+    *)
+      echo "Unknown action"
+      exit 1
+      ;;
+  esac
+}
+
+function checkEnvVars() {
+  if [ -z "${AZURE_APPLICATION_CLIENT_ID}" ]; then
+    echo "AZURE_APPLICATION_CLIENT_ID is empty"
+    exit 1
+  fi
+
+  if [ -z "${AZURE_APPLICATION_PASSWORD}" ]; then
+    echo "AZURE_APPLICATION_PASSWORD is empty"
+    exit 1
+  fi
+
+  if [ -z "${CONNECTED_CLUSTER_NAME}" ]; then
+    echo "CONNECTED_CLUSTER_NAME is empty"
+    exit 1
+  fi
+
+  if [ -z "${AZURE_RESOURCE_GROUP}" ]; then
+    echo "AZURE_RESOURCE_GROUP is empty"
+    exit 1
+  fi
+}
+
+# Validate environment variables.
+checkEnvVars
+# Generate kubeconfig from service account.
+generate_kubeconfig
+# Login to the AZURE CLI.
+azure_login
+# Register or remove the Lokomotive cluster from Azure arc.
+perform_action

--- a/pkg/components/azure-arc-onboarding/template.go
+++ b/pkg/components/azure-arc-onboarding/template.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The Lokomotive Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azurearconboarding
+
+const chartValuesTmpl = `
+applicationClientID: {{ .ApplicationClientID }}
+tenantID: {{ .TenantID }}
+applicationPassword: {{ .ApplicationPassword }}
+resourceGroup: {{ .ResourceGroup }}
+clusterName: {{ .ClusterName }}
+`


### PR DESCRIPTION
This PR adds a new Lokomotive component `azure-arc-lokomotive` for onboarding and removing a Lokomotive cluster from Azure Arc.

To test:
follow the configuration reference documentation for the component.

```
component azure-arc-lokomotive {
  application_client_id=""
  tenant_id=""
  application_password=""
  resource_group=""
  cluster_name=""
}
```


```
lokoctl component apply azure-arc-onboarding
```