### PR TITLE
docs/howto/rook-ceph: use new label syntax

### DIFF
--- a/docs/how-to-guides/rook-ceph-storage.md
+++ b/docs/how-to-guides/rook-ceph-storage.md
@@ -35,8 +35,12 @@ cluster "packet" {
     count = 3
     node_type = "c2.medium.x86"
 
-    labels = "storage.lokomotive.io=ceph"
-    taints = "storage.lokomotive.io=ceph:NoSchedule"
+    labels = {
+      "storage.lokomotive.io" = "ceph"
+    }
+    taints = {
+      "storage.lokomotive.io" = "ceph:NoSchedule"
+    }
   }
 }
 ```


### PR DESCRIPTION
In 07c493da303266579b39cd231aa9085bb8d2a40e and
221249dcad626f8e68625c60ed1682d8668d321e we changed the syntax of labels
and taints to a map.

This changes the Rook Ceph how to guide to use the new format.