### PR TITLE
baremetal: fix terraform non-parallel execution

### DIFF
--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -121,7 +121,7 @@ func (c *config) ApplyWithoutParallel(ex *terraform.Executor) error {
 		return fmt.Errorf("initializing Terraform configuration: %w", err)
 	}
 
-	return ex.Apply([]string{"parallelism=1"})
+	return ex.Apply([]string{"-parallelism=1"})
 }
 
 func (c *config) Destroy(ex *terraform.Executor) error {


### PR DESCRIPTION
In order to limit the number of cnocurrent operations as Terraform walks
the graph, `-parallelism=n` is used, with a default value of 10.

When rotating certificates, it is desirable to limit parallelism to `1`,
so that certificates are rotated one by one and we still have quorum.

In baremtal platform, there is a case of missing hiphen before
`parallelism`:
```
current - return ex.Apply([]string{"parallelism=1"})
correct - return ex.Apply([]string{"-parallelism=1"})
```

Hence the following error:

```
stat parallelism=1: no such file or directory
```

This commit provides the fix by correcting the code in question.

Signed-off-by: Imran Pochi <imran@kinvolk.io>