### PR TITLE
pkg/terraform: increase the default parallelism

### DIFF
--- a/pkg/platform/aks/aks.go
+++ b/pkg/platform/aks/aks.go
@@ -292,7 +292,7 @@ func (c *config) Apply(ex *terraform.Executor) error {
 		return err
 	}
 
-	return ex.Apply(nil)
+	return ex.Apply([]string{terraform.WithParallelism})
 }
 
 // ApplyWithoutParallel applies Terraform configuration without parallel execution.
@@ -301,7 +301,7 @@ func (c *config) ApplyWithoutParallel(ex *terraform.Executor) error {
 		return fmt.Errorf("initializing Terraform configuration: %w", err)
 	}
 
-	return ex.Apply([]string{"-parallelism=1"})
+	return ex.Apply([]string{terraform.WithoutParallelism})
 }
 
 // Destroy destroys AKS infrastructure via Terraform.

--- a/pkg/platform/aws/aws.go
+++ b/pkg/platform/aws/aws.go
@@ -140,7 +140,7 @@ func (c *config) Apply(ex *terraform.Executor) error {
 		return err
 	}
 
-	return ex.Apply(nil)
+	return ex.Apply([]string{terraform.WithParallelism})
 }
 
 // ApplyWithoutParallel applies Terraform configuration without parallel execution.
@@ -149,7 +149,7 @@ func (c *config) ApplyWithoutParallel(ex *terraform.Executor) error {
 		return fmt.Errorf("initializing Terraform configuration: %w", err)
 	}
 
-	return ex.Apply([]string{"-parallelism=1"})
+	return ex.Apply([]string{terraform.WithoutParallelism})
 }
 
 func (c *config) Destroy(ex *terraform.Executor) error {

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -117,7 +117,7 @@ func (c *config) Apply(ex *terraform.Executor) error {
 		return err
 	}
 
-	return ex.Apply(nil)
+	return ex.Apply([]string{terraform.WithParallelism})
 }
 
 // ApplyWithoutParallel applies Terraform configuration without parallel execution.
@@ -126,7 +126,7 @@ func (c *config) ApplyWithoutParallel(ex *terraform.Executor) error {
 		return fmt.Errorf("initializing Terraform configuration: %w", err)
 	}
 
-	return ex.Apply([]string{"-parallelism=1"})
+	return ex.Apply([]string{terraform.WithoutParallelism})
 }
 
 func (c *config) Destroy(ex *terraform.Executor) error {

--- a/pkg/platform/packet/packet.go
+++ b/pkg/platform/packet/packet.go
@@ -215,7 +215,7 @@ func (c *config) Apply(ex *terraform.Executor) error {
 		return err
 	}
 
-	return c.terraformSmartApply(ex, c.DNS, nil)
+	return c.terraformSmartApply(ex, c.DNS, []string{terraform.WithParallelism})
 }
 
 // ApplyWithoutParallel applies Terraform configuration without parallel execution.
@@ -224,7 +224,7 @@ func (c *config) ApplyWithoutParallel(ex *terraform.Executor) error {
 		return fmt.Errorf("initializing Terraform configuration: %w", err)
 	}
 
-	return c.terraformSmartApply(ex, c.DNS, []string{"-parallelism=1"})
+	return c.terraformSmartApply(ex, c.DNS, []string{terraform.WithoutParallelism})
 }
 
 func (c *config) Destroy(ex *terraform.Executor) error {

--- a/pkg/platform/tinkerbell/tinkerbell.go
+++ b/pkg/platform/tinkerbell/tinkerbell.go
@@ -162,7 +162,7 @@ func (c *Config) Apply(ex *terraform.Executor) error {
 		return err
 	}
 
-	return ex.Apply(nil)
+	return ex.Apply([]string{terraform.WithParallelism})
 }
 
 // ApplyWithoutParallel applies Terraform configuration without parallel executions.
@@ -171,7 +171,7 @@ func (c *Config) ApplyWithoutParallel(ex *terraform.Executor) error {
 		return fmt.Errorf("initializing Terraform configuration: %w", err)
 	}
 
-	return ex.Apply([]string{"-parallelism=1"})
+	return ex.Apply([]string{terraform.WithoutParallelism})
 }
 
 // Destroy destroys Terraform managed resources.

--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -46,6 +46,11 @@ const (
 	requiredVersion = ">= 0.13, < 0.14"
 
 	noOfLinesOnError = 20
+
+	// WithoutParallelism sets the parallelism value to 1.
+	WithoutParallelism = "-parallelism=1"
+	// WithParallelism sets the parallelism value to 100.
+	WithParallelism = "-parallelism=100"
 )
 
 // ErrBinaryNotFound denotes the fact that the Terraform binary could not be


### PR DESCRIPTION
The default of 10 parallel steps does not limit creation of a small cluster but on a cluster with more than 10 nodes it leads to creation in sequential batches of 10, slowing the bring up down.

This PR is in a series of multiple PRs that will be created to ease the review/acceptance/merge of a large PR #1402 