### PR TITLE
cli/cmd/cluster: allow to skip the control plane update

### DIFF
--- a/cli/cmd/cluster-apply.go
+++ b/cli/cmd/cluster-apply.go
@@ -26,6 +26,7 @@ var (
 	verbose                  bool
 	skipComponents           bool
 	skipPreUpdateHealthCheck bool
+	skipControlPlaneUpdate   bool
 	upgradeKubelets          bool
 )
 
@@ -47,6 +48,8 @@ func init() {
 
 	pf.BoolVarP(&skipPreUpdateHealthCheck, "skip-pre-update-health-check", "", false,
 		"Skip ensuring that cluster is healthy before updating (not recommended)")
+	pf.BoolVarP(&skipControlPlaneUpdate, "skip-control-plane-update", "", false,
+		"Skip updating the control plane (not recommended)")
 
 	pf.BoolVarP(&upgradeKubelets, "upgrade-kubelets", "", false, "Experimentally upgrade self-hosted kubelets")
 }
@@ -62,6 +65,7 @@ func runClusterApply(cmd *cobra.Command, args []string) {
 		UpgradeKubelets:          upgradeKubelets,
 		SkipComponents:           skipComponents,
 		SkipPreUpdateHealthCheck: skipPreUpdateHealthCheck,
+		SkipControlPlaneUpdate:   skipControlPlaneUpdate,
 		Verbose:                  verbose,
 		ConfigPath:               viper.GetString("lokocfg"),
 		ValuesPath:               viper.GetString("lokocfg-vars"),

--- a/cli/cmd/cluster/apply.go
+++ b/cli/cmd/cluster/apply.go
@@ -31,6 +31,7 @@ type ApplyOptions struct {
 	UpgradeKubelets          bool
 	SkipComponents           bool
 	SkipPreUpdateHealthCheck bool
+	SkipControlPlaneUpdate   bool
 	Verbose                  bool
 	ConfigPath               string
 	ValuesPath               string
@@ -126,7 +127,7 @@ func Apply(contextLogger *log.Entry, options ApplyOptions) error {
 	}
 
 	// Do controlplane upgrades only if cluster already exists and it is not a managed platform.
-	if exists && !c.platform.Meta().Managed {
+	if exists && !options.SkipControlPlaneUpdate && !c.platform.Meta().Managed {
 		fmt.Printf("\nEnsuring that cluster controlplane is up to date.\n")
 
 		if err := c.upgradeControlPlane(contextLogger, kubeconfig); err != nil {

--- a/docs/cli/lokoctl_cluster_apply.md
+++ b/docs/cli/lokoctl_cluster_apply.md
@@ -21,6 +21,7 @@ lokoctl cluster apply [flags]
       --confirm                        Upgrade cluster without asking for confirmation
   -h, --help                           help for apply
       --skip-components                Skip applying component configuration
+      --skip-control-plane-update      Skip updating the control plane (not recommended)
       --skip-pre-update-health-check   Skip ensuring that cluster is healthy before updating (not recommended)
       --upgrade-kubelets               Experimentally upgrade self-hosted kubelets
   -v, --verbose                        Show output from Terraform


### PR DESCRIPTION
When the cluster is not fully set up and lokoctl is run again to fix that
problem, the user may want to avoid the control plane update happen at the
same time, because it can cause issues.

This PR is in a series of multiple PRs that will be created to ease the review/acceptance/merge of a large PR #1402
