### PR TITLE
tinkerbell: replace alpine base image

### DIFF
--- a/assets/terraform-modules/tinkerbell-sandbox/assets/deploy/tls/Dockerfile
+++ b/assets/terraform-modules/tinkerbell-sandbox/assets/deploy/tls/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:3.11
+FROM ubuntu:18.04
 ENTRYPOINT [ "/entrypoint.sh" ]
 
-RUN apk add --no-cache --update --upgrade ca-certificates postgresql-client
-RUN apk add --no-cache --update --upgrade --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing cfssl
+RUN apt-get update && apt-get install -y \
+  ca-certificates \
+  postgresql-client \
+  golang-cfssl
 
 COPY . .


### PR DESCRIPTION
Updates the docker image as docker build fails to build the image due to
cfssl package not being present anymore in alpine packages.

```
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec): Step
4/5 : RUN apk add --no-cache --update --upgrade
--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing cfssl
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec):
---> Running in 11cf4dd5fd38
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec):
fetch
http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec):
fetch
http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec):
fetch
http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec):
ERROR: unable to select packages:
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec):
cfssl (no such package):
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec):
required by: world[cfssl]
module.tinkerbell_sandbox.libvirt_domain.provisioner (remote-exec): The
command '/bin/sh -c apk add --no-cache --update --upgrade
--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing cfssl'
returned a non-zero code: 1

```

Upon further inspection, the cfssl package is not part of Alpine
packages anymore.

https://pkgs.alpinelinux.org/packages?name=cfssl&branch=edge&maintainer=None

Signed-off-by: Imran Pochi <imran@kinvolk.io>