### PR TITLE
baremetal disable lvm mappings wipe additional disks

### DIFF
--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller_profiles.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller_profiles.tf
@@ -15,4 +15,5 @@ module "controller_profile" {
   ssh_keys                 = var.ssh_keys
   ignition_clc_config      = module.controller[count.index].clc_config
   cached_install           = var.cached_install
+  wipe_additional_disks    = var.wipe_additional_disks
 }

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -215,3 +215,9 @@ variable "node_specific_labels" {
   description = "Map of node specific labels map."
   default     = {}
 }
+
+variable "wipe_additional_disks" {
+  type        = bool
+  description = "Wipes any additional disks attached, if set to true"
+  default     = false
+}

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker_profiles.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker_profiles.tf
@@ -15,4 +15,5 @@ module "worker_profile" {
   ssh_keys                 = var.ssh_keys
   ignition_clc_config      = module.worker[count.index].clc_config
   cached_install           = var.cached_install
+  wipe_additional_disks    = var.wipe_additional_disks
 }

--- a/assets/terraform-modules/matchbox-flatcar/profiles.tf
+++ b/assets/terraform-modules/matchbox-flatcar/profiles.tf
@@ -28,6 +28,7 @@ resource "matchbox_profile" "flatcar-install" {
     install_to_smallest_disk = var.install_to_smallest_disk
     kernel_console           = join(" ", var.kernel_console)
     kernel_args              = join(" ", var.kernel_args)
+    wipe_additional_disks    = var.wipe_additional_disks
     # only cached-container-linux profile adds -b baseurl
     baseurl_flag = ""
   })
@@ -65,6 +66,7 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     install_to_smallest_disk = var.install_to_smallest_disk
     kernel_console           = join(" ", var.kernel_console)
     kernel_args              = join(" ", var.kernel_args)
+    wipe_additional_disks    = var.wipe_additional_disks
     # profile uses -b baseurl to install from matchbox cache
     baseurl_flag = "-b ${var.http_endpoint}/assets/flatcar"
   })

--- a/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
+++ b/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
@@ -36,6 +36,19 @@ storage:
           # unmount any leftovers at the beginning before we modify the disk the mount uses
           umount /tmp/oemfs || true
           lvchange -an /dev/mapper/* || true
+          %{~ if wipe_additional_disks ~}
+          disks="$(lsblk -lnpdb -x SIZE -o NAME \
+            | (
+            while IFS= read -r drive; do
+              mountpoints=$(lsblk -ln -o MOUNTPOINT "$drive")
+              if [[ -z "$mountpoints" ]]; then
+                echo "$drive"
+              fi
+            done))"
+          for disk in $${disks}; do
+            wipefs -f -a "$${disk}" || echo "error: failed to wipe $${disk}"
+          done
+          %{~ endif ~}
           curl --retry 10 "${ignition_endpoint}?{{.request.raw_query}}&os=installed" -o ignition.json
           flatcar-install \
             %{~ if install_to_smallest_disk ~}

--- a/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
+++ b/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
@@ -35,6 +35,7 @@ storage:
           #!/bin/bash -ex
           # unmount any leftovers at the beginning before we modify the disk the mount uses
           umount /tmp/oemfs || true
+          lvchange -an /dev/mapper/* || true
           curl --retry 10 "${ignition_endpoint}?{{.request.raw_query}}&os=installed" -o ignition.json
           flatcar-install \
             %{~ if install_to_smallest_disk ~}

--- a/assets/terraform-modules/matchbox-flatcar/variables.tf
+++ b/assets/terraform-modules/matchbox-flatcar/variables.tf
@@ -76,3 +76,9 @@ variable "node_mac" {
   type        = string
   description = "MAC address identifying the node/machine (e.g. 52:54:00:a1:9c:ae)."
 }
+
+variable "wipe_additional_disks" {
+  type        = bool
+  description = "Wipes any additional disks attached, if set to true"
+  default     = false
+}

--- a/docs/configuration-reference/platforms/baremetal.md
+++ b/docs/configuration-reference/platforms/baremetal.md
@@ -130,6 +130,8 @@ cluster "bare-metal" {
   kernel_args = var.kernel_args
 
   network_ip_auto_detection = "can-reach=172.18.169.0"
+
+  wipe_additional_disks = true
 }
 ```
 
@@ -200,6 +202,7 @@ os_version = var.custom_default_os_version
 | `oidc.username_claim`             | JWT claim to use as the user name.                                                                                                                                                                                                                                                                                                                                                        | "email"                | string            | false    |
 | `oidc.groups_claim`               | JWT claim to use as the user’s group.                                                                                                                                                                                                                                                                                                                                                     | "groups"               | string            | false    |
 | `conntrack_max_per_core`          | Maximum number of entries in conntrack table per CPU on all nodes in the cluster. If you require more fain-grained control over this value, set it to 0 and add CLC snippet setting `net.netfilter.nf_conntrack_max` sysctl setting per node pool. See [Flatcar documentation about sysctl](https://docs.flatcar-linux.org/os/other-settings/#tuning-sysctl-parameters) for more details. | 32768                  | number            | false    |
+| `wipe_additional_disks`          | Wipes any additional disks attached to the machine.                                                                                                                                                                                                                                                                                                                                        | false                  | bool              | false    |
 
 ## Applying
 

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -68,6 +68,7 @@ type config struct {
 	NetworkIPAutodetectionMethod string              `hcl:"network_ip_autodetection_method,optional"`
 	CLCSnippets                  map[string][]string `hcl:"clc_snippets,optional"`
 	CertsValidityPeriodHours     int                 `hcl:"certs_validity_period_hours,optional"`
+	WipeAdditionalDisks          bool                `hcl:"wipe_additional_disks,optional"`
 	KubeAPIServerExtraFlags      []string
 }
 
@@ -251,6 +252,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		DownloadProtocol             string
 		NetworkIPAutodetectionMethod string
 		CLCSnippets                  map[string][]string
+		WipeAdditionalDisks          bool
 	}{
 		CachedInstall:                cfg.CachedInstall,
 		ClusterName:                  cfg.ClusterName,
@@ -285,6 +287,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		DownloadProtocol:             cfg.DownloadProtocol,
 		NetworkIPAutodetectionMethod: cfg.NetworkIPAutodetectionMethod,
 		CLCSnippets:                  cfg.CLCSnippets,
+		WipeAdditionalDisks:          cfg.WipeAdditionalDisks,
 	}
 
 	if err := t.Execute(f, terraformCfg); err != nil {

--- a/pkg/platform/baremetal/template.go
+++ b/pkg/platform/baremetal/template.go
@@ -110,6 +110,8 @@ module "bare-metal-{{.ClusterName}}" {
 
   download_protocol = "{{ .DownloadProtocol }}"
 
+  wipe_additional_disks = "{{ .WipeAdditionalDisks }}"
+
   network_ip_autodetection_method = "{{ .NetworkIPAutodetectionMethod }}"
 
   {{- if .CLCSnippets}}


### PR DESCRIPTION
This PR disables LVM partitions so that any detected LVM partitions are not automatically 
activated on bootup disrupting the installation and wipes any additional disks attached to the
machine before proceeeding 

This PR is in a series of multiple PRs that will be created to ease the review/acceptance/merge of a large PR #1402

