### PR TITLE
k8s: Update to v1.21.1

### DIFF
--- a/assets/charts/components/dex/templates/deployment.yaml
+++ b/assets/charts/components/dex/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
         ports:
         - name: https
           containerPort: 5556
+        env:
+        - name: KUBERNETES_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: config
           mountPath: /etc/dex/cfg

--- a/assets/charts/control-plane/kube-apiserver/Chart.yaml
+++ b/assets/charts/control-plane/kube-apiserver/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.3
-appVersion: v1.20.4
+version: 0.1.4
+appVersion: v1.21.1

--- a/assets/charts/control-plane/kube-apiserver/values.yaml
+++ b/assets/charts/control-plane/kube-apiserver/values.yaml
@@ -9,7 +9,7 @@ apiserver:
   aggregationCaCert:
   aggregationClientCert:
   aggregationClientKey:
-  image: k8s.gcr.io/kube-apiserver:v1.20.4
+  image: k8s.gcr.io/kube-apiserver:v1.21.1
   cloudProvider:
   etcdServers:
   aggregationFlags:

--- a/assets/charts/control-plane/kubelet/Chart.yaml
+++ b/assets/charts/control-plane/kubelet/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.3
-appVersion: v1.20.4
+version: 0.1.4
+appVersion: v1.21.1

--- a/assets/charts/control-plane/kubelet/container-image/Dockerfile
+++ b/assets/charts/control-plane/kubelet/container-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/poseidon/kubelet:v1.20.4
+FROM quay.io/poseidon/kubelet:v1.21.1
 
 RUN clean-install \
     sed \

--- a/assets/charts/control-plane/kubelet/values.yaml
+++ b/assets/charts/control-plane/kubelet/values.yaml
@@ -1,4 +1,4 @@
-image: quay.io/kinvolk/kubelet:v1.20.4
+image: quay.io/kinvolk/kubelet:v1.21.1
 clusterDNS: 10.0.0.10
 clusterDomain: cluster.local
 enableTLSBootstrap: true

--- a/assets/charts/control-plane/kubernetes/Chart.yaml
+++ b/assets/charts/control-plane/kubernetes/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.3
-appVersion: v1.20.4
+version: 0.1.4
+appVersion: v1.21.1

--- a/assets/charts/control-plane/kubernetes/values.yaml
+++ b/assets/charts/control-plane/kubernetes/values.yaml
@@ -2,19 +2,19 @@ controllerManager:
   serviceAccountKey:
   caCert:
   caKey:
-  image: k8s.gcr.io/kube-controller-manager:v1.20.4
+  image: k8s.gcr.io/kube-controller-manager:v1.21.1
   cloudProvider:
   serviceCIDR: 10.0.0.0/24
   podCIDR: 10.2.0.0/16
   controlPlaneReplicas: 1
   trustedCertsDir: /usr/share/ca-certificates
 kubeProxy:
-  image: k8s.gcr.io/kube-proxy:v1.20.4
+  image: k8s.gcr.io/kube-proxy:v1.21.1
   podCIDR: 10.2.0.0/16
   trustedCertsDir: /usr/share/ca-certificates
   conntrackMaxPerCore: 32768
 kubeScheduler:
-  image: k8s.gcr.io/kube-scheduler:v1.20.4
+  image: k8s.gcr.io/kube-scheduler:v1.21.1
   controlPlaneReplicas: 1
 kubeConfigInCluster:
   server:

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -141,7 +141,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4
+          KUBELET_IMAGE_TAG=v1.21.1
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"
     - path: /etc/kubernetes/etcd.env

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -121,7 +121,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4
+          KUBELET_IMAGE_TAG=v1.21.1
           NODE_LABELS="${join(",", [for k, v in node_labels : "${k}=${v}"])}"
           NODE_TAINTS="${join(",", [for k, v in taints : "${k}=${v}"])}"
     - path: /etc/sysctl.d/max-user-watches.conf
@@ -154,7 +154,7 @@ storage:
             -v /etc/kubernetes:/etc/kubernetes:ro \
             -v /var/lib/kubelet:/var/lib/kubelet:ro \
             --entrypoint=/usr/local/bin/kubectl \
-            quay.io/kinvolk/kubelet:v1.20.4 \
+            quay.io/kinvolk/kubelet:v1.21.1 \
             %{~ if enable_tls_bootstrap ~}
             --kubeconfig=/var/lib/kubelet/kubeconfig delete node $(hostname)
             %{~ else ~}

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -128,7 +128,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4
+          KUBELET_IMAGE_TAG=v1.21.1
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"

--- a/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -106,7 +106,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4
+          KUBELET_IMAGE_TAG=v1.21.1
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/node"
     - path: /etc/sysctl.d/max-user-watches.conf
@@ -126,7 +126,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://quay.io/kinvolk/kubelet:v1.20.4 \
+            docker://quay.io/kinvolk/kubelet:v1.21.1 \
             --net=host \
             --dns=host \
             -- \

--- a/assets/terraform-modules/bootkube/variables.tf
+++ b/assets/terraform-modules/bootkube/variables.tf
@@ -93,13 +93,13 @@ variable "container_images" {
     calico_cni              = "quay.io/kinvolk/calico-cni:v3.18.1"
     calico_controllers      = "quay.io/kinvolk/calico-kube-controllers:v3.18.1"
     flexvol_driver_image    = "quay.io/kinvolk/calico-pod2daemon-flexvol:v3.18.1"
-    kubelet_image           = "quay.io/kinvolk/kubelet:v1.20.4"
+    kubelet_image           = "quay.io/kinvolk/kubelet:v1.21.1"
     coredns                 = "quay.io/kinvolk/coredns:1.8.0"
     pod_checkpointer        = "quay.io/kinvolk/checkpoint:43ec4b414e44f202e07bf43e57d2b5ffbcfd4415"
-    kube_apiserver          = "k8s.gcr.io/kube-apiserver:v1.20.4"
-    kube_controller_manager = "k8s.gcr.io/kube-controller-manager:v1.20.4"
-    kube_scheduler          = "k8s.gcr.io/kube-scheduler:v1.20.4"
-    kube_proxy              = "k8s.gcr.io/kube-proxy:v1.20.4"
+    kube_apiserver          = "k8s.gcr.io/kube-apiserver:v1.21.1"
+    kube_controller_manager = "k8s.gcr.io/kube-controller-manager:v1.21.1"
+    kube_scheduler          = "k8s.gcr.io/kube-scheduler:v1.21.1"
+    kube_proxy              = "k8s.gcr.io/kube-proxy:v1.21.1"
   }
 }
 

--- a/assets/terraform-modules/controller/variables.tf
+++ b/assets/terraform-modules/controller/variables.tf
@@ -75,7 +75,7 @@ variable "kubelet_image_name" {
 variable "kubelet_image_tag" {
   type        = string
   description = "Tag for kubelet Docker image."
-  default     = "v1.20.4"
+  default     = "v1.21.1"
 }
 
 variable "set_standard_hostname" {

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -129,7 +129,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4
+          KUBELET_IMAGE_TAG=v1.21.1
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"

--- a/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -100,7 +100,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4
+          KUBELET_IMAGE_TAG=v1.21.1
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/node"
     - path: /etc/sysctl.d/max-user-watches.conf
@@ -120,7 +120,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://quay.io/kinvolk/kubelet:v1.20.4 \
+            docker://quay.io/kinvolk/kubelet:v1.21.1 \
             --net=host \
             --dns=host \
             -- \

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -131,7 +131,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4
+          KUBELET_IMAGE_TAG=v1.21.1
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"

--- a/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -109,7 +109,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4
+          KUBELET_IMAGE_TAG=v1.21.1
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
           NODE_LABELS="node.kubernetes.io/node"
     - path: /etc/sysctl.d/max-user-watches.conf
@@ -148,7 +148,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://quay.io/kinvolk/kubelet:v1.20.4 \
+            docker://quay.io/kinvolk/kubelet:v1.21.1 \
             --net=host \
             --dns=host \
             -- \

--- a/assets/terraform-modules/node/variables.tf
+++ b/assets/terraform-modules/node/variables.tf
@@ -37,7 +37,7 @@ variable "kubelet_image_name" {
 variable "kubelet_image_tag" {
   type        = string
   description = "Tag for kubelet Docker image."
-  default     = "v1.20.4"
+  default     = "v1.21.1"
 }
 
 variable "kubelet_taints" {

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -195,7 +195,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4-${os_arch}
+          KUBELET_IMAGE_TAG=v1.21.1-${os_arch}
           NODE_LABELS="node.kubernetes.io/master,node.kubernetes.io/controller=true"
           NODE_TAINTS="node-role.kubernetes.io/master=:NoSchedule"
     - path: /etc/kubernetes/etcd.env

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -292,7 +292,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/kinvolk/kubelet
-          KUBELET_IMAGE_TAG=v1.20.4-${os_arch}
+          KUBELET_IMAGE_TAG=v1.21.1-${os_arch}
           NODE_LABELS="${join(",", [for k, v in node_labels : "${k}=${v}"])}"
           NODE_TAINTS="${join(",", [for k, v in taints : "${k}=${v}"])}"
     - path: /etc/sysctl.d/max-user-watches.conf
@@ -312,7 +312,7 @@ storage:
             -v /etc/kubernetes:/etc/kubernetes:ro \
             -v /var/lib/kubelet:/var/lib/kubelet:ro \
             --entrypoint=/usr/local/bin/kubectl \
-            quay.io/kinvolk/kubelet:v1.20.4-${os_arch} \
+            quay.io/kinvolk/kubelet:v1.21.1-${os_arch} \
             %{~ if enable_tls_bootstrap ~}
             --kubeconfig=/var/lib/kubelet/kubeconfig delete node $(hostname)
             %{~ else ~}

--- a/assets/terraform-modules/worker/variables.tf
+++ b/assets/terraform-modules/worker/variables.tf
@@ -47,7 +47,7 @@ variable "kubelet_image_name" {
 variable "kubelet_image_tag" {
   type        = string
   description = "Tag for kubelet Docker image."
-  default     = "v1.20.4"
+  default     = "v1.21.1"
 }
 
 variable "kubelet_taints" {

--- a/docs/how-to-guides/troubleshoot-openebs.md
+++ b/docs/how-to-guides/troubleshoot-openebs.md
@@ -30,7 +30,7 @@ fix.
 #### Step 1.1: Update the image
 
 ```bash
-kubectl -n kube-system set image ds kubelet kubelet=quay.io/kinvolk/kubelet:v1.20.4
+kubectl -n kube-system set image ds kubelet kubelet=quay.io/kinvolk/kubelet:v1.21.1
 ```
 
 #### Step 1.2: Remove the iSCSI mount
@@ -85,7 +85,7 @@ sed -i '/iscsiadm/d' /etc/systemd/system/kubelet.service
 - Run the following commands to update the kubelet version:
 
   ```bash
-  export latest_kubelet_version=v1.20.4
+  export latest_kubelet_version=v1.21.1
   sed -i "s|.*KUBELET_IMAGE_TAG.*|KUBELET_IMAGE_TAG=${latest_kubelet_version}|g" /etc/kubernetes/kubelet.env
   ```
 


### PR DESCRIPTION
Release Notes:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md

---

**Notes for upcoming release**

- Release should include a script that updates bootstrap kubelet version.