### PR TITLE
baremetal: sets hostname controller_names/worker_names

### DIFF
--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller.tf
@@ -10,6 +10,17 @@ module "controller" {
   apiserver              = format("%s.%s", var.cluster_name, var.k8s_domain_name)
   ca_cert                = module.bootkube.ca_cert
   kubelet_labels         = lookup(var.node_specific_labels, var.controller_names[count.index], {})
-  clc_snippets           = lookup(var.clc_snippets, var.controller_names[count.index], [])
-  set_standard_hostname  = true
+  set_standard_hostname  = false
+  clc_snippets = concat(lookup(var.clc_snippets, var.controller_names[count.index], []), [
+    <<EOF
+storage:
+  files:
+    - path: /etc/hostname
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: ${var.controller_names[count.index]}
+EOF
+    ,
+  ])
 }

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker.tf
@@ -9,7 +9,18 @@ module "worker" {
   apiserver              = format("%s.%s", var.cluster_name, var.k8s_domain_name)
   kubelet_labels         = merge(lookup(var.node_specific_labels, var.worker_names[count.index], {}), var.labels)
   cluster_name           = var.cluster_name
-  clc_snippets           = lookup(var.clc_snippets, var.worker_names[count.index], [])
-  set_standard_hostname  = true
+  set_standard_hostname  = false
+  clc_snippets = concat(lookup(var.clc_snippets, var.worker_names[count.index], []), [
+    <<EOF
+storage:
+  files:
+    - path: /etc/hostname
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: ${var.worker_names[count.index]}
+EOF
+    ,
+  ])
 }
 

--- a/test/components/kubernetes/baremetal_kubelet_labels_test.go
+++ b/test/components/kubernetes/baremetal_kubelet_labels_test.go
@@ -34,17 +34,17 @@ func Test_Baremetal_NodeSpecificLabels(t *testing.T) {
 	// The labels include the labels common to every worker node derived from `labels` and
 	// labels specific to the node.
 	nodeNamesAndExpectedLabelsInCI := map[string]map[string]string{
-		"mercury-controller-0": {
+		"node1": {
 			"testkey":                       "testvalue",
 			"node.kubernetes.io/master":     "",
 			"node.kubernetes.io/controller": "true",
 		},
-		"mercury-worker-0": {
+		"node2": {
 			"ingressnode": "yes",
 			"testing.io":  "yes",
 			"roleofnode":  "testing",
 		},
-		"mercury-worker-1": {
+		"node3": {
 			"storagenode": "yes",
 			"testing.io":  "yes",
 			"roleofnode":  "testing",
@@ -72,11 +72,15 @@ func Test_Baremetal_NodeSpecificLabels(t *testing.T) {
 			t.Errorf("expected node with name %q not found: %v", nodeName, err)
 		}
 
+		if len(nodes.Items) != 1 {
+			t.Fatalf("expected a single node, got %d", len(nodes.Items))
+		}
+
 		// Currently we assume that the labels added to the node in CI are unique to the worker node.
 		// This check confirms that the expected set of labels as per CI configuration were
 		// present on the correct node.
-		if len(nodes.Items) == 1 && nodes.Items[0].Name != nodeName {
-			t.Errorf("expected node %q to have the labels %s", nodes.Items[0].Name, labels)
+		if nodes.Items[0].Name != nodeName {
+			t.Fatalf("expected node %q but found %q to have the labels %s", nodeName, nodes.Items[0].Name, labels)
 		}
 	}
 }


### PR DESCRIPTION
Sets the hostname from the `<cluster_name>-worker-<count_index>` which
is set when `set_standard_hostname` is true, to
`controller_names<count_index>` for controllers and
`worker_names<count_index>` for workers
