### PR TITLE
baremetal: let installer.service retry on failure

### DIFF
--- a/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
+++ b/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
@@ -8,7 +8,10 @@ systemd:
         Requires=network-online.target
         After=network-online.target
         [Service]
-        Type=simple
+        Type=oneshot
+        RemainAfterExit=true
+        Restart=on-failure
+        RestartSec=10s
         ExecStart=/opt/installer
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
In case the network only has a temporary problem, the installer service
should start again on failure.
Convert it to a oneshot service to set RemainAfterExist, so that it is
not triggered twice if anything that depends on it is pulling it in
again after it finished.
