### PR TITLE
typo: fix typo

### DIFF
--- a/pkg/components/rook/component.go
+++ b/pkg/components/rook/component.go
@@ -120,7 +120,7 @@ func (c *component) Metadata() components.Metadata {
 func convertNodeSelector(m map[string]string) string {
 	var ret string
 
-	// Covert map to slice and sort them
+	// Convert map to slice and sort them
 	// by keys.
 	keys := []string{}
 


### PR DESCRIPTION
Tihs is causing codespell to fail.

Signed-off-by: Imran Pochi <imran@kinvolk.io>