### PR TITLE
EM ARM: Use HTTP for iPXE URL

### DIFF
--- a/ci/packet_arm/packet_arm-cluster.lokocfg.envsubst
+++ b/ci/packet_arm/packet_arm-cluster.lokocfg.envsubst
@@ -27,7 +27,7 @@ EOF
 
   project_id = "$PACKET_PROJECT_ID"
 
-  ipxe_script_url = "https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe"
+  ipxe_script_url = "http://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe"
   os_arch         = "arm64"
   os_channel      = "alpha"
   controller_type = "c2.large.arm"
@@ -38,7 +38,7 @@ EOF
 
   worker_pool "pool-1" {
     count           = 1
-    ipxe_script_url = "https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe"
+    ipxe_script_url = "http://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe"
     os_arch         = "arm64"
     os_channel      = "alpha"
     node_type       = "c2.large.arm"

--- a/docs/configuration-reference/platforms/packet.md
+++ b/docs/configuration-reference/platforms/packet.md
@@ -284,7 +284,7 @@ module:
 ```
 os_arch = "arm64"
 os_channel = "alpha"
-ipxe_script_url = "https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe"
+ipxe_script_url = "http://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe"
 ```
 
 The iPXE boot variable can be removed once Flatcar is available for


### PR DESCRIPTION
HTTPs with iPXE is unreliable and fails to download the content with
errors like:

```
https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe... Invalid argument (http://ipxe.org/1c0de882)
Could not boot image: Invalid argument (http://ipxe.org/1c0de882)
No more network devices
```

So this commit switches from HTTPs to HTTP.

