### PR TITLE
cert-rotation: print journal on error when restarting etcd

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
@@ -74,7 +74,10 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
       "sudo chown -R etcd:etcd /etc/ssl/etcd",
       "sudo chmod -R 500 /etc/ssl/etcd",
-      "sudo systemctl restart etcd",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl restart etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
     ]
   }
 

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -74,7 +74,10 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
       "sudo chown -R etcd:etcd /etc/ssl/etcd",
       "sudo chmod -R 500 /etc/ssl/etcd",
-      "sudo systemctl restart etcd",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl restart etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
     ]
   }
 

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
@@ -60,7 +60,10 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
       "sudo chown -R etcd:etcd /etc/ssl/etcd",
       "sudo chmod -R 500 /etc/ssl/etcd",
-      "sudo systemctl restart etcd",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl restart etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
     ]
   }
 

--- a/assets/terraform-modules/platforms/tinkerbell/controllers/ssh.tf
+++ b/assets/terraform-modules/platforms/tinkerbell/controllers/ssh.tf
@@ -68,7 +68,10 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
       "sudo chown -R etcd:etcd /etc/ssl/etcd",
       "sudo chmod -R 500 /etc/ssl/etcd",
-      "sudo systemctl restart etcd",
+      # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
+      # Terraform before we return error. We should be able to remove it once
+      # https://github.com/hashicorp/terraform/issues/27121 is resolved.
+      "sudo systemctl restart etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
     ]
   }
 


### PR DESCRIPTION
We observed CI failures when restarting etcd after copying its
certificates. This prints logs when restarting fails which is
interesting in general.