### PR TITLE
baremetal: integrate automated (re-)provisioning logic

### DIFF
--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller.tf
@@ -13,8 +13,22 @@ module "controller" {
   set_standard_hostname  = false
   clc_snippets = concat(lookup(var.clc_snippets, var.controller_names[count.index], []), [
     <<EOF
+filesystems:
+  - name: root
+    mount:
+      device: /dev/disk/by-label/ROOT
+      format: ext4
+      wipe_filesystem: true
+      label: ROOT
 storage:
   files:
+    - path: /ignition_ran
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          Flag file indicating that Ignition ran.
+          Should be deleted by the SSH step that checks it.
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller_profiles.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller_profiles.tf
@@ -1,8 +1,10 @@
 module "controller_profile" {
   source                   = "../../../matchbox-flatcar"
   count                    = length(var.controller_names)
+  asset_dir                = var.asset_dir
   node_name                = var.controller_names[count.index]
   node_mac                 = var.controller_macs[count.index]
+  node_domain              = var.controller_domains[count.index]
   download_protocol        = var.download_protocol
   os_channel               = var.os_channel
   os_version               = var.os_version
@@ -17,4 +19,7 @@ module "controller_profile" {
   ignition_clc_config      = module.controller[count.index].clc_config
   cached_install           = var.cached_install
   wipe_additional_disks    = var.wipe_additional_disks
+  ignore_changes           = true
+  pxe_commands             = var.pxe_commands
+  install_pre_reboot_cmds  = var.install_pre_reboot_cmds
 }

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller_profiles.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/controller_profiles.tf
@@ -9,6 +9,7 @@ module "controller_profile" {
   http_endpoint            = var.matchbox_http_endpoint
   kernel_args              = var.kernel_args
   kernel_console           = var.kernel_console
+  installer_clc_snippets   = lookup(var.installer_clc_snippets, var.controller_names[count.index], [])
   install_disk             = var.install_disk
   install_to_smallest_disk = var.install_to_smallest_disk
   container_linux_oem      = var.container_linux_oem

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -81,7 +81,12 @@ resource "null_resource" "copy-controller-secrets" {
     ]
   }
 
+
+  # Triggered when the Ignition Config changes (used to recreate a controller)
   triggers = {
+    clc_config       = module.controller[count.index].clc_config
+    kernel_console   = join(" ", var.kernel_console)
+    kernel_args      = join(" ", var.kernel_args)
     etcd_ca_cert     = module.bootkube.etcd_ca_cert
     etcd_server_cert = module.bootkube.etcd_server_cert
     etcd_peer_cert   = module.bootkube.etcd_peer_cert

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -61,6 +61,12 @@ variable "clc_snippets" {
   default     = {}
 }
 
+variable "installer_clc_snippets" {
+  type        = map(list(string))
+  description = "Map from machine names to lists of Container Linux Config snippets, applied for the PXE-booted installer OS"
+  default     = {}
+}
+
 variable "labels" {
   type        = map(string)
   description = "Map of labels for worker nodes."

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -227,3 +227,15 @@ variable "wipe_additional_disks" {
   description = "Wipes any additional disks attached, if set to true"
   default     = false
 }
+
+variable "pxe_commands" {
+  type        = string
+  default     = "echo 'you must (re)provision the node by booting via iPXE from http://MATCHBOX/boot.ipxe'; exit 1"
+  description = "shell commands to execute for PXE (re)provisioning, with access to the variables $mac (the MAC address), $name (the node name), and $domain (the domain name), e.g., 'bmc=bmc-$domain; ipmitool -H $bmc power off; ipmitool -H $bmc chassis bootdev pxe; ipmitool -H $bmc power on'"
+}
+
+variable "install_pre_reboot_cmds" {
+  type        = string
+  default     = "true"
+  description = "shell commands to execute on the provisioned host after installation finished and before reboot, e.g., docker run --privileged --net host --rm debian sh -c 'apt update && apt install -y ipmitool && ipmitool chassis bootdev disk options=persistent'"
+}

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker.tf
@@ -12,8 +12,22 @@ module "worker" {
   set_standard_hostname  = false
   clc_snippets = concat(lookup(var.clc_snippets, var.worker_names[count.index], []), [
     <<EOF
+filesystems:
+  - name: root
+    mount:
+      device: /dev/disk/by-label/ROOT
+      format: ext4
+      wipe_filesystem: true
+      label: ROOT
 storage:
   files:
+    - path: /ignition_ran
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          Flag file indicating that Ignition ran.
+          Should be deleted by the SSH step that checks it.
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker_profiles.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker_profiles.tf
@@ -1,8 +1,10 @@
 module "worker_profile" {
   source                   = "../../../matchbox-flatcar"
   count                    = length(var.worker_names)
+  asset_dir                = var.asset_dir
   node_name                = var.worker_names[count.index]
   node_mac                 = var.worker_macs[count.index]
+  node_domain              = var.worker_domains[count.index]
   download_protocol        = var.download_protocol
   os_channel               = var.os_channel
   os_version               = var.os_version
@@ -17,4 +19,6 @@ module "worker_profile" {
   ignition_clc_config      = module.worker[count.index].clc_config
   cached_install           = var.cached_install
   wipe_additional_disks    = var.wipe_additional_disks
+  pxe_commands             = var.pxe_commands
+  install_pre_reboot_cmds  = var.install_pre_reboot_cmds
 }

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker_profiles.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/worker_profiles.tf
@@ -9,6 +9,7 @@ module "worker_profile" {
   http_endpoint            = var.matchbox_http_endpoint
   kernel_args              = var.kernel_args
   kernel_console           = var.kernel_console
+  installer_clc_snippets   = lookup(var.installer_clc_snippets, var.worker_names[count.index], [])
   install_disk             = var.install_disk
   install_to_smallest_disk = var.install_to_smallest_disk
   container_linux_oem      = var.container_linux_oem

--- a/assets/terraform-modules/matchbox-flatcar/profiles.tf
+++ b/assets/terraform-modules/matchbox-flatcar/profiles.tf
@@ -18,7 +18,11 @@ resource "matchbox_profile" "flatcar-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = templatefile("${path.module}/templates/install.yaml.tmpl", {
+  raw_ignition = data.ct_config.install-ignitions.rendered
+}
+
+data "ct_config" "install-ignitions" {
+  content = templatefile("${path.module}/templates/install.yaml.tmpl", {
     os_channel               = var.os_channel
     os_version               = var.os_version
     ignition_endpoint        = format("%s/ignition", var.http_endpoint)
@@ -31,7 +35,12 @@ resource "matchbox_profile" "flatcar-install" {
     wipe_additional_disks    = var.wipe_additional_disks
     # only cached-container-linux profile adds -b baseurl
     baseurl_flag = ""
+    mac_address  = var.node_mac
   })
+
+  pretty_print = false
+
+  snippets = var.installer_clc_snippets
 }
 
 // Flatcar Container Linux Install profile (from matchbox /assets cache)
@@ -56,7 +65,11 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = templatefile("${path.module}/templates/install.yaml.tmpl", {
+  raw_ignition = data.ct_config.cached-install-ignitions.rendered
+}
+
+data "ct_config" "cached-install-ignitions" {
+  content = templatefile("${path.module}/templates/install.yaml.tmpl", {
     os_channel               = var.os_channel
     os_version               = var.os_version
     ignition_endpoint        = format("%s/ignition", var.http_endpoint)
@@ -69,7 +82,12 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     wipe_additional_disks    = var.wipe_additional_disks
     # profile uses -b baseurl to install from matchbox cache
     baseurl_flag = "-b ${var.http_endpoint}/assets/flatcar"
+    mac_address  = var.node_mac
   })
+
+  pretty_print = false
+
+  snippets = var.installer_clc_snippets
 }
 
 resource "matchbox_profile" "node" {

--- a/assets/terraform-modules/matchbox-flatcar/profiles.tf
+++ b/assets/terraform-modules/matchbox-flatcar/profiles.tf
@@ -33,6 +33,7 @@ data "ct_config" "install-ignitions" {
     kernel_console           = join(" ", var.kernel_console)
     kernel_args              = join(" ", var.kernel_args)
     wipe_additional_disks    = var.wipe_additional_disks
+    install_pre_reboot_cmds  = var.install_pre_reboot_cmds
     # only cached-container-linux profile adds -b baseurl
     baseurl_flag = ""
     mac_address  = var.node_mac
@@ -80,6 +81,7 @@ data "ct_config" "cached-install-ignitions" {
     kernel_console           = join(" ", var.kernel_console)
     kernel_args              = join(" ", var.kernel_args)
     wipe_additional_disks    = var.wipe_additional_disks
+    install_pre_reboot_cmds  = var.install_pre_reboot_cmds
     # profile uses -b baseurl to install from matchbox cache
     baseurl_flag = "-b ${var.http_endpoint}/assets/flatcar"
     mac_address  = var.node_mac

--- a/assets/terraform-modules/matchbox-flatcar/pxe-helper.sh.tmpl
+++ b/assets/terraform-modules/matchbox-flatcar/pxe-helper.sh.tmpl
@@ -1,0 +1,87 @@
+# (executed in-line, #!/... would be ignored)
+# Terraform template variable substitution:
+name=${name}
+domain=${domain}
+mac=${mac}
+asset_dir=${asset_dir}
+ignore_changes=${ignore_changes}
+kernel_args="${kernel_args}"
+kernel_console="${kernel_console}"
+ignition_endpoint="${ignition_endpoint}"
+# From now on use $var for dynamic shell substitution
+
+if test -f "$asset_dir/$mac" && [ "$(cat "$asset_dir/$mac")" = "$domain" ]; then
+  echo "found $asset_dir/$mac containing $domain, skipping PXE install"
+  node_exists=yes
+else
+  echo "$asset_dir/$mac does not contain $domain, forcing PXE install"
+  node_exists=no
+fi
+
+if [ $node_exists = yes ]; then
+  if $ignore_changes ; then
+    echo "Keeping old config because 'ignore_changes' is set."
+    exit 0
+  else
+    # run single commands that can be retried without a side effect in case the connection got disrupted
+    count=30
+    while [ $count -gt 0 ] && ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 core@$domain sudo touch /boot/flatcar/first_boot; do
+      sleep 1
+      count=$((count - 1))
+    done
+    if [ $count -eq 0 ]; then
+      echo "error reaching $domain via SSH, please remove the $asset_dir/$mac file to force a PXE install"
+      exit 1
+    fi
+    echo "created the first_boot flag file to reprovision $domain"
+    count=5
+    while [ $count -gt 0 ] && ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 core@$domain "printf 'set linux_append=\"$kernel_args ignition.config.url=$ignition_endpoint?mac=$mac&os=installed\"\\nset linux_console=\"$kernel_console\"\\n' | sudo tee /usr/share/oem/grub.cfg"; do
+      sleep 1
+      count=$((count - 1))
+    done
+    if [ $count -eq 0 ]; then
+      echo "error reaching $domain via SSH, please retry"
+      exit 1
+    fi
+    count=5
+    while [ $count -gt 0 ] && ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 core@$domain sudo systemctl reboot; do
+      sleep 1
+      count=$((count - 1))
+    done
+    if [ $count -eq 0 ]; then
+      echo "error reaching $domain via SSH, please reboot manually"
+      exit 1
+    fi
+    echo "rebooted the $domain"
+  fi
+else
+  # the user may provide ipmitool commands or any other logic for forcing a PXE boot
+  ${pxe_commands}
+fi
+
+echo "checking that $domain comes up"
+count=600
+# check that we can reach the node and that it has the flag file which we remove here, indicating a reboot happened which prevents a race when issuing the reboot takes longer (both the systemctl reboot and PXE case)
+# Just in case the connection breaks and SSH may report an error code but still execute successfully, we will first check file existence and then delete with "rm -f" to be able to rerun both commands.
+# This sequence gives us the same error reporting as just running "rm" once.
+while [ $count -gt 0 ] && ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 core@$domain test -f /ignition_ran; do
+  sleep 1
+  count=$((count - 1))
+done
+if [ $count -eq 0 ]; then
+  echo "error: failed verifying with SSH if $domain came up by checking the /ignition_ran flag file"
+  exit 1
+fi
+count=5
+while [ $count -gt 0 ] && ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 core@$domain sudo rm -f /ignition_ran; do
+  sleep 1
+  count=$((count - 1))
+done
+if [ $count -eq 0 ]; then
+  echo "error: failed to remove the /ignition_ran flag file on $domain"
+  exit 1
+else
+  echo "$domain came up again"
+fi
+# only write the state file once the system is up, this allows to rerun lokoctl if the first PXE boot did not work and it will try again
+echo $domain > "$asset_dir/$mac"

--- a/assets/terraform-modules/matchbox-flatcar/ssh.tf
+++ b/assets/terraform-modules/matchbox-flatcar/ssh.tf
@@ -1,0 +1,14 @@
+resource "null_resource" "reprovision-node-when-ignition-changes" {
+  # Triggered when the Ignition Config changes
+  triggers = {
+    ignition_config = matchbox_profile.node.raw_ignition
+    kernel_args     = join(" ", var.kernel_args)
+    kernel_console  = join(" ", var.kernel_console)
+  }
+  # Wait for the new Ignition config object to be ready before rebooting
+  depends_on = [matchbox_group.node]
+  # Trigger running Ignition on the next reboot (first_boot flag file) and reboot the instance, or, if the instance needs to be (re)provisioned, run external commands for PXE booting (also runs on the first provisioning)
+  provisioner "local-exec" {
+    command = templatefile("${path.module}/pxe-helper.sh.tmpl", { domain = var.node_domain, name = var.node_name, mac = var.node_mac, pxe_commands = var.pxe_commands, asset_dir = var.asset_dir, kernel_args = join(" ", var.kernel_args), kernel_console = join(" ", var.kernel_console), ignition_endpoint = format("%s/ignition", var.http_endpoint), ignore_changes = var.ignore_changes })
+  }
+}

--- a/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
+++ b/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
@@ -67,6 +67,7 @@ storage:
           echo 'set linux_append="${kernel_args} ignition.config.url=${ignition_endpoint}?mac=${mac_address}&os=installed"' >> /tmp/oemfs/grub.cfg
           echo 'set linux_console="${kernel_console}"' >> /tmp/oemfs/grub.cfg
           umount /tmp/oemfs
+          ${install_pre_reboot_cmds}
           systemctl reboot
 passwd:
   users:

--- a/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
+++ b/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
@@ -49,7 +49,6 @@ storage:
             wipefs -f -a "$${disk}" || echo "error: failed to wipe $${disk}"
           done
           %{~ endif ~}
-          curl --retry 10 "${ignition_endpoint}?mac=${mac_address}&os=installed" -o ignition.json
           flatcar-install \
             %{~ if install_to_smallest_disk ~}
             -s \
@@ -59,14 +58,13 @@ storage:
             -C ${os_channel} \
             -V ${os_version} \
             -o "${container_linux_oem}" \
-            ${baseurl_flag} \
-            -i ignition.json
+            ${baseurl_flag}
           udevadm settle
           OEM_DEV="$(blkid -t "LABEL=OEM" -o device)"
           mkdir -p /tmp/oemfs
           mount "$${OEM_DEV}" /tmp/oemfs
           # append to file on newly created partition, do not remove the defaults
-          echo 'set linux_append="${kernel_args}"' >> /tmp/oemfs/grub.cfg
+          echo 'set linux_append="${kernel_args} ignition.config.url=${ignition_endpoint}?mac=${mac_address}&os=installed"' >> /tmp/oemfs/grub.cfg
           echo 'set linux_console="${kernel_console}"' >> /tmp/oemfs/grub.cfg
           umount /tmp/oemfs
           systemctl reboot

--- a/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
+++ b/assets/terraform-modules/matchbox-flatcar/templates/install.yaml.tmpl
@@ -49,7 +49,7 @@ storage:
             wipefs -f -a "$${disk}" || echo "error: failed to wipe $${disk}"
           done
           %{~ endif ~}
-          curl --retry 10 "${ignition_endpoint}?{{.request.raw_query}}&os=installed" -o ignition.json
+          curl --retry 10 "${ignition_endpoint}?mac=${mac_address}&os=installed" -o ignition.json
           flatcar-install \
             %{~ if install_to_smallest_disk ~}
             -s \

--- a/assets/terraform-modules/matchbox-flatcar/variables.tf
+++ b/assets/terraform-modules/matchbox-flatcar/variables.tf
@@ -67,6 +67,12 @@ variable "ignition_clc_config" {
   description = "Ignition CLC snippets to include in the configuration."
 }
 
+variable "installer_clc_snippets" {
+  type        = list(string)
+  description = "List of Container Linux Config snippets."
+  default     = []
+}
+
 variable "node_name" {
   type        = string
   description = "Name of the node/machine."

--- a/assets/terraform-modules/matchbox-flatcar/variables.tf
+++ b/assets/terraform-modules/matchbox-flatcar/variables.tf
@@ -88,3 +88,31 @@ variable "wipe_additional_disks" {
   description = "Wipes any additional disks attached, if set to true"
   default     = false
 }
+
+variable "ignore_changes" {
+  description = "When set to true, ignores the reprovisioning of the node (unless the MAC address flag file is removed to force a PXE install)."
+  type        = bool
+  default     = false
+}
+
+variable "asset_dir" {
+  description = "Path to a directory where generated assets should be placed (contains secrets)"
+  type        = string
+}
+
+variable "node_domain" {
+  type        = string
+  description = "Node FQDN (e.g node1.example.com)."
+}
+
+variable "pxe_commands" {
+  type        = string
+  description = "shell commands to execute for PXE (re)provisioning, with access to the variables $mac (the MAC address), $name (the node name), and $domain (the domain name), e.g., 'bmc=bmc-$domain; ipmitool -H $bmc power off; ipmitool -H $bmc chassis bootdev pxe; ipmitool -H $bmc power on'."
+  default     = "echo 'you must (re)provision the node by booting via iPXE from http://MATCHBOX/boot.ipxe'; exit 1"
+}
+
+variable "install_pre_reboot_cmds" {
+  type        = string
+  description = "shell commands to execute on the provisioned host after installation finished and before reboot, e.g., docker run --privileged --net host --rm debian sh -c 'apt update && apt install -y ipmitool && ipmitool chassis bootdev disk options=persistent'."
+  default     = "true"
+}

--- a/assets/terraform-modules/matchbox-flatcar/versions.tf
+++ b/assets/terraform-modules/matchbox-flatcar/versions.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
+    ct = {
+      source  = "poseidon/ct"
+      version = "0.8.0"
+    }
     template = {
       source  = "hashicorp/template"
       version = "2.2.0"

--- a/ci/baremetal/baremetal-cluster.lokocfg.envsubst
+++ b/ci/baremetal/baremetal-cluster.lokocfg.envsubst
@@ -31,6 +31,7 @@ cluster "bare-metal" {
     "node2",
     "node3",
   ]
+  pxe_commands = "true" # The VMs are booted up outside of the CI Docker image at the right time already and we will not reprovision nor could do so because the VMs are managed at another level
   # Adds oidc flags to API server with default values.
   # Acts as a smoke test to check if API server is functional after addition
   # of extra flags.

--- a/docs/quickstarts/baremetal.md
+++ b/docs/quickstarts/baremetal.md
@@ -8,6 +8,9 @@ weight: 10
 This quickstart guide walks through the steps needed to create a Lokomotive cluster on bare metal with
 Flatcar Container Linux utilizing PXE.
 
+We recommend you to check out [Racker](https://github.com/kinvolk/racker) for an integrated solution
+based on the Lokomotive bare metal platform.
+
 By the end of this guide, you'll have a working Kubernetes cluster with 1 controller node and 2
 worker nodes.
 
@@ -15,14 +18,14 @@ worker nodes.
 
 * Basic understanding of Kubernetes concepts.
 * Terraform v0.13.x installed locally.
-* Machines with at least 2GB RAM, 30GB disk, PXE-enabled NIC and IPMI.
+* Machines with at least 2.5GB RAM, 30GB disk, PXE-enabled NIC and IPMI.
 * PXE-enabled [network boot](https://coreos.com/matchbox/docs/latest/network-setup.html) environment.
 * Matchbox v0.6+ deployment with API enabled.
 * Matchbox credentials `client.crt`, `client.key`, `ca.crt`.
 * An SSH key pair for management access.
 * `kubectl` installed locally to access the Kubernetes cluster.
 
-Note that the machines should only be powered on after starting the installation, see below.
+Note that without a proper `pxe_commands` value the machines should only be powered on manually after starting the installation, see below.
 
 ## Steps
 
@@ -171,6 +174,9 @@ cluster "bare-metal" {
     "node2",
     "node3",
   ]
+
+  # Automation to force a PXE boot, a dummy sleep for now as you will do it manually.
+  pxe_commands = "sleep 300"
 }
 
 ```
@@ -197,7 +203,9 @@ Run the following command to create the cluster:
 lokoctl cluster apply
 ```
 
-**Proceed to Power on the PXE machines while this loops.**
+**Proceed to Power on the PXE machines while this loops, but only after Matchbox has the configuration ready.**
+See the [configuration reference](../configuration-reference/platforms/baremetal.md) on how to properly configure `pxe_commands`
+to automate the provisioning reliably.
 
 Once the command finishes, your Lokomotive cluster details are stored in the path you've specified
 under `asset_dir`.

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -67,6 +67,7 @@ type config struct {
 	DownloadProtocol             string              `hcl:"download_protocol,optional"`
 	NetworkIPAutodetectionMethod string              `hcl:"network_ip_autodetection_method,optional"`
 	CLCSnippets                  map[string][]string `hcl:"clc_snippets,optional"`
+	InstallerCLCSnippets         map[string][]string `hcl:"installer_clc_snippets,optional"`
 	CertsValidityPeriodHours     int                 `hcl:"certs_validity_period_hours,optional"`
 	WipeAdditionalDisks          bool                `hcl:"wipe_additional_disks,optional"`
 	KubeAPIServerExtraFlags      []string
@@ -252,6 +253,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		DownloadProtocol             string
 		NetworkIPAutodetectionMethod string
 		CLCSnippets                  map[string][]string
+		InstallerCLCSnippets         map[string][]string
 		WipeAdditionalDisks          bool
 	}{
 		CachedInstall:                cfg.CachedInstall,
@@ -287,6 +289,7 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		DownloadProtocol:             cfg.DownloadProtocol,
 		NetworkIPAutodetectionMethod: cfg.NetworkIPAutodetectionMethod,
 		CLCSnippets:                  cfg.CLCSnippets,
+		InstallerCLCSnippets:         cfg.InstallerCLCSnippets,
 		WipeAdditionalDisks:          cfg.WipeAdditionalDisks,
 	}
 

--- a/pkg/platform/baremetal/baremetal.go
+++ b/pkg/platform/baremetal/baremetal.go
@@ -50,6 +50,8 @@ type config struct {
 	NetworkMTU                   int                 `hcl:"network_mtu,optional"`
 	OSChannel                    string              `hcl:"os_channel,optional"`
 	OSVersion                    string              `hcl:"os_version,optional"`
+	PXECommands                  string              `hcl:"pxe_commands,optional"`
+	InstallPreBootCmds           string              `hcl:"install_pre_reboot_cmds,optional"`
 	SSHPubKeys                   []string            `hcl:"ssh_pubkeys"`
 	WorkerNames                  []string            `hcl:"worker_names"`
 	WorkerMacs                   []string            `hcl:"worker_macs"`
@@ -234,6 +236,8 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		NetworkMTU                   int
 		OSChannel                    string
 		OSVersion                    string
+		PXECommands                  string
+		InstallPreBootCmds           string
 		SSHPublicKeys                string
 		WorkerNames                  string
 		WorkerMacs                   string
@@ -270,6 +274,8 @@ func createTerraformConfigFile(cfg *config, terraformPath string) error {
 		NetworkMTU:                   cfg.NetworkMTU,
 		OSChannel:                    cfg.OSChannel,
 		OSVersion:                    cfg.OSVersion,
+		PXECommands:                  cfg.PXECommands,
+		InstallPreBootCmds:           cfg.InstallPreBootCmds,
 		SSHPublicKeys:                string(keyListBytes),
 		WorkerNames:                  string(workerNames),
 		WorkerMacs:                   string(workerMacs),

--- a/pkg/platform/baremetal/template.go
+++ b/pkg/platform/baremetal/template.go
@@ -128,6 +128,21 @@ EOF
     {{- end }}
   }
   {{- end }}
+
+  {{- if .InstallerCLCSnippets}}
+  installer_clc_snippets = {
+    {{- range $nodeName, $clcSnippetList := .InstallerCLCSnippets }}
+    "{{ $nodeName }}" = [
+    {{- range $clcSnippet := $clcSnippetList }}
+      <<EOF
+{{ $clcSnippet }}
+EOF
+      ,
+    {{- end }}
+    ]
+    {{- end }}
+  }
+  {{- end }}
 }
 
 terraform {

--- a/pkg/platform/baremetal/template.go
+++ b/pkg/platform/baremetal/template.go
@@ -108,6 +108,18 @@ module "bare-metal-{{.ClusterName}}" {
   ]
   {{- end }}
 
+  {{- if .PXECommands }}
+  pxe_commands = <<EOT
+{{ .PXECommands }}
+EOT
+  {{- end }}
+
+  {{- if .InstallPreBootCmds }}
+  install_pre_reboot_cmds = <<EOT
+{{ .InstallPreBootCmds }}
+EOT
+  {{- end }}
+
   download_protocol = "{{ .DownloadProtocol }}"
 
   wipe_additional_disks = "{{ .WipeAdditionalDisks }}"


### PR DESCRIPTION
-  baremetal: introduce CLC snippets for the installer    
    The installer OS needs to be able to get its network configuration as
    CLC snippet if DHCP is not used.
    
    Add CLC snippets for the installer and migrate the matchbox-specific
    CLC template to the normal CLC template which is needed for CLC
    snippets. The request template variable is replaced by the actually
    used "mac" parameter.
- baremetal: use ignition.config.url kernel parameter
    The Ignition configuration currently gets written out only once to the
    OEM partition and any updates to it in the matchbox store are not
    propagated to the node's Ignition environment when Ignition is forced
    to run again.
    
    Use the Ignition kernel parameter to point the node's Ignition
    environment directly to matchbox where the userdata lies.
- baremetal: integrate automated (re-)provisioning logic
    The bare-metal platform currently lacks any understanding of whether an
    instance is actually running the configuration that lokoctl put into
    matchbox, because, when the configuration was updated, there is no
    notification to the user that PXE booting has to be done again for this
    instance.
    Also, it is not clear to the user when to boot from PXE because the PXE
    boot must happen after lokoctl populated matchbox with the (new)
    configuration but before any other steps time out.
    The goal of this patch is to bring the baremetal platform to an
    actually usable level and support automated provisioning and
    reprovisioning, in a configurable way regardless if IPMI is used or VMs
    are created. In addition, we don't want to require a complicated PXE
    boot for each configuration update because it is slow, fragile and
    needs a special DHCP infrastructure which may be lacking in a
    production environment.
    
    Add user-defined commands in the "pxe_commands" variable to perform
    automated PXE provisioning at the right time, i.e. initally at the
    first run or when recreating a node.
    To address the problem that PXE booting is a long and maybe even manual
    process, or even impossible at production side, we can rely on Ignition
    to simulate reprovisioning by creating the "first_boot" flag file via
    SSH and issuing a reboot, which makes Ignition fetch the configuration
    from matchbox, and if we make sure to clean the root filesystem by
    formatting it, the result is the same as if reprovisioned was done with
    a PXE boot.
    The logic is achieved by a "null resource" in Terraform that executes a
    helper script which either does a PXE boot or uses SSH to trigger a
    reprovisioning with Ignition. It also handles the case of ignoring
    userdata changes for controller nodes to prevent losing etcd state.
    Since there is no notion of a baremetal node on the Terraform level
    (reminder: all this exercise here is done because we don't have a
    Terraform provider doing this for us) a local flag file is created
    under the asset directory on the machine which runs lokoctl. If it
    exists, the node was provisioned with PXE and SSH will be used for
    reprovisioning, if it does not exist, it will be provisioned with PXE
    during inital setup and for the next reprovisioning because the user
    forced recreating the node by deleting the flag file.
    Another flag file on the node is used to check whether a node was
    successfully reprovisioned.
    When SSH is used to reprovision, the kernel parameters for GRUB are
    updated directly because they are not part of the Ignition
    configuration.
    The "copy-controller-secrets" step is run after recreating a controller
    node, again since there is no notion of a node object this is solved by
    depending on the variables itself which define the node state.
    Also add user-defined commands in the "install_pre_reboot_cmds"
    variable to run after the PXE OS installation and before booting into
    the final OS, needed to set up persistent booting from disk after the
    PXE booting was configured in "pxe_commands".
    The whole patch is used by Racker (https://github.com/kinvolk/racker),
    and can be tested either with the "bootstrap/prepare.sh" script to
    create VMs with lokoctl or by running Racker in the QEMU IPMI simulator
    environment through the "racker-sim/ipmi-env.sh" script and a Racker
    Docker image built with "installer/conf.yaml" pointing to this
    Lokomotive branch.
