### PR TITLE
aws ci: Use c5a.2xlarge for controllers

### DIFF
--- a/ci/aws/aws-cluster.lokocfg.envsubst
+++ b/ci/aws/aws-cluster.lokocfg.envsubst
@@ -11,6 +11,7 @@ cluster "aws" {
   asset_dir        = pathexpand(var.asset_dir)
   cluster_name     = "$CLUSTER_ID"
   controller_count = 2
+  controller_type  = "c5a.2xlarge"
   dns_zone         = "$AWS_DNS_ZONE"
   dns_zone_id      = "$AWS_DNS_ZONE_ID"
   os_channel       = var.os_channel


### PR DESCRIPTION
AWS CI keeps failing on cert-rotation test because apiserver takes a
really long time to come back up.

It is possible that the failure rate on AWS is higher because the
machine type on AWS is tiny which is unable to sustain the load
generated due to control plane component restarts.

This commit upgrades the control plane machine to fairly larger one.

