### PR TITLE
Only restart containers from systemd

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -19,7 +19,6 @@ systemd:
         ExecStartPre=-docker rm -f etcd
         ExecStartPre=sh -c "docker run -d \
           --name=etcd \
-          --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
           -u $(id -u \"$${USER}\"):$(id -u \"$${USER}\") \
@@ -69,7 +68,6 @@ systemd:
         ExecStartPre=-docker rm -f kubelet
         ExecStartPre=docker run -d \
           --name=kubelet \
-          --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
           --pid=host \

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -15,6 +15,12 @@ systemd:
         RestartSec=5s
         TimeoutStartSec=0
         LimitNOFILE=40000
+        ConditionPathExists=/etc/ssl/etcd/etcd/server-ca.crt
+        ConditionPathExists=/etc/ssl/etcd/etcd/server.crt
+        ConditionPathExists=/etc/ssl/etcd/etcd/server.key
+        ConditionPathExists=/etc/ssl/etcd/etcd/peer-ca.crt
+        ConditionPathExists=/etc/ssl/etcd/etcd/peer.crt
+        ConditionPathExists=/etc/ssl/etcd/etcd/peer.key
         EnvironmentFile=/etc/kubernetes/etcd.env
         ExecStartPre=-docker rm -f etcd
         ExecStartPre=sh -c "docker run -d \

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/ssh.tf
@@ -61,6 +61,7 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo chown root:root /etc/kubernetes/kubeconfig",
       "sudo chmod 600 /etc/kubernetes/kubeconfig",
+      "sudo systemctl stop etcd",
       # Using "etcd/." copies the etcd/ folder recursively in an idempotent
       # way. See https://unix.stackexchange.com/a/228637 for details.
       "[ -d /etc/ssl/etcd ] && sudo cp -R /etc/ssl/etcd/. /etc/ssl/etcd.old && sudo rm -rf /etc/ssl/etcd",
@@ -77,7 +78,7 @@ resource "null_resource" "copy-controller-secrets" {
       # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
       # Terraform before we return error. We should be able to remove it once
       # https://github.com/hashicorp/terraform/issues/27121 is resolved.
-      "sudo systemctl restart etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
+      "sudo systemctl start etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
     ]
   }
 

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -42,7 +42,6 @@ systemd:
         ExecStartPre=-docker rm -f kubelet
         ExecStartPre=docker run -d \
           --name=kubelet \
-          --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
           --pid=host \

--- a/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -61,6 +61,7 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo chown root:root /etc/kubernetes/kubeconfig",
       "sudo chmod 600 /etc/kubernetes/kubeconfig",
+      "sudo systemctl stop etcd",
       # Using "etcd/." copies the etcd/ folder recursively in an idempotent
       # way. See https://unix.stackexchange.com/a/228637 for details.
       "[ -d /etc/ssl/etcd ] && sudo cp -R /etc/ssl/etcd/. /etc/ssl/etcd.old && sudo rm -rf /etc/ssl/etcd",
@@ -77,7 +78,7 @@ resource "null_resource" "copy-controller-secrets" {
       # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
       # Terraform before we return error. We should be able to remove it once
       # https://github.com/hashicorp/terraform/issues/27121 is resolved.
-      "sudo systemctl restart etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
+      "sudo systemctl start etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
     ]
   }
 

--- a/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
+++ b/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
@@ -24,7 +24,6 @@ systemd:
         ExecStartPre=-docker rm -f etcd
         ExecStartPre=sh -c "docker run -d \
           --name=etcd \
-          --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
           -u $(id -u \"$${USER}\"):$(id -u \"$${USER}\") \

--- a/assets/terraform-modules/node/templates/node.yaml.tmpl
+++ b/assets/terraform-modules/node/templates/node.yaml.tmpl
@@ -36,7 +36,6 @@ systemd:
         ExecStartPre=-docker rm -f kubelet
         ExecStartPre=docker run -d \
           --name=kubelet \
-          --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
           --pid=host \

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -16,6 +16,12 @@ systemd:
         RestartSec=5s
         TimeoutStartSec=0
         LimitNOFILE=40000
+        ConditionPathExists=/etc/ssl/etcd/etcd/server-ca.crt
+        ConditionPathExists=/etc/ssl/etcd/etcd/server.crt
+        ConditionPathExists=/etc/ssl/etcd/etcd/server.key
+        ConditionPathExists=/etc/ssl/etcd/etcd/peer-ca.crt
+        ConditionPathExists=/etc/ssl/etcd/etcd/peer.crt
+        ConditionPathExists=/etc/ssl/etcd/etcd/peer.key
         EnvironmentFile=/etc/kubernetes/etcd.config
         EnvironmentFile=/etc/kubernetes/etcd.env
         ExecStartPre=-docker rm -f etcd

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -21,7 +21,6 @@ systemd:
         ExecStartPre=-docker rm -f etcd
         ExecStartPre=sh -c "docker run -d \
           --name=etcd \
-          --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
           -u $(id -u \"$${USER}\"):$(id -u \"$${USER}\") \
@@ -107,7 +106,6 @@ systemd:
         ExecStartPre=-docker rm -f kubelet
         ExecStartPre=docker run -d \
           --name=kubelet \
-          --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
           --pid=host \

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/ssh.tf
@@ -47,6 +47,7 @@ resource "null_resource" "copy-controller-secrets" {
   provisioner "remote-exec" {
     inline = [
       "set -e",
+      "sudo systemctl stop etcd",
       # Using "etcd/." copies the etcd/ folder recursively in an idempotent
       # way. See https://unix.stackexchange.com/a/228637 for details.
       "[ -d /etc/ssl/etcd ] && sudo cp -R /etc/ssl/etcd/. /etc/ssl/etcd.old && sudo rm -rf /etc/ssl/etcd",
@@ -63,7 +64,7 @@ resource "null_resource" "copy-controller-secrets" {
       # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
       # Terraform before we return error. We should be able to remove it once
       # https://github.com/hashicorp/terraform/issues/27121 is resolved.
-      "sudo systemctl restart etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
+      "sudo systemctl start etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
     ]
   }
 

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -68,7 +68,6 @@ systemd:
         ExecStartPre=-docker rm -f kubelet
         ExecStartPre=docker run -d \
           --name=kubelet \
-          --restart=unless-stopped \
           --log-driver=journald \
           --network=host \
           --pid=host \

--- a/assets/terraform-modules/platforms/tinkerbell/controllers/ssh.tf
+++ b/assets/terraform-modules/platforms/tinkerbell/controllers/ssh.tf
@@ -55,6 +55,7 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo chown root:root /etc/kubernetes/kubeconfig",
       "sudo chmod 600 /etc/kubernetes/kubeconfig",
+      "sudo systemctl stop etcd",
       # Using "etcd/." copies the etcd/ folder recursively in an idempotent
       # way. See https://unix.stackexchange.com/a/228637 for details.
       "[ -d /etc/ssl/etcd ] && sudo cp -R /etc/ssl/etcd/. /etc/ssl/etcd.old && sudo rm -rf /etc/ssl/etcd",
@@ -71,7 +72,7 @@ resource "null_resource" "copy-controller-secrets" {
       # Use stdbuf to disable the buffer while printing logs to make sure everything is transmitted back to
       # Terraform before we return error. We should be able to remove it once
       # https://github.com/hashicorp/terraform/issues/27121 is resolved.
-      "sudo systemctl restart etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
+      "sudo systemctl start etcd || (stdbuf -i0 -o0 -e0 sudo journalctl -u etcd --no-pager; exit 1)",
     ]
   }
 


### PR DESCRIPTION
- Only restart containers from systemd
    Restarting etcd or the kubelet container from the Docker daemon
    introduces a race because the "docker logs" command will terminate and
    then the systemd unit will also restart the container in parallel to
    the Docker daemon. This race causes problems like terminating the
    container again or failing to start it, but it also introduces
    additional issues because the ExecStartPre and ExecStopPost commands
    run while the container is running, which means the state can get
    corrupted. Even if the systemd unit would not restart in parallel, it
    is not wanted to restart the container from the Docker daemon because
    the systemd unit should first run the ExecStartPre/Post commands, e.g.,
    for the "etcd-rejoin" script.
    
    Only restart the containers from the systemd unit, not from the Docker
    daemon.

- etcd: stop the service before modifying the etcd folder
    
    The etcd folder was modified while the etcd service was running which
    could lead to an earlier restart of the service because the service
    conditions for existing files are finally met and it may conflict
    with any commands in the ExecStopPost directive.
    
    First stop the etcd service unit before touching the files and only
    start the unit after the modification is done.

- aws|packet: align etcd unit file with the shared controller module
    
    The shared etcd CLC systemd unit has additional conditions for startup
    which were missing in the aws and packet etcd systemd units. It seems
    that these conditions help to make the bootstap more robust.
    
    Port the startup conditions over to aws and packet to align the
    platforms (which also makes debugging more clear).

## How to use


## Testing done

Looking at CI