### PR TITLE
cert-rotator: Add retry to cluster upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ run-e2e-tests:
 	# This is a test that should be run in the end to reduce the disruption to other tests because
 	# it will delete a node.
 	# The timeout is made longer as it will perform actions that will take longer than the default 10 minutes.
-	KUBECONFIG=${kubeconfig} PLATFORM=${platform} go test -timeout 30m -mod=$(MOD) -tags="$(platform),disruptivee2e" -covermode=atomic -buildmode=exe -v -count=1 ./test/...
+	KUBECONFIG=${kubeconfig} PLATFORM=${platform} go test -timeout 90m -mod=$(MOD) -tags="$(platform),disruptivee2e" -covermode=atomic -buildmode=exe -v -count=1 ./test/...
 
 .PHONY: all
 all: build test


### PR DESCRIPTION
Lot of failures that I have seen are in the upgrade path, so adding a retry here.

```bash
...
Ensuring controlplane component 'pod-checkpointer' is up to date... W0622 13:45:02.357960   17470 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0622 13:45:02.369443   17470 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0622 13:45:02.385962   17470 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Done.
Ensuring controlplane component 'kube-apiserver' is up to date... Failed!
    cert_rotate_disruptive_test.go:73: Rotating Certificates failed: running controlplane upgrade: upgrading controlplane component "kube-apiserver": updating controlplane component: an error occurred while finding last successful release. original upgrade error: Get "https://ci1624368234-pp.test.lokomotive-k8s.net:6443/apis/apps/v1/namespaces/kube-system/daemonsets/kube-apiserver": dial tcp 3.67.242.144:6443: connect: connection refused: Kubernetes cluster unreachable: Get "https://ci1624368234-pp.test.lokomotive-k8s.net:6443/version?timeout=32s": dial tcp 3.66.10.41:6443: connect: connection refused
--- FAIL: TestCertificateRotate (159.54s)
=== RUN   TestControlplaneComponentsDaemonSe
...
```