### PR TITLE
cluster/apply: enable upgrade kubelets by default

### DIFF
--- a/cli/cmd/cluster-apply.go
+++ b/cli/cmd/cluster-apply.go
@@ -51,7 +51,7 @@ func init() {
 	pf.BoolVarP(&skipControlPlaneUpdate, "skip-control-plane-update", "", false,
 		"Skip updating the control plane (not recommended)")
 
-	pf.BoolVarP(&upgradeKubelets, "upgrade-kubelets", "", false, "Experimentally upgrade self-hosted kubelets")
+	pf.BoolVarP(&upgradeKubelets, "upgrade-kubelets", "", true, "Upgrade self-hosted kubelets")
 }
 
 func runClusterApply(cmd *cobra.Command, args []string) {

--- a/docs/cli/lokoctl_cluster_apply.md
+++ b/docs/cli/lokoctl_cluster_apply.md
@@ -23,7 +23,7 @@ lokoctl cluster apply [flags]
       --skip-components                Skip applying component configuration
       --skip-control-plane-update      Skip updating the control plane (not recommended)
       --skip-pre-update-health-check   Skip ensuring that cluster is healthy before updating (not recommended)
-      --upgrade-kubelets               Experimentally upgrade self-hosted kubelets
+      --upgrade-kubelets               Upgrade self-hosted kubelets (default true)
   -v, --verbose                        Show output from Terraform
 ```
 


### PR DESCRIPTION
It has been tested enough and it works reliably.

Fixes #110 