### PR TITLE
terraform: fix ignored ConditionPathExists= in unit files

### DIFF
--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -9,18 +9,18 @@ systemd:
         Documentation=https://github.com/etcd-io/etcd
         Wants=docker.service
         After=docker.service
-        [Service]
-        Type=simple
-        Restart=always
-        RestartSec=5s
-        TimeoutStartSec=0
-        LimitNOFILE=40000
         ConditionPathExists=/etc/ssl/etcd/etcd/server-ca.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/server.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/server.key
         ConditionPathExists=/etc/ssl/etcd/etcd/peer-ca.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/peer.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/peer.key
+        [Service]
+        Type=simple
+        Restart=always
+        RestartSec=5s
+        TimeoutStartSec=0
+        LimitNOFILE=40000
         EnvironmentFile=/etc/kubernetes/etcd.env
         ExecStartPre=-docker rm -f etcd
         ExecStartPre=sh -c "docker run -d \

--- a/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -65,7 +65,6 @@ systemd:
         Description=Kubelet
         Wants=rpc-statd.service
         [Service]
-        ConditionPathExists=/etc/kubernetes/kubeconfig
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/assets/terraform-modules/controller/main.tf
+++ b/assets/terraform-modules/controller/main.tf
@@ -7,7 +7,6 @@ systemd:
     - name: 10-controller.conf
       contents: |
         [Service]
-        ConditionPathExists=/etc/kubernetes/kubeconfig
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
 EOF

--- a/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
+++ b/assets/terraform-modules/controller/templates/etcd.yaml.tmpl
@@ -8,18 +8,18 @@ systemd:
         Documentation=https://github.com/etcd-io/etcd
         Wants=docker.service
         After=docker.service
-        [Service]
-        Type=simple
-        Restart=always
-        RestartSec=5s
-        TimeoutStartSec=0
-        LimitNOFILE=40000
         ConditionPathExists=/etc/ssl/etcd/etcd/server-ca.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/server.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/server.key
         ConditionPathExists=/etc/ssl/etcd/etcd/peer-ca.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/peer.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/peer.key
+        [Service]
+        Type=simple
+        Restart=always
+        RestartSec=5s
+        TimeoutStartSec=0
+        LimitNOFILE=40000
         EnvironmentFile=/etc/kubernetes/etcd.env
         ExecStartPre=-docker rm -f etcd
         ExecStartPre=sh -c "docker run -d \

--- a/assets/terraform-modules/node/templates/node.yaml.tmpl
+++ b/assets/terraform-modules/node/templates/node.yaml.tmpl
@@ -27,7 +27,6 @@ systemd:
         Description=Kubelet
         Wants=rpc-statd.service
         [Service]
-        ConditionPathExists=/etc/kubernetes/kubeconfig
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -103,7 +103,6 @@ systemd:
         Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/run/metadata/flatcar
-        ConditionPathExists=/etc/kubernetes/kubeconfig
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/assets/terraform-modules/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -10,18 +10,18 @@ systemd:
         Wants=docker.service
         After=docker.service create-etcd-config.service
         Requires=create-etcd-config.service
-        [Service]
-        Type=simple
-        Restart=always
-        RestartSec=5s
-        TimeoutStartSec=0
-        LimitNOFILE=40000
         ConditionPathExists=/etc/ssl/etcd/etcd/server-ca.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/server.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/server.key
         ConditionPathExists=/etc/ssl/etcd/etcd/peer-ca.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/peer.crt
         ConditionPathExists=/etc/ssl/etcd/etcd/peer.key
+        [Service]
+        Type=simple
+        Restart=always
+        RestartSec=5s
+        TimeoutStartSec=0
+        LimitNOFILE=40000
         EnvironmentFile=/etc/kubernetes/etcd.config
         EnvironmentFile=/etc/kubernetes/etcd.env
         ExecStartPre=-docker rm -f etcd


### PR DESCRIPTION
Over time we've added ConditionPathExists= parameters to several unit
files. However, in some instances we were adding them in the [Service]
section instead of the [Unit] section. This meant they were ignored and
didn't have any effect.

This moves those conditions to the [Unit] section everywhere.

Fixes #1066 