### PR TITLE
how-to-docs: require_volume_annotation information

### DIFF
--- a/docs/how-to-guides/backup-rook-ceph-volumes.md
+++ b/docs/how-to-guides/backup-rook-ceph-volumes.md
@@ -47,6 +47,7 @@ component "velero" {
 
   restic {
     credentials = file("./credentials-velero")
+    require_volume_annotation = true
     backup_storage_location {
       provider = "aws"
       bucket   = "rook-ceph-backup"
@@ -162,6 +163,8 @@ $ kubectl -n demo-ns exec -it demo-app-0 -- /bin/sh -c 'du -s /data'
 ```
 
 ### Step 3: Annotate pods
+
+> **NOTE**: To backup all pod volumes without having to individually annotate every pod, set the parameter `require_volume_annotation` to `false` or remove it from the configuration.
 
 Annotate the pods with volumes attached to them with their volume names so that Velero takes backup
 of volume data. Replace the pod name and the volume name as needed in the following command:


### PR DESCRIPTION
This add information about restic parameter `require_volume_annotation`.
It is set to false by default and all the volumes are backed up without
need for annotation.

closes: #1519
Signed-off-by: knrt10 <kautilya@kinvolk.io>