### PR TITLE
test: fix azure-arc-onboarding unit test flakiness

### DIFF
--- a/pkg/components/azure-arc-onboarding/component_test.go
+++ b/pkg/components/azure-arc-onboarding/component_test.go
@@ -26,8 +26,6 @@ import (
 func TestConfig(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	c := azurearconboarding.NewConfig()
-
 	tests := []struct {
 		desc    string
 		config  string
@@ -153,6 +151,8 @@ component azure-arc-onboarding {
 			if diagnostics.HasErrors() {
 				t.Fatalf("Error getting component body: %v", diagnostics)
 			}
+
+			c := azurearconboarding.NewConfig()
 
 			diagnostics = c.LoadConfig(body, &hcl.EvalContext{})
 			if test.wantErr && !diagnostics.HasErrors() {


### PR DESCRIPTION
Declaring the component config outside made the azure-arc-onboarding
component's unit tests flaky.

This commit fixes the flakiness.

Signed-off-by: Imran Pochi <imran@kinvolk.io>