### PR TITLE
feat: define MaxHistory for Helm releases

### DIFF
--- a/cli/cmd/cluster/cluster.go
+++ b/cli/cmd/cluster/cluster.go
@@ -358,6 +358,7 @@ func (c controlplaneUpdater) ensureComponent(component, namespace string) error 
 
 	rollback.Wait = true
 	rollback.Version = history[0].Version
+	rollback.MaxHistory = 10
 
 	fmt.Printf("Ensuring controlplane component '%s' is properly configured... ", component)
 


### PR DESCRIPTION
# define MaxHistory for Helm releases to cleanup Helm history

Defining the `MaxHistory` option during the rollback Helm action so that
the releases history is cleaned up accordingly.
Without this option, the history would never be cleared which is
accumulating old configuration which can be harmful when an incorrect
rollback is applied. By cleaning up the history, we limit the potential
impact of rolling back to an older version.

## How to use

Run `lokoctl cluster apply` more than 10 times and inspect the helm history manually of some of the control plane components. For example `helm history kube-apiserver -n kube-system`, ensure the history doesn't contain more than 10 releases.

## Testing done

I haven't tested this locally yet
