### PR TITLE
feat: define MaxHistory for Helm releases

### DIFF
--- a/cli/cmd/cluster/cluster.go
+++ b/cli/cmd/cluster/cluster.go
@@ -358,6 +358,7 @@ func (c controlplaneUpdater) ensureComponent(component, namespace string) error 
 
 	rollback.Wait = true
 	rollback.Version = history[0].Version
+	rollback.MaxHistory = 10
 
 	fmt.Printf("Ensuring controlplane component '%s' is properly configured... ", component)
 


### PR DESCRIPTION
Defining the `MaxHistory` option during the rollback Helm action so that
the releases history is cleaned up accordingly.
Without this option the history would never been cleared which is
accumulating old configuration which can be harmful when a incorrect
rollback is applied. By cleaning up the history, we limit the potential
impact rolling back to a older version.