### PR TITLE
prometheus-operator: Fix the repeated annotations

### DIFF
--- a/assets/charts/components/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
+++ b/assets/charts/components/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
@@ -3,13 +3,12 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-admission
 {{- if .Values.global.rbac.pspAnnotations }}
-  annotations:
 {{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}
 {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}

--- a/pkg/components/prometheus-operator/template.go
+++ b/pkg/components/prometheus-operator/template.go
@@ -184,6 +184,7 @@ kubeScheduler:
       tier: control-plane
 
 kube-state-metrics:
+  enabled: true
   podSecurityPolicy:
     annotations:
       seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'


### PR DESCRIPTION
This commit fixes the repeated `annotations` in the PSP config. Existing
config has `annotations` defined once outside the `{{- if .. }}` block
and again inside it. So if a user defines the `annotations` value in the
values file then in end the PSP has two `annotations` block.