### PR TITLE
docs: update build instructions for kubelet

### DIFF
--- a/assets/charts/control-plane/kubelet/container-image/README.md
+++ b/assets/charts/control-plane/kubelet/container-image/README.md
@@ -28,7 +28,7 @@ export IMAGE_URL=quay.io/kinvolk/kubelet
 ```bash
 export ARCH=amd64
 
-docker build -t $IMAGE_URL:$NEW_VERSION-$ARCH . && docker push $IMAGE_URL:$NEW_VERSION-$ARCH
+docker buildx build --load -t $IMAGE_URL:$NEW_VERSION-$ARCH -f Dockerfile --platform linux/$ARCH .
 ```
 
 ### ARM
@@ -36,7 +36,7 @@ docker build -t $IMAGE_URL:$NEW_VERSION-$ARCH . && docker push $IMAGE_URL:$NEW_V
 ```bash
 export ARCH=arm64
 
-docker build -t $IMAGE_URL:$NEW_VERSION-$ARCH . && docker push $IMAGE_URL:$NEW_VERSION-$ARCH
+docker buildx build --load -t $IMAGE_URL:$NEW_VERSION-$ARCH -f Dockerfile --platform linux/$ARCH .
 ```
 
 ### Combined image tag


### PR DESCRIPTION
The earlier instructions to build the kubelet image builds the same
image for both amd64 and arm64 if building both on the same machine.

Using docker's buildx we can build multiple architecture images on the
same machine.

Signed-off-by: Imran Pochi <imran@kinvolk.io>