### PR TITLE
tinkerbell: Add btrfs-progs and gawk to Dockerfile

### DIFF
--- a/assets/terraform-modules/tinkerbell-sandbox/assets/deploy/flatcar-install/Dockerfile
+++ b/assets/terraform-modules/tinkerbell-sandbox/assets/deploy/flatcar-install/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu
 
 RUN apt update && \
-		apt install -y udev gpg wget
+		apt install -y udev gpg wget btrfs-progs gawk
 
 RUN wget https://raw.githubusercontent.com/flatcar-linux/init/flatcar-master/bin/flatcar-install -O /usr/local/bin/flatcar-install && \
     chmod +x /usr/local/bin/flatcar-install


### PR DESCRIPTION
This commit adds additional packages which are required in the
`flatcar-install` script.

Signed-off-by: Imran Pochi <imran@kinvolk.io>